### PR TITLE
Add a DreamTunnelDash "Entry"

### DIFF
--- a/Ahorn/entities/DreamTunnelEntry.jl
+++ b/Ahorn/entities/DreamTunnelEntry.jl
@@ -1,0 +1,62 @@
+module CommunalHelperDreamTunnelEntry
+
+using ..Ahorn, Maple
+
+@mapdef Entity "CommunalHelper/DreamTunnelEntry" DreamTunnelEntry(x::Integer, y::Integer, 
+	oneUse::Bool=false, overrideAllowStaticMovers=false)
+
+const placements = Ahorn.PlacementDict(
+	"DreamTunnelEntry ($dir) (Communal Helper)" => Ahorn.EntityPlacement(
+		DreamTunnelEntry,
+		"rectangle",
+		Dict{String, Any}(
+			"orientation" => dir
+		),
+	) for dir in Maple.spike_directions
+)
+
+Ahorn.editingOptions(entity::DreamTunnelEntry) = Dict{String, Any}(
+    "orientation" => Maple.spike_directions
+)
+
+Ahorn.minimumSize(entity::DreamTunnelEntry) = 8, 8
+
+const resizeDirections = Dict{String, Tuple{Bool, Bool}}(
+	"Up" => (true, false),
+	"Down" => (true, false),
+	"Left" => (false, true),
+	"Right" => (false, true),
+)
+
+function Ahorn.resizable(entity::DreamTunnelEntry)
+	orientation = get(entity.data, "orientation", "Up")
+	return resizeDirections[orientation]
+end
+
+function Ahorn.selection(entity::DreamTunnelEntry)
+	x, y = Ahorn.position(entity)
+
+	width = Int(get(entity.data, "width", 8))
+	height = Int(get(entity.data, "height", 8))
+
+	orientation = get(entity.data, "orientation", "Up")
+
+	return Ahorn.Rectangle(x, y, width, height)
+end
+
+function Ahorn.renderAbs(ctx::Ahorn.Cairo.CairoContext, entity::DreamTunnelEntry)
+	orientation = get(entity.data, "orientation", "Up")
+
+	width = Int(get(entity.data, "width", 8))
+	height = Int(get(entity.data, "height", 8))
+	
+	x, y = Ahorn.position(entity)
+	ox, oy = x + width * (orientation == "Right"), y + height * (orientation == "Down")
+	cx, cy = x + width * in(orientation, ("Up", "Down", "Right")), y + height * in(orientation, ("Down", "Left", "Right"))
+
+	Ahorn.drawRectangle(ctx, x, y, width, height, (0.0, 0.0, 0.0, 0.4))
+	Ahorn.drawLines(ctx, ((ox, oy), (cx, cy)), (1.0, 1.0, 1.0, 1.0), thickness=1)
+
+end
+
+end 

--- a/Ahorn/entities/DreamTunnelEntry.jl
+++ b/Ahorn/entities/DreamTunnelEntry.jl
@@ -1,12 +1,13 @@
 module CommunalHelperDreamTunnelEntry
 
 using ..Ahorn, Maple
+using Ahorn.CommunalHelper
 
 @mapdef Entity "CommunalHelper/DreamTunnelEntry" DreamTunnelEntry(x::Integer, y::Integer, 
-	overrideAllowStaticMovers=false)
+	overrideAllowStaticMovers=false, depth::Integer=-13000)
 
 const placements = Ahorn.PlacementDict(
-	"DreamTunnelEntry ($dir) (Communal Helper)" => Ahorn.EntityPlacement(
+	"Dream Tunnel Entry ($dir) (Communal Helper)" => Ahorn.EntityPlacement(
 		DreamTunnelEntry,
 		"rectangle",
 		Dict{String, Any}(
@@ -16,7 +17,8 @@ const placements = Ahorn.PlacementDict(
 )
 
 Ahorn.editingOptions(entity::DreamTunnelEntry) = Dict{String, Any}(
-    "orientation" => Maple.spike_directions
+    "orientation" => Maple.spike_directions,
+	"depth" => CommunalHelper.depths
 )
 
 Ahorn.minimumSize(entity::DreamTunnelEntry) = 8, 8

--- a/Ahorn/entities/DreamTunnelEntry.jl
+++ b/Ahorn/entities/DreamTunnelEntry.jl
@@ -3,7 +3,7 @@ module CommunalHelperDreamTunnelEntry
 using ..Ahorn, Maple
 
 @mapdef Entity "CommunalHelper/DreamTunnelEntry" DreamTunnelEntry(x::Integer, y::Integer, 
-	oneUse::Bool=false, overrideAllowStaticMovers=false)
+	overrideAllowStaticMovers=false)
 
 const placements = Ahorn.PlacementDict(
 	"DreamTunnelEntry ($dir) (Communal Helper)" => Ahorn.EntityPlacement(

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -139,6 +139,8 @@ placements.entities.CommunalHelper/DreamCrumbleWallOnRumble.tooltips.persistent=
 
 # -- Dream Tunnel Entry --
 placements.entities.CommunalHelper/DreamTunnelEntry.tooltips.overrideAllowStaticMovers=Enable a hack that allows this entity to attach to SolidTiles, among other things.
+placements.entities.CommunalHelper/DreamTunnelEntry.tooltips.orientation=The way this Dream Tunnel Entry faces.
+placements.entities.CommunalHelper/DreamTunnelEntry.tooltips.depth=The depth value for this entity. Used to make it render below or above other entities.
 
 
 # -- Move Swap Block --

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -137,6 +137,9 @@ placements.entities.CommunalHelper/DreamCrumbleWallOnRumble.tooltips.featherMode
 placements.entities.CommunalHelper/DreamCrumbleWallOnRumble.tooltips.oneUse=Whether this block should shatter upon exit.
 placements.entities.CommunalHelper/DreamCrumbleWallOnRumble.tooltips.persistent=Whether this block should remain broken permanently.
 
+# -- Dream Tunnel Entry --
+placements.entities.CommunalHelper/DreamTunnelEntry.tooltips.overrideAllowStaticMovers=Enable a hack that allows this entity to attach to SolidTiles, among other things.
+
 
 # -- Move Swap Block --
 placements.entities.CommunalHelper/MoveSwapBlock.tooltips.canSteer=Whether the Move Swap Block can be moved by the player.

--- a/Ahorn/libraries/CommunalHelper.jl
+++ b/Ahorn/libraries/CommunalHelper.jl
@@ -11,6 +11,30 @@ export renderDreamBlock
 export renderCassetteBlock, cassetteColorNames, getCassetteColor
 # Connected Blocks
 export getExtensionRectangles, notAdjacent
+# Depths
+export depths
+
+"Celeste.Depths"
+const depths = Dict{String, Integer}(
+        "BGTerrain (10000)" => 10000,
+        "BGDecals (9000)" => 9000,
+        "BGParticles (8000)" => 8000,
+        "Below (2000)" => 2000,
+        "NPCs (1000)" => 1000,
+        "Player (0)" => 0,
+        "Dust (-50)" => -50,
+        "Pickups (-100)" => -100,
+        "Particles (-8000)" => -8000,
+        "Above Particles (-8500)" => -8500,
+        "Solids (-9000)" => -9000,
+        "FGTerrain (-10000)" => -10000,
+        "FGDecals (-10500)" => -10500,
+        "DreamBlocks (-11000)" => -11000,
+        "CrystalSpinners (-11500)" => -11500,
+        "Chaser (-12500)" => -12500,
+        "Fake Walls (-13000)" => -13000,
+        "FGParticles (-50000)" => -50000
+)
 
 """
 	 hexToRGBA(hex)

--- a/GameBananaPage.html
+++ b/GameBananaPage.html
@@ -26,6 +26,10 @@ The current list of included mechanics:
 		<b>Dream Refill</b> - 
 		A special refill that once collected, allows the player to dash through any solid, except for dream blocks which will kill them.
 	</li>
+   <li>
+      <b>Dream Tunnel Entry</b> - 
+      A panel that can be attached to any solid that allows the player to Dream Tunnel through it.
+   </li>
 	<li>
 		<b>Cassette Zip Mover</b>, <b>Move Block</b>, <b>Swap Block</b> and <b>Falling Block</b> - 
 		Similar to the dream block types above, each of these entities take the movement behaviour of a specific solid, and apply it to a cassette block. 

--- a/Release Log.txt
+++ b/Release Log.txt
@@ -1,3 +1,6 @@
+--?.?.? (??/??/????)--
+* Added Dream Tunnel Entry
+
 --1.7.1 (30/03/2021)--
 * [Silent] Added Manual Cassette Controller.
 * Fixed crashes involving using readonly structs.

--- a/src/CommunalHelper.csproj
+++ b/src/CommunalHelper.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+	<PackageReference Include="MonoMod" Version="21.4.2.3" PrivateAssets="all" />
 	<PackageReference Include="MonoMod.RuntimeDetour" Version="21.01.11.01" PrivateAssets="all" ExcludeAssets="runtime">
 	  <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>

--- a/src/CommunalHelperModule.cs
+++ b/src/CommunalHelperModule.cs
@@ -40,7 +40,6 @@ namespace Celeste.Mod.CommunalHelper {
 
             DreamTunnelDash.Load();
             DreamRefill.Load();
-            DreamTunnelEntry.Load();
 
             CustomDreamBlock.Load();
             // Individual Dream Blocks hooked in CustomDreamBlock.Load
@@ -93,6 +92,9 @@ namespace Celeste.Mod.CommunalHelper {
 
             // Register CustomCassetteBlock types
             CustomCassetteBlock.Initialize();
+
+            // We may hook methods in other mods, so this needs to be done after they're loaded
+            DreamTunnelEntry.LoadDelayed();
         }
 
         public override void LoadContent(bool firstLoad) {

--- a/src/CommunalHelperModule.cs
+++ b/src/CommunalHelperModule.cs
@@ -40,6 +40,7 @@ namespace Celeste.Mod.CommunalHelper {
 
             DreamTunnelDash.Load();
             DreamRefill.Load();
+            // DreamTunnelEntry loaded late in LoadContent
 
             CustomDreamBlock.Load();
             // Individual Dream Blocks hooked in CustomDreamBlock.Load
@@ -53,7 +54,6 @@ namespace Celeste.Mod.CommunalHelper {
             AbstractController.Load();
             // Controller-specific hooks loaded from AbstractController.Load
             // TimedTriggerSpikes hooked in Initialize
-            DreamTunnelEntryHooks.Hook();
 
             HeartGemShard.Load();
             CustomSummitGem.Load();
@@ -80,7 +80,6 @@ namespace Celeste.Mod.CommunalHelper {
             MoveSwapBlock.Unload();
             AbstractController.Unload();
             TimedTriggerSpikes.Unload();
-            DreamTunnelEntryHooks.Unhook();
 
             HeartGemShard.Unload();
             CustomSummitGem.Unload();

--- a/src/CommunalHelperModule.cs
+++ b/src/CommunalHelperModule.cs
@@ -41,6 +41,7 @@ namespace Celeste.Mod.CommunalHelper {
             DreamTunnelDash.Load();
             DreamRefill.Load();
             // DreamTunnelEntry loaded late in LoadContent
+            DreamBlockDummy.Load();
 
             CustomDreamBlock.Load();
             // Individual Dream Blocks hooked in CustomDreamBlock.Load
@@ -66,8 +67,7 @@ namespace Celeste.Mod.CommunalHelper {
             DreamTunnelDash.Unload();
             DreamRefill.Unload();
             DreamTunnelEntry.Unload();
-
-            DreamBlockDummy.Load();
+            DreamBlockDummy.Unload();
 
             CustomDreamBlock.Unload();
             // Individual Dream Blocks unhooked in CustomDreamBlock.Unload

--- a/src/CommunalHelperModule.cs
+++ b/src/CommunalHelperModule.cs
@@ -53,6 +53,7 @@ namespace Celeste.Mod.CommunalHelper {
             AbstractController.Load();
             // Controller-specific hooks loaded from AbstractController.Load
             // TimedTriggerSpikes hooked in Initialize
+            DreamTunnelEntryHooks.Hook();
 
             HeartGemShard.Load();
             CustomSummitGem.Load();
@@ -79,6 +80,7 @@ namespace Celeste.Mod.CommunalHelper {
             MoveSwapBlock.Unload();
             AbstractController.Unload();
             TimedTriggerSpikes.Unload();
+            DreamTunnelEntryHooks.Unhook();
 
             HeartGemShard.Unload();
             CustomSummitGem.Unload();

--- a/src/CommunalHelperModule.cs
+++ b/src/CommunalHelperModule.cs
@@ -40,6 +40,7 @@ namespace Celeste.Mod.CommunalHelper {
 
             DreamTunnelDash.Load();
             DreamRefill.Load();
+            DreamTunnelEntry.Load();
 
             CustomDreamBlock.Load();
             // Individual Dream Blocks hooked in CustomDreamBlock.Load
@@ -64,6 +65,9 @@ namespace Celeste.Mod.CommunalHelper {
 
             DreamTunnelDash.Unload();
             DreamRefill.Unload();
+            DreamTunnelEntry.Unload();
+
+            DreamBlockDummy.Load();
 
             CustomDreamBlock.Unload();
             // Individual Dream Blocks unhooked in CustomDreamBlock.Unload

--- a/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntry.cs
+++ b/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntry.cs
@@ -588,7 +588,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             cursor.GotoNext(MoveType.After, instr => instr.OpCode == OpCodes.Callvirt &&
                 ((MethodReference) instr.Operand).FullName == "System.Boolean Monocle.Entity::CollideCheck<Celeste.DreamBlock>(Microsoft.Xna.Framework.Vector2)");
             cursor.Emit(OpCodes.Ldarg_0);
-            cursor.Emit(OpCodes.Ldfld, typeof(Player).GetNestedType("<DashCoroutine>d__423", BindingFlags.NonPublic).GetField("<>4__this"));
+            cursor.Emit(OpCodes.Ldfld, typeof(Player).GetNestedType("<DashCoroutine>d__427", BindingFlags.NonPublic).GetField("<>4__this"));
             cursor.EmitDelegate<Func<bool, Player, bool>>((v, player) => {
                 return v || player.CollideCheck<DreamTunnelEntry>(player.Position + Vector2.UnitY);
             });

--- a/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntry.cs
+++ b/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntry.cs
@@ -231,10 +231,15 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             level = scene as Level;
             PlayerHasDreamDash = level.Session.Inventory.DreamDash;
 
-            DreamBlockDummy block = DreamBlockDummy.Create(scene).Initialize(
-                Activate, FastActivate, ActivateNoRoutine,
-                Deactivate, FastDeactivate, DeactivateNoRoutine,
-                Setup);
+            scene.Add(new DreamBlockDummy() {
+                OnActivate = Activate,
+                OnFastActivate = FastActivate,
+                OnActivateNoRoutine = ActivateNoRoutine,
+                OnDeactivate = Deactivate,
+                OnFastDeactivate = FastDeactivate,
+                OnDeactivateNoRoutine = DeactivateNoRoutine,
+                OnSetup = Setup
+            });
 
             Setup();
         }

--- a/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntry.cs
+++ b/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntry.cs
@@ -32,10 +32,10 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         public static Entity LoadDreamTunnelEntry(Level level, LevelData levelData, Vector2 offset, EntityData entityData) {
             Spikes.Directions orientation = entityData.Enum<Spikes.Directions>("orientation");
-            return new DreamTunnelEntry(entityData.Position + offset, 
-                GetSize(entityData, orientation), 
-                orientation, 
-                entityData.Bool("overrideAllowStaticMovers"), 
+            return new DreamTunnelEntry(entityData.Position + offset,
+                GetSize(entityData, orientation),
+                orientation,
+                entityData.Bool("overrideAllowStaticMovers"),
                 entityData.Bool("below"),
                 entityData.Bool("featherMode"));
         }
@@ -110,8 +110,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
             surfaceSoundIndex = SurfaceIndex.DreamBlockInactive;
 
-            particleTextures = new MTexture[]
-            {
+            particleTextures = new MTexture[] {
                 GFX.Game["objects/dreamblock/particles"].GetSubtexture(14, 0, 7, 7, null),
                 GFX.Game["objects/dreamblock/particles"].GetSubtexture(7, 0, 7, 7, null),
                 GFX.Game["objects/dreamblock/particles"].GetSubtexture(0, 0, 7, 7, null),
@@ -180,7 +179,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                     else
                         return false;
                 }
-            } else if (Orientation is Spikes.Directions.Up or Spikes.Directions.Down) { 
+            } else if (Orientation is Spikes.Directions.Up or Spikes.Directions.Down) {
                 if (player.Left < Left) {
                     // Sorry for my jank
                     if (!(player.OnGround() && !player.CollideCheck<Solid>(new Vector2(Left - player.Width / 2, at.Y)))) {
@@ -378,7 +377,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                     Draw.Line(vector3 - vector2 * 10f, vector4 - vector2 * 10f, backColor * 0.4f);
                     Draw.Line(vector3 - vector2 * 11f, vector4 - vector2 * 11f, backColor * 0.2f);
                 }
-                if(line)
+                if (line)
                     Draw.Line(vector3, vector4, lineColor);
                 scaleFactor = lerp;
             }
@@ -664,7 +663,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         private static int Platform_GetLandOrStepSoundIndex(Func<Platform, Entity, int> orig, Platform self, Entity entity) {
             foreach (StaticMover sm in new DynData<Platform>(self).Get<List<StaticMover>>("staticMovers")) {
-                if (sm.Entity is DreamTunnelEntry entry && entry.Orientation == Spikes.Directions.Up && entity.CollideCheck(entry, entity.Position + Vector2.UnitY)) { 
+                if (sm.Entity is DreamTunnelEntry entry && entry.Orientation == Spikes.Directions.Up && entity.CollideCheck(entry, entity.Position + Vector2.UnitY)) {
                     return entry.surfaceSoundIndex;
                 }
             }
@@ -675,10 +674,10 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             foreach (StaticMover sm in new DynData<Platform>(self).Get<List<StaticMover>>("staticMovers")) {
                 if (sm.Entity is DreamTunnelEntry entry) {
                     if (side == (int) Facings.Left && entry.Orientation == Spikes.Directions.Right && player.CollideCheck(entry, player.Position - Vector2.UnitX)) {
-                            return entry.surfaceSoundIndex;
-                    } 
-                    if (side == (int) Facings.Right && entry.Orientation == Spikes.Directions.Left && player.CollideCheck(entry, player.Position + Vector2.UnitX)) { 
-                            return entry.surfaceSoundIndex;
+                        return entry.surfaceSoundIndex;
+                    }
+                    if (side == (int) Facings.Right && entry.Orientation == Spikes.Directions.Left && player.CollideCheck(entry, player.Position + Vector2.UnitX)) {
+                        return entry.surfaceSoundIndex;
                     }
                 }
             }
@@ -696,7 +695,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
              */
             ILCursor cursor = new ILCursor(il);
             // oof
-            cursor.GotoNext(MoveType.After, instr => instr.OpCode == OpCodes.Callvirt && 
+            cursor.GotoNext(MoveType.After, instr => instr.OpCode == OpCodes.Callvirt &&
                 ((MethodReference) instr.Operand).FullName == "System.Boolean Monocle.Entity::CollideCheck<Celeste.DreamBlock>(Microsoft.Xna.Framework.Vector2)");
             cursor.Emit(OpCodes.Ldarg_0);
             cursor.Emit(OpCodes.Ldfld, typeof(Player).GetNestedType("<DashCoroutine>d__423", BindingFlags.NonPublic).GetField("<>4__this"));
@@ -715,8 +714,8 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             cursor.EmitDelegate<Func<Platform, Player, Platform>>((platform, player) => {
                 foreach (StaticMover sm in new DynData<Platform>(platform).Get<List<StaticMover>>("staticMovers")) {
                     Vector2 origin = player.Position + new Vector2((float) player.Facing * 3, -4f);
-                    if (sm.Entity is DreamTunnelEntry entry 
-                        && (entry.Orientation == Spikes.Directions.Left || entry.Orientation == Spikes.Directions.Right) 
+                    if (sm.Entity is DreamTunnelEntry entry
+                        && (entry.Orientation == Spikes.Directions.Left || entry.Orientation == Spikes.Directions.Right)
                         && entry.CollidePoint(origin + Vector2.UnitX * (float) player.Facing)) {
                         entry.FootstepRipple(origin);
                     }
@@ -732,7 +731,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             cursor.Emit(OpCodes.Ldarg_0);
             cursor.EmitDelegate<Func<Platform, Player, Platform>>((platform, player) => {
                 foreach (StaticMover sm in new DynData<Platform>(platform).Get<List<StaticMover>>("staticMovers")) {
-                    if (sm.Entity is DreamTunnelEntry entry && entry.Orientation == Spikes.Directions.Up 
+                    if (sm.Entity is DreamTunnelEntry entry && entry.Orientation == Spikes.Directions.Up
                         && player.CollideCheck(entry, player.Position + Vector2.UnitY)) {
                         entry.FootstepRipple(player.Position);
                     }

--- a/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntry.cs
+++ b/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntry.cs
@@ -39,9 +39,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                 GetSize(entityData, orientation),
                 orientation,
                 entityData.Bool("overrideAllowStaticMovers"),
-                false,
-                false,
-                false);
+                entityData.Int("depth", Depths.FakeWalls));
         }
 
         private static int GetSize(EntityData data, Spikes.Directions dir) {
@@ -92,9 +90,12 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         private Level level;
 
-        public DreamTunnelEntry(Vector2 position, float size, Spikes.Directions orientation, bool overrideAllowStaticMovers, bool below, bool featherMode, bool oneUse)
+        private int originalDepth = Depths.FakeWalls;
+
+        public DreamTunnelEntry(Vector2 position, float size, Spikes.Directions orientation, bool overrideAllowStaticMovers, int depth)
             : base(position) {
-            Depth = Depths.FakeWalls - 10;
+            Depth = depth - 10;
+            originalDepth = depth;
             Orientation = orientation;
             this.overrideAllowStaticMovers = overrideAllowStaticMovers;
 
@@ -282,13 +283,13 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                 }
             }
 
-            scene.Tracker.GetEntity<DreamTunnelEntryRenderer>().Track(this);
+            scene.Tracker.GetEntity<DreamTunnelEntryRenderer>().Track(this, originalDepth, level);
         }
 
         private void Destroy() {
             Collidable = false;
             // Stop rendering the block/outline
-            Scene.Tracker.GetEntity<DreamTunnelEntryRenderer>().Untrack(this);
+            Scene.Tracker.GetEntity<DreamTunnelEntryRenderer>().Untrack(this, originalDepth, level);
             // "Lock the Camera" to keep dreamblock particles in place
             lockedCamera = SceneAs<Level>().Camera.Position;
             Tween tween = Tween.Create(Tween.TweenMode.Oneshot, Ease.Linear, 1, true);
@@ -329,7 +330,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             }
             base.Removed(scene);
 
-            scene.Tracker.GetEntity<DreamTunnelEntryRenderer>().Untrack(this);
+            scene.Tracker.GetEntity<DreamTunnelEntryRenderer>().Untrack(this, originalDepth, level);
         }
 
         public void FootstepRipple(Vector2 position) {

--- a/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntry.cs
+++ b/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntry.cs
@@ -11,7 +11,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using static Celeste.Mod.CommunalHelper.Entities.DreamTunnelDash;
-using DreamParticle = Celeste.Mod.CommunalHelper.Entities.CustomDreamBlock.DreamParticle;
 
 /*
 * Slow routine: Particles spray out from each end diagonally, moving inwards
@@ -24,12 +23,20 @@ using DreamParticle = Celeste.Mod.CommunalHelper.Entities.CustomDreamBlock.Dream
 * Two modes, one uses deactivated texture and blocks dashcollides, other fades away and does not block
 * Add support for PandorasBox DreamDash controller
 * Add OneUse mode
+* Add interaction with DreamTunnelDash
 */
 
 namespace Celeste.Mod.CommunalHelper.Entities {
     [CustomEntity("CommunalHelper/DreamTunnelEntry = LoadDreamTunnelEntry")]
     [Tracked]
     public class DreamTunnelEntry : Entity {
+
+        private struct DreamParticle {
+            public Vector2 Position;
+            public int Layer;
+            public Color Color;
+            public float TimeOffset;
+        }
 
         #region Loading
 
@@ -103,7 +110,8 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                 Spikes.Directions.Up => new Hitbox(size, 8f),
                 Spikes.Directions.Down => new Hitbox(size, 8f),
                 Spikes.Directions.Left => new Hitbox(8f, size),
-                Spikes.Directions.Right => new Hitbox(8f, size)
+                Spikes.Directions.Right => new Hitbox(8f, size),
+                _ => null
             };
 
             Add(staticMover = new StaticMover {

--- a/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntry.cs
+++ b/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntry.cs
@@ -1,0 +1,730 @@
+﻿using Celeste.Mod.Entities;
+using Microsoft.Xna.Framework;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Monocle;
+using MonoMod.Cil;
+using MonoMod.RuntimeDetour;
+using MonoMod.Utils;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using static Celeste.Mod.CommunalHelper.Entities.DreamTunnelDash;
+
+/*
+* Slow routine: Particles spray out from each end diagonally, moving inwards
+* Fast routine: Particles spray outwards + diagonally from the ends
+* Try to keep the timing on these the same as for DreamBlocks
+*/
+
+namespace Celeste.Mod.CommunalHelper.Entities {
+    [CustomEntity("CommunalHelper/DreamTunnelEntry = LoadDreamTunnelEntry")]
+    [Tracked]
+    public class DreamTunnelEntry : Entity {
+
+        #region Loading
+
+        public static Entity LoadDreamTunnelEntry(Level level, LevelData levelData, Vector2 offset, EntityData entityData) {
+            Spikes.Directions orientation = entityData.Enum<Spikes.Directions>("orientation");
+            return new DreamTunnelEntry(entityData.Position + offset, GetSize(entityData, orientation), orientation, entityData.Bool("featherMode"));
+        }
+
+        private static int GetSize(EntityData data, Spikes.Directions dir) {
+            if (dir <= Spikes.Directions.Down) {
+                return data.Width;
+            }
+            return data.Height;
+        }
+
+        #endregion
+
+        public bool PlayerHasDreamDash;
+
+        public Spikes.Directions Orientation;
+
+        private StaticMover staticMover;
+        private LightOcclude occlude;
+        private bool overrideAllowStaticMovers = true;
+
+        private DashCollision platformDashCollide;
+        private int surfaceSoundIndex;
+        private float size;
+
+        private Shaker shaker;
+        private Vector2 shake;
+        private Vector2 platformShake;
+        private float whiteFill;
+        private float whiteHeight;
+
+        private float animTimer;
+        private float wobbleEase;
+        private float wobbleFrom;
+        private float wobbleTo;
+
+        private CustomDreamBlock.DreamParticle[] particles;
+        private MTexture[] particleTextures;
+
+        private Level level;
+
+        public DreamTunnelEntry(Vector2 position, float size, Spikes.Directions orientation,  bool featherMode)
+            : base(position) {
+            Depth = Depths.FGTerrain;
+            Orientation = orientation;
+
+            this.size = size;
+            switch (orientation) {
+                case Spikes.Directions.Up:
+                    Collider = new Hitbox(size, 8f, 0f, 0f);
+                    break;
+                case Spikes.Directions.Down:
+                    Collider = new Hitbox(size, 8f, 0f, -8f);
+                    break;
+                case Spikes.Directions.Left:
+                    Collider = new Hitbox(8f, size, 0f, 0f);
+                    break;
+                case Spikes.Directions.Right:
+                    Collider = new Hitbox(8f, size, -8f, 0f);
+                    break;
+            }
+
+            Add(staticMover = new StaticMover {
+                OnAttach = OnAttach,
+                OnShake = v => platformShake = v,
+                SolidChecker = IsRiding,
+                OnEnable = ActivateNoRoutine,
+                OnDisable = DeactivateNoRoutine
+            });
+
+            surfaceSoundIndex = SurfaceIndex.DreamBlockInactive;
+
+            particleTextures = new MTexture[]
+            {
+                GFX.Game["objects/dreamblock/particles"].GetSubtexture(14, 0, 7, 7, null),
+                GFX.Game["objects/dreamblock/particles"].GetSubtexture(7, 0, 7, 7, null),
+                GFX.Game["objects/dreamblock/particles"].GetSubtexture(0, 0, 7, 7, null),
+                GFX.Game["objects/dreamblock/particles"].GetSubtexture(7, 0, 7, 7, null)
+            };
+        }
+
+        private void OnAttach(Platform platform) {
+            platformDashCollide = platform.OnDashCollide;
+            platform.OnDashCollide = OnDashCollide;
+        }
+
+        private DashCollisionResults OnDashCollide(Player player, Vector2 dir) {
+            // Correct position/ignore if only partially intersecting
+            if (PlayerHasDreamDash) {
+                switch (Orientation) {
+                    case Spikes.Directions.Up:
+                        if (dir.Y > 0 && CheckPlayerCollision(player, Vector2.UnitY)) {
+                            player.StateMachine.State = StDreamTunnelDash;
+                            return DashCollisionResults.Ignore;
+                        }
+                        break;
+                    case Spikes.Directions.Down:
+                        if (dir.Y < 0 && CheckPlayerCollision(player, -Vector2.UnitY)) {
+                            player.StateMachine.State = StDreamTunnelDash;
+                            return DashCollisionResults.Ignore;
+                        }
+                        break;
+                    case Spikes.Directions.Left:
+                        if (dir.X > 0 && CheckPlayerCollision(player, Vector2.UnitX)) {
+                            player.StateMachine.State = StDreamTunnelDash;
+                            return DashCollisionResults.Ignore;
+                        }
+                        break;
+                    case Spikes.Directions.Right:
+                        if (dir.X < 0 && CheckPlayerCollision(player, -Vector2.UnitX)) {
+                            player.StateMachine.State = StDreamTunnelDash;
+                            return DashCollisionResults.Ignore;
+                        }
+                        break;
+                }
+            }
+            return platformDashCollide?.Invoke(player, dir) ?? DashCollisionResults.NormalCollision;
+        }
+
+        private bool CheckPlayerCollision(Player player, Vector2 offset) {
+            if (!player.CollideCheck(this, player.Position + offset))
+                return false;
+
+            switch (Orientation) {
+                case Spikes.Directions.Left:
+                case Spikes.Directions.Right:
+                    if (player.Top < Top) {
+                        if (Top - player.Top <= 4)
+                            player.Top = Top;
+                        else
+                            return false;
+                    } else if (player.Bottom > Bottom) {
+                        if (player.Bottom - Bottom <= 4)
+                            player.Bottom = Bottom;
+                        else
+                            return false;
+                    }
+                    break;
+                case Spikes.Directions.Up:
+                case Spikes.Directions.Down:
+                    if (player.Left < Left) {
+                        if (Left - player.Left <= 4)
+                            player.Left = Left;
+                        else
+                            return false;
+                    } else if (player.Right > Right) {
+                        if (player.Right - Right <= 4)
+                            player.Right = Right;
+                        else
+                            return false;
+                    }
+                    break;
+            }
+            return true;
+        }
+
+        private bool IsRiding(Solid solid) {
+            return Left >= solid.Left && Right <= solid.Right && Top >= solid.Top && Bottom <= solid.Bottom;
+        }
+
+        public override void Added(Scene scene) {
+            base.Added(scene);
+            level = scene as Level;
+            PlayerHasDreamDash = level.Session.Inventory.DreamDash;
+
+            scene.Add(new DreamBlockDummy {
+                OnActivate = Activate,
+                OnFastActivate = FastActivate,
+                OnActivateNoRoutine = ActivateNoRoutine,
+                OnDeactivate = Deactivate,
+                OnFastDeactivate = FastDeactivate,
+                OnDeactivateNoRoutine = DeactivateNoRoutine,
+                OnSetup = Setup
+            });
+
+            Setup();
+        }
+
+        public override void Awake(Scene scene) {
+            base.Awake(scene);
+            foreach (Entity entity in scene.GetEntitiesByTagMask(Tags.Global | Tags.Persistent)) {
+                if (entity is Solid && entity.Scene == scene) {
+                    entity.Awake(scene);
+                }
+            }
+        }
+
+        private void OneUseDestroy() {
+            Collidable = Visible = false;
+            RemoveSelf();
+        }
+
+        public override void Update() {
+            base.Update();
+            if (PlayerHasDreamDash) {
+                animTimer += 6f * Engine.DeltaTime;
+                wobbleEase += Engine.DeltaTime * 2f;
+                if (wobbleEase > 1f) {
+                    wobbleEase = 0f;
+                    wobbleFrom = wobbleTo;
+                    wobbleTo = Calc.Random.NextFloat(Calc.Circle);
+                }
+                surfaceSoundIndex = SurfaceIndex.DreamBlockActive;
+            }
+        }
+
+        public override void Removed(Scene scene) {
+            if (staticMover.Platform != null && (staticMover.Platform.TagCheck(Tags.Global)|| staticMover.Platform.TagCheck(Tags.Persistent))) {
+                List<StaticMover> movers = new DynData<Platform>(staticMover.Platform).Get<List<StaticMover>>("staticMovers");
+                for (int i = movers.Count - 1; i >= 0; i--) {
+                    if (movers[i].Entity is DreamTunnelEntry entry) {
+                        movers[i].Platform.OnDashCollide = entry.platformDashCollide;
+                        movers.RemoveAt(i);
+                    }
+                }
+            }
+            base.Removed(scene);
+        }
+
+        public void FootstepRipple(Vector2 position) {
+            if (PlayerHasDreamDash) {
+                DisplacementRenderer.Burst burst = level.Displacement.AddBurst(position, 0.5f, 0f, 25f, 1f);
+                burst.WorldClipCollider = Collider;
+                burst.WorldClipPadding = 1;
+            }
+        }
+
+        public override void Render() {
+            Camera camera = SceneAs<Level>().Camera;
+            if (Right < camera.Left || Left > camera.Right || Bottom < camera.Top || Top > camera.Bottom) {
+                return;
+            }
+
+            Color activeBackColor = CustomDreamBlock.ActiveBackColor;
+            Color disabledBackColor = CustomDreamBlock.DisabledBackColor;
+
+            Draw.Rect(shake.X + X, shake.Y + Y, Width, Height, PlayerHasDreamDash ? activeBackColor : disabledBackColor);
+            
+            Vector2 position = camera.Position;
+            for (int i = 0; i < particles.Length; i++) {
+                int layer = particles[i].Layer;
+                Vector2 vector = particles[i].Position;
+                vector += position * (0.3f + 0.25f * layer);
+                vector = PutInside(vector);
+                Color color = particles[i].Color;
+                MTexture mtexture;
+                if (layer == 0) {
+                    int num = (int) ((particles[i].TimeOffset * 4f + animTimer) % 4f);
+                    mtexture = particleTextures[3 - num];
+                } else if (layer == 1) {
+                    int num2 = (int) ((particles[i].TimeOffset * 2f + animTimer) % 2f);
+                    mtexture = particleTextures[1 + num2];
+                } else {
+                    mtexture = particleTextures[2];
+                }
+                if (vector.X >= X + 2f && vector.Y >= Y + 2f && vector.X < Right - 2f && vector.Y < Bottom - 2f) {
+                    mtexture.DrawCentered(vector + shake, color);
+                }
+            }
+            
+            if (whiteFill > 0f) {
+                Draw.Rect(X + shake.X, Y + shake.Y, Width, Height * whiteHeight, Color.White * whiteFill);
+            }
+            Vector2 start = new Vector2(
+                X + (Orientation == Spikes.Directions.Right || Orientation == Spikes.Directions.Down ? Width : 0), 
+                Y + (Orientation == Spikes.Directions.Left ? Height : 0));
+            Vector2 end = new Vector2(
+                X + (Orientation == Spikes.Directions.Up || Orientation == Spikes.Directions.Right ? Width : 0),
+                Y + (Orientation == Spikes.Directions.Right || Orientation == Spikes.Directions.Down ? Height : 0));
+            WobbleLine(shake + start, shake + end, 0f);
+        }
+
+        private void WobbleLine(Vector2 from, Vector2 to, float offset) {
+            float length = (to - from).Length();
+            Vector2 vector = Vector2.Normalize(to - from);
+            Vector2 vector2 = new Vector2(vector.Y, -vector.X);
+            Color lineColor = PlayerHasDreamDash ? CustomDreamBlock.ActiveLineColor : CustomDreamBlock.DisabledLineColor;
+            Color backColor = PlayerHasDreamDash ? CustomDreamBlock.ActiveBackColor : CustomDreamBlock.DisabledBackColor;
+            if (whiteFill > 0f) {
+                lineColor = Color.Lerp(lineColor, Color.White, whiteFill);
+                backColor = Color.Lerp(backColor, Color.White, whiteFill);
+            }
+            float scaleFactor = 0f;
+            int interval = 8;
+            for (int i = 0; i < length; i += interval) {
+                float lerp = MathHelper.Lerp(LineAmplitude(wobbleFrom + offset, i), LineAmplitude(wobbleTo + offset, i), wobbleEase);
+                if (i + interval >= length) {
+                    lerp = 0f;
+                }
+                float num5 = Math.Min(interval, length - i);
+                Vector2 vector3 = from + vector * i + vector2 * scaleFactor;
+                Vector2 vector4 = from + vector * (i + num5) + vector2 * lerp;
+                Draw.Line(vector3 - vector2, vector4 - vector2, backColor);
+                Draw.Line(vector3 - vector2 * 2f, vector4 - vector2 * 2f, backColor);
+                Draw.Line(vector3, vector4, lineColor);
+                scaleFactor = lerp;
+            }
+        }
+
+        private float LineAmplitude(float seed, float index) {
+            return (float) (Math.Sin(seed + index / 16f + Math.Sin(seed * 2f + index / 32f) * Calc.Circle) + 1.0) * 1.5f;
+        }
+
+        private Vector2 PutInside(Vector2 pos) {
+            while (pos.X < X) {
+                pos.X += Width;
+            }
+            while (pos.X > X + Width) {
+                pos.X -= Width;
+            }
+            while (pos.Y < Y) {
+                pos.Y += Height;
+            }
+            while (pos.Y > Y + Height) {
+                pos.Y -= Height;
+            }
+            return pos;
+        }
+
+        public void Setup() {
+            particles = new CustomDreamBlock.DreamParticle[(int) ((Width / 4f) * (Height / 4f))];
+            for (int i = 0; i < particles.Length; i++) {
+                particles[i].Position = new Vector2(Calc.Random.NextFloat(Width), Calc.Random.NextFloat(Height));
+                particles[i].Layer = Calc.Random.Choose(0, 1, 1, 2, 2, 2);
+                particles[i].TimeOffset = Calc.Random.NextFloat();
+                particles[i].Color = Color.LightGray * (0.5f + particles[i].Layer / 2f * 0.5f);
+                if (PlayerHasDreamDash) {
+                    switch (particles[i].Layer) {
+                        case 0:
+                            particles[i].Color = Calc.Random.Choose(Calc.HexToColor("FFEF11"), Calc.HexToColor("FF00D0"), Calc.HexToColor("08a310"));
+                            break;
+                        case 1:
+                            particles[i].Color = Calc.Random.Choose(Calc.HexToColor("5fcde4"), Calc.HexToColor("7fb25e"), Calc.HexToColor("E0564C"));
+                            break;
+                        case 2:
+                            particles[i].Color = Calc.Random.Choose(Calc.HexToColor("5b6ee1"), Calc.HexToColor("CC3B3B"), Calc.HexToColor("7daa64"));
+                            break;
+                    }
+                }
+            }
+        }
+
+        #region Activation
+
+        public IEnumerator Activate() {
+            Level level = SceneAs<Level>();
+            yield return 1f;
+            Input.Rumble(RumbleStrength.Light, RumbleLength.Long);
+            Add(shaker = new Shaker(true, delegate (Vector2 t) {
+                shake = t;
+            }));
+            shaker.Interval = 0.02f;
+            shaker.On = true;
+            for (float p = 0f; p < 1f; p += Engine.DeltaTime) {
+                whiteFill = Ease.CubeIn(p);
+                yield return null;
+            }
+            shaker.On = false;
+            yield return 0.5f;
+            ActivateNoRoutine();
+            whiteHeight = 1f;
+            whiteFill = 1f;
+            for (float p = 1f; p > 0f; p -= Engine.DeltaTime * 0.5f) {
+                whiteHeight = p;
+                if (level.OnInterval(0.1f)) {
+                    int num = 0;
+                    while (num < Width) {
+                        level.ParticlesFG.Emit(Strawberry.P_WingsBurst, new Vector2(X + num, Y + Height * whiteHeight + 1f));
+                        num += 4;
+                    }
+                }
+                if (level.OnInterval(0.1f)) {
+                    level.Shake(0.3f);
+                }
+                Input.Rumble(RumbleStrength.Strong, RumbleLength.Short);
+                yield return null;
+            }
+            while (whiteFill > 0f) {
+                whiteFill -= Engine.DeltaTime * 3f;
+                yield return null;
+            }
+            yield break;
+        }
+
+        public void ActivateNoRoutine() {
+            if (!PlayerHasDreamDash) {
+                PlayerHasDreamDash = true;
+                Setup();
+                Remove(occlude);
+                whiteHeight = 0f;
+                whiteFill = 0f;
+                if (shaker != null) {
+                    shaker.On = false;
+                }
+            }
+        }
+
+        public void DeactivateNoRoutine() {
+            if (PlayerHasDreamDash) {
+                PlayerHasDreamDash = false;
+                Setup();
+                if (occlude == null) {
+                    occlude = new LightOcclude(1f);
+                }
+                Add(occlude);
+                whiteHeight = 1f;
+                whiteFill = 0f;
+                if (shaker != null) {
+                    shaker.On = false;
+                }
+                surfaceSoundIndex = SurfaceIndex.DreamBlockInactive;
+            }
+        }
+
+        public IEnumerator Deactivate() {
+            Level level = SceneAs<Level>();
+            yield return 1f;
+            Input.Rumble(RumbleStrength.Light, RumbleLength.Long);
+            if (shaker == null) {
+                shaker = new Shaker(true, delegate (Vector2 t) {
+                    shake = t;
+                });
+            }
+            Add(shaker);
+            shaker.Interval = 0.02f;
+            shaker.On = true;
+            for (float alpha = 0f; alpha < 1f; alpha += Engine.DeltaTime) {
+                whiteFill = Ease.CubeIn(alpha);
+                yield return null;
+            }
+            shaker.On = false;
+            yield return 0.5f;
+            DeactivateNoRoutine();
+            whiteHeight = 1f;
+            whiteFill = 1f;
+            for (float alpha = 1f; alpha > 0f; alpha -= Engine.DeltaTime * 0.5f) {
+                whiteHeight = alpha;
+                if (level.OnInterval(0.1f)) {
+                    int num = 0;
+                    while (num < Width) {
+                        level.ParticlesFG.Emit(Strawberry.P_WingsBurst, new Vector2(X + num, Y + Height * whiteHeight + 1f));
+                        num += 4;
+                    }
+                }
+                if (level.OnInterval(0.1f)) {
+                    level.Shake(0.3f);
+                }
+                Input.Rumble(RumbleStrength.Strong, RumbleLength.Short);
+                yield return null;
+            }
+            while (whiteFill > 0f) {
+                whiteFill -= Engine.DeltaTime * 3f;
+                yield return null;
+            }
+            yield break;
+        }
+
+        public IEnumerator FastDeactivate() {
+            Level level = SceneAs<Level>();
+            yield return null;
+            Input.Rumble(RumbleStrength.Light, RumbleLength.Short);
+            if (shaker == null) {
+                shaker = new Shaker(true, delegate (Vector2 t) {
+                    shake = t;
+                });
+            }
+            Add(shaker);
+            shaker.Interval = 0.02f;
+            shaker.On = true;
+            for (float alpha = 0f; alpha < 1f; alpha += Engine.DeltaTime * 3f) {
+                whiteFill = Ease.CubeIn(alpha);
+                yield return null;
+            }
+            shaker.On = false;
+            yield return 0.1f;
+            DeactivateNoRoutine();
+            whiteHeight = 1f;
+            whiteFill = 1f;
+            level.ParticlesFG.Emit(Strawberry.P_WingsBurst, (int) Width, TopCenter, Vector2.UnitX * Width / 2f, Color.White, 3.14159274f);
+            level.ParticlesFG.Emit(Strawberry.P_WingsBurst, (int) Width, BottomCenter, Vector2.UnitX * Width / 2f, Color.White, 0f);
+            level.ParticlesFG.Emit(Strawberry.P_WingsBurst, (int) Height, CenterLeft, Vector2.UnitY * Height / 2f, Color.White, 4.712389f);
+            level.ParticlesFG.Emit(Strawberry.P_WingsBurst, (int) Height, CenterRight, Vector2.UnitY * Height / 2f, Color.White, 1.57079637f);
+            level.Shake(0.3f);
+            yield return 0.1f;
+            while (whiteFill > 0f) {
+                whiteFill -= Engine.DeltaTime * 3f;
+                yield return null;
+            }
+            yield break;
+        }
+
+        public IEnumerator FastActivate() {
+            Level level = SceneAs<Level>();
+            yield return null;
+            Input.Rumble(RumbleStrength.Light, RumbleLength.Short);
+            if (shaker == null) {
+                shaker = new Shaker(true, delegate (Vector2 t) {
+                    shake = t;
+                });
+            }
+            Add(shaker);
+            shaker.Interval = 0.02f;
+            shaker.On = true;
+            for (float alpha = 0f; alpha < 1f; alpha += Engine.DeltaTime * 3f) {
+                whiteFill = Ease.CubeIn(alpha);
+                yield return null;
+            }
+            shaker.On = false;
+            yield return 0.1f;
+            ActivateNoRoutine();
+            whiteHeight = 1f;
+            whiteFill = 1f;
+            level.ParticlesFG.Emit(Strawberry.P_WingsBurst, (int) Width, TopCenter, Vector2.UnitX * Width / 2f, Color.White, 3.14159274f);
+            level.ParticlesFG.Emit(Strawberry.P_WingsBurst, (int) Width, BottomCenter, Vector2.UnitX * Width / 2f, Color.White, 0f);
+            level.ParticlesFG.Emit(Strawberry.P_WingsBurst, (int) Height, CenterLeft, Vector2.UnitY * Height / 2f, Color.White, 4.712389f);
+            level.ParticlesFG.Emit(Strawberry.P_WingsBurst, (int) Height, CenterRight, Vector2.UnitY * Height / 2f, Color.White, 1.57079637f);
+            level.Shake(0.3f);
+            yield return 0.1f;
+            while (whiteFill > 0f) {
+                whiteFill -= Engine.DeltaTime * 3f;
+                yield return null;
+            }
+            yield break;
+        }
+
+        #endregion
+
+        #region Hooks
+
+        private static List<IDetour> hook_Platform_GetLandOrStepSoundIndex = new List<IDetour>();
+        private static List<IDetour> hook_Platform_GetWallSoundIndex = new List<IDetour>();
+        private static IDetour hook_Player_DashCoroutine;
+        private static IDetour hook_Player_orig_WallJump;
+
+        internal static void Load() {
+            // TODO: Move this to LoadContent
+            // Land and Step sound are identical
+            MethodInfo Platform_GetLandOrStepSoundIndex = typeof(DreamTunnelEntry).GetMethod("Platform_GetLandOrStepSoundIndex", BindingFlags.NonPublic | BindingFlags.Static);
+            foreach (MethodInfo method in typeof(Platform).GetMethod("GetLandSoundIndex").GetOverrides()) {
+                Logger.Log(LogLevel.Info, "Communal Helper", $"Hooking {method.DeclaringType}.{method.Name} to override when DreamTunnelEntry present.");
+                hook_Platform_GetLandOrStepSoundIndex.Add(
+                    new Hook(method,
+                        Platform_GetLandOrStepSoundIndex)
+                );
+            }
+            foreach (MethodInfo method in typeof(Platform).GetMethod("GetStepSoundIndex").GetOverrides()) {
+                Logger.Log(LogLevel.Info, "Communal Helper", $"Hooking {method.DeclaringType}.{method.Name} to override when DreamTunnelEntry present.");
+                hook_Platform_GetLandOrStepSoundIndex.Add(
+                    new Hook(method,
+                        Platform_GetLandOrStepSoundIndex)
+                );
+            }
+            MethodInfo Platform_GetWallSoundIndex = typeof(DreamTunnelEntry).GetMethod("Platform_GetWallSoundIndex", BindingFlags.NonPublic | BindingFlags.Static);
+            foreach (MethodInfo method in typeof(Platform).GetMethod("GetWallSoundIndex").GetOverrides()) {
+                Logger.Log(LogLevel.Info, "Communal Helper", $"Hooking {method.DeclaringType}.{method.Name} to override when DreamTunnelEntry present.");
+                hook_Platform_GetWallSoundIndex.Add(
+                    new Hook(method,
+                        Platform_GetWallSoundIndex)
+                );
+            }
+
+            hook_Player_DashCoroutine = new ILHook(
+                typeof(Player).GetMethod("DashCoroutine", BindingFlags.NonPublic | BindingFlags.Instance).GetStateMachineTarget(),
+                Player_DashCoroutine);
+
+            IL.Celeste.Player.ClimbBegin += Player_ClimbBegin;
+            IL.Celeste.Player.OnCollideV += Player_OnCollideV;
+            hook_Player_orig_WallJump = new ILHook(
+                typeof(Player).GetMethod("orig_WallJump", BindingFlags.NonPublic | BindingFlags.Instance),
+                Player_orig_WallJump);
+
+            On.Celeste.Solid.Awake += Solid_Awake;
+        }
+
+        internal static void Unload() {
+            hook_Platform_GetLandOrStepSoundIndex.ForEach(h => h.Dispose());
+            hook_Platform_GetWallSoundIndex.ForEach(h => h.Dispose());
+
+            hook_Player_DashCoroutine.Dispose();
+
+            IL.Celeste.Player.ClimbBegin -= Player_ClimbBegin;
+            IL.Celeste.Player.OnCollideV -= Player_OnCollideV;
+            hook_Player_orig_WallJump.Dispose();
+
+            On.Celeste.Solid.Awake -= Solid_Awake;
+        }
+
+        private static int Platform_GetLandOrStepSoundIndex(Func<Platform, Entity, int> orig, Platform self, Entity entity) {
+            foreach (StaticMover sm in new DynData<Platform>(self).Get<List<StaticMover>>("staticMovers")) {
+                if (sm.Entity is DreamTunnelEntry entry && entry.Orientation == Spikes.Directions.Up && entity.CollideCheck(entry, entity.Position + Vector2.UnitY)) { 
+                    return entry.surfaceSoundIndex;
+                }
+            }
+            return orig(self, entity);
+        }
+
+        private static int Platform_GetWallSoundIndex(Func<Platform, Player, int, int> orig, Platform self, Player player, int side) {
+            foreach (StaticMover sm in new DynData<Platform>(self).Get<List<StaticMover>>("staticMovers")) {
+                if (sm.Entity is DreamTunnelEntry entry) {
+                    if (side == (int) Facings.Left && entry.Orientation == Spikes.Directions.Right && player.CollideCheck(entry, player.Position - Vector2.UnitX)) {
+                            return entry.surfaceSoundIndex;
+                    } 
+                    if (side == (int) Facings.Right && entry.Orientation == Spikes.Directions.Left && player.CollideCheck(entry, player.Position + Vector2.UnitX)) { 
+                            return entry.surfaceSoundIndex;
+                    }
+                }
+            }
+            return orig(self, player, side);
+        }
+
+        private static void Player_DashCoroutine(ILContext il) {
+            /*
+             * adds a check for !player.CollideCheck<DreamTunnelEntry>(player.Position + Vector2.UnitY) to
+             * if (player.onGround && player.DashDir.X != 0f && player.DashDir.Y > 0f && player.Speed.Y > 0f && 
+             *  (!player.Inventory.DreamDash || !player.CollideCheck<DreamBlock>(player.Position + Vector2.UnitY)))
+             */
+            ILCursor cursor = new ILCursor(il);
+            // oof
+            cursor.GotoNext(MoveType.After, instr => instr.OpCode == OpCodes.Callvirt && 
+                ((MethodReference) instr.Operand).FullName == "System.Boolean Monocle.Entity::CollideCheck<Celeste.DreamBlock>(Microsoft.Xna.Framework.Vector2)");
+            cursor.Emit(OpCodes.Ldarg_0);
+            cursor.Emit(OpCodes.Ldfld, typeof(Player).GetNestedType("<DashCoroutine>d__423", BindingFlags.NonPublic).GetField("<>4__this"));
+            cursor.EmitDelegate<Func<bool, Player, bool>>((v, player) => {
+                return v || player.CollideCheck<DreamTunnelEntry>(player.Position + Vector2.UnitY);
+            });
+        }
+
+        private static void Player_ClimbBegin(ILContext il) {
+            ILCursor cursor = new ILCursor(il);
+
+            cursor.GotoNext(instr => instr.MatchIsinst<DreamBlock>());
+            cursor.Emit(OpCodes.Ldarg_0);
+            cursor.EmitDelegate<Func<Platform, Player, Platform>>((platform, player) => {
+                foreach (StaticMover sm in new DynData<Platform>(platform).Get<List<StaticMover>>("staticMovers")) {
+                    Vector2 origin = player.Position + new Vector2((float) player.Facing * 3, -4f);
+                    if (sm.Entity is DreamTunnelEntry entry 
+                        && (entry.Orientation == Spikes.Directions.Left || entry.Orientation == Spikes.Directions.Right) 
+                        && entry.CollidePoint(origin + Vector2.UnitX * (float) player.Facing)) {
+                        entry.FootstepRipple(origin);
+                    }
+                }
+                return platform;
+            });
+        }
+
+        private static void Player_OnCollideV(ILContext il) {
+            ILCursor cursor = new ILCursor(il);
+
+            cursor.GotoNext(instr => instr.MatchIsinst<DreamBlock>());
+            cursor.Emit(OpCodes.Ldarg_0);
+            cursor.EmitDelegate<Func<Platform, Player, Platform>>((platform, player) => {
+                foreach (StaticMover sm in new DynData<Platform>(platform).Get<List<StaticMover>>("staticMovers")) {
+                    if (sm.Entity is DreamTunnelEntry entry && entry.Orientation == Spikes.Directions.Up 
+                        && player.CollideCheck(entry, player.Position + Vector2.UnitY)) {
+                        entry.FootstepRipple(player.Position);
+                    }
+                }
+                return platform;
+            });
+        }
+
+        private static void Player_orig_WallJump(ILContext il) {
+            ILCursor cursor = new ILCursor(il);
+
+            cursor.GotoNext(instr => instr.MatchIsinst<DreamBlock>());
+            cursor.Emit(OpCodes.Ldarg_0);
+            cursor.Emit(OpCodes.Ldarg_1);
+            cursor.EmitDelegate<Func<Platform, Player, int, Platform>>((platform, player, dir) => {
+                foreach (StaticMover sm in new DynData<Platform>(platform).Get<List<StaticMover>>("staticMovers")) {
+                    if (sm.Entity is DreamTunnelEntry entry
+                        && (entry.Orientation == Spikes.Directions.Left || entry.Orientation == Spikes.Directions.Right)
+                        && entry.CollidePoint(player.Position - Vector2.UnitX * dir * 4f)) {
+                        entry.FootstepRipple(player.Position + new Vector2(0, -4f));
+                    }
+                }
+                return platform;
+            });
+        }
+
+        private static void Solid_Awake(On.Celeste.Solid.orig_Awake orig, Solid self, Scene scene) {
+            orig(self, scene);
+            if (!self.AllowStaticMovers) {
+                bool collidable = self.Collidable;
+                self.Collidable = true;
+                DynData<Solid> solidData = null;
+                foreach (Component component in scene.Tracker.GetComponents<StaticMover>()) {
+                    StaticMover staticMover = (StaticMover) component;
+                    if (staticMover.Entity is DreamTunnelEntry entry && entry.overrideAllowStaticMovers && staticMover.IsRiding(self) && staticMover.Platform == null) {
+                        solidData = solidData ?? new DynData<Solid>(self);
+                        solidData.Get<List<StaticMover>>("staticMovers").Add(staticMover);
+                        staticMover.Platform = self;
+                        staticMover.OnAttach?.Invoke(self);
+                    }
+                }
+                self.Collidable = collidable;
+            }
+        }
+
+        #endregion
+
+    }
+}

--- a/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntry.cs
+++ b/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntry.cs
@@ -283,13 +283,13 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                 }
             }
 
-            scene.Tracker.GetEntity<DreamTunnelEntryRenderer>().Track(this, originalDepth, level);
+            scene.Tracker.GetEntity<DreamTunnelEntryRenderer>().Track(this, originalDepth);
         }
 
         private void Destroy() {
             Collidable = false;
             // Stop rendering the block/outline
-            Scene.Tracker.GetEntity<DreamTunnelEntryRenderer>().Untrack(this, originalDepth, level);
+            Scene.Tracker.GetEntity<DreamTunnelEntryRenderer>().Untrack(this, originalDepth);
             // "Lock the Camera" to keep dreamblock particles in place
             lockedCamera = SceneAs<Level>().Camera.Position;
             Tween tween = Tween.Create(Tween.TweenMode.Oneshot, Ease.Linear, 1, true);
@@ -330,7 +330,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             }
             base.Removed(scene);
 
-            scene.Tracker.GetEntity<DreamTunnelEntryRenderer>().Untrack(this, originalDepth, level);
+            scene.Tracker.GetEntity<DreamTunnelEntryRenderer>().Untrack(this, originalDepth);
         }
 
         public void FootstepRipple(Vector2 position) {

--- a/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntryRenderer.cs
+++ b/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntryRenderer.cs
@@ -1,21 +1,21 @@
 ﻿using Microsoft.Xna.Framework;
 using Monocle;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Celeste.Mod.CommunalHelper.Entities {
 
+    /// <summary>
+    /// Handles the background and line rendering for DreamTunnelEntries
+    /// Added in a LevelLoader.LoadingThread hook in DreamTunnelEntry
+    /// </summary>
     [Tracked(false)]
     class DreamTunnelEntryRenderer : Entity {
 
         private List<DreamTunnelEntry> list = new List<DreamTunnelEntry>();
 
         public DreamTunnelEntryRenderer() {
-            base.Tag = ((int) Tags.Global | (int) Tags.TransitionUpdate);
-            base.Depth = Depths.FakeWalls;
+            Tag = Tags.Global | Tags.TransitionUpdate;
+            Depth = Depths.FakeWalls;
         }
 
         public void Track(DreamTunnelEntry entity) => list.Add(entity);
@@ -24,36 +24,22 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         public override void Render() {
             foreach(DreamTunnelEntry e in list) {
+                Vector2 shake = e.shake + e.platformShake;
 
-                Vector2 start = e.shake + e.start;
-                Vector2 end = e.shake + e.end;
+                Vector2 start = shake + e.start;
+                Vector2 end = shake + e.end;
 
-                Draw.Rect(e.shake.X + e.X, e.shake.Y + e.Y, e.Width, e.Height, e.PlayerHasDreamDash ? CustomDreamBlock.ActiveBackColor : CustomDreamBlock.DisabledBackColor);
+                Draw.Rect(shake.X + e.X, shake.Y + e.Y, e.Width, e.Height, e.PlayerHasDreamDash ? CustomDreamBlock.ActiveBackColor : CustomDreamBlock.DisabledBackColor * e.Alpha);
                 if (e.whiteFill > 0f) {
-                    Draw.Rect(e.X + e.shake.X, e.Y + e.shake.Y, e.Width, e.Height * e.whiteHeight, Color.White * e.whiteFill);
+                    Draw.Rect(e.X + shake.X, e.Y + shake.Y, e.Width, e.Height * e.whiteHeight, Color.White * e.whiteFill * e.Alpha);
                 }
                 e.WobbleLine(start, end, 0f, false, true);
             }
 
             foreach (DreamTunnelEntry e in list) {
-                e.WobbleLine(e.shake + e.start, e.shake + e.end, 0f, true, false);
+                Vector2 shake = e.shake + e.platformShake;
+                e.WobbleLine(shake + e.start, shake + e.end, 0f, true, false);
             }
-        }
-    }
-
-    class DreamTunnelEntryHooks {
-        
-        public static void Hook() {
-            On.Celeste.LevelLoader.LoadingThread += LevelLoader_LoadingThread;
-        }
-
-        public static void Unhook() {
-            On.Celeste.LevelLoader.LoadingThread -= LevelLoader_LoadingThread;
-        }
-
-        private static void LevelLoader_LoadingThread(On.Celeste.LevelLoader.orig_LoadingThread orig, LevelLoader self) {
-            orig(self);
-            self.Level.Add(new DreamTunnelEntryRenderer());
         }
            
     }

--- a/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntryRenderer.cs
+++ b/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntryRenderer.cs
@@ -5,41 +5,71 @@ using System.Collections.Generic;
 namespace Celeste.Mod.CommunalHelper.Entities {
 
     /// <summary>
-    /// Handles the background and line rendering for DreamTunnelEntries
-    /// Added in a LevelLoader.LoadingThread hook in DreamTunnelEntry
+    /// Handles the background and line rendering for DreamTunnelEntries.
+    /// Added in a LevelLoader.LoadingThread hook in DreamTunnelEntry.
     /// </summary>
     [Tracked(false)]
     class DreamTunnelEntryRenderer : Entity {
 
-        private List<DreamTunnelEntry> list = new List<DreamTunnelEntry>();
+        private class CustomDepthDreamTunnelEntryRenderer : Entity{
+            public List<DreamTunnelEntry> list = new List<DreamTunnelEntry>();
+
+            public CustomDepthDreamTunnelEntryRenderer(int depth) {
+                Tag = Tags.Global | Tags.TransitionUpdate;
+                Depth = depth;
+            }
+
+            public override void Render() {
+                foreach (DreamTunnelEntry e in list) {
+                    Vector2 shake = e.Shake;
+
+                    Vector2 start = shake + e.Start;
+                    Vector2 end = shake + e.End;
+
+                    Draw.Rect(shake.X + e.X, shake.Y + e.Y, e.Width, e.Height, e.PlayerHasDreamDash ? CustomDreamBlock.ActiveBackColor : CustomDreamBlock.DisabledBackColor * e.Alpha);
+                    if (e.Whitefill > 0f) {
+                        Draw.Rect(e.X + shake.X, e.Y + shake.Y, e.Width, e.Height * e.WhiteHeight, Color.White * e.Whitefill * e.Alpha);
+                    }
+                    e.WobbleLine(start, end, 0f, false, true);
+                }
+
+                foreach (DreamTunnelEntry e in list) {
+                    e.WobbleLine(e.Shake + e.Start, e.Shake + e.End, 0f, true, false);
+                }
+            }
+        }
+
+        private Dictionary<int, CustomDepthDreamTunnelEntryRenderer> renderers = new Dictionary<int, CustomDepthDreamTunnelEntryRenderer>();
 
         public DreamTunnelEntryRenderer() {
             Tag = Tags.Global | Tags.TransitionUpdate;
             Depth = Depths.FakeWalls;
         }
 
-        public void Track(DreamTunnelEntry entity) => list.Add(entity);
-
-        public void Untrack(DreamTunnelEntry entity) => list.Remove(entity);
-
-        public override void Render() {
-            foreach (DreamTunnelEntry e in list) {
-                Vector2 shake = e.Shake;
-
-                Vector2 start = shake + e.Start;
-                Vector2 end = shake + e.End;
-
-                Draw.Rect(shake.X + e.X, shake.Y + e.Y, e.Width, e.Height, e.PlayerHasDreamDash ? CustomDreamBlock.ActiveBackColor : CustomDreamBlock.DisabledBackColor * e.Alpha);
-                if (e.Whitefill > 0f) {
-                    Draw.Rect(e.X + shake.X, e.Y + shake.Y, e.Width, e.Height * e.WhiteHeight, Color.White * e.Whitefill * e.Alpha);
-                }
-                e.WobbleLine(start, end, 0f, false, true);
+        public void Track(DreamTunnelEntry entity, int depth, Level level) {
+            // Create new renderer with specific depth if doesn't exist, or get the older one otherwise.
+            CustomDepthDreamTunnelEntryRenderer renderer;
+            if (renderers.TryGetValue(depth, out CustomDepthDreamTunnelEntryRenderer oldRenderer)) {
+                renderer = oldRenderer;
+            } else {
+                renderers.Add(depth, renderer = new CustomDepthDreamTunnelEntryRenderer(depth));
+                level.Add(renderer);
             }
 
-            foreach (DreamTunnelEntry e in list) {
-                e.WobbleLine(e.Shake + e.Start, e.Shake + e.End, 0f, true, false);
-            }
+            // Add entity
+            renderer.list.Add(entity);
         }
 
+        public void Untrack(DreamTunnelEntry entity, int depth, Level level) {
+            if (renderers.TryGetValue(depth, out CustomDepthDreamTunnelEntryRenderer renderer)) {
+                renderer.list.Remove(entity);
+
+                if (renderer.list.Count == 0) {
+                    // No entity with this renderer's depth exist, get rid of it.
+                    renderers.Remove(depth);
+                    level.Remove(renderer);
+                }
+            }
+        }
     }
 }

--- a/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntryRenderer.cs
+++ b/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntryRenderer.cs
@@ -24,21 +24,20 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         public override void Render() {
             foreach (DreamTunnelEntry e in list) {
-                Vector2 shake = e.shake + e.platformShake;
+                Vector2 shake = e.Shake;
 
-                Vector2 start = shake + e.start;
-                Vector2 end = shake + e.end;
+                Vector2 start = shake + e.Start;
+                Vector2 end = shake + e.End;
 
                 Draw.Rect(shake.X + e.X, shake.Y + e.Y, e.Width, e.Height, e.PlayerHasDreamDash ? CustomDreamBlock.ActiveBackColor : CustomDreamBlock.DisabledBackColor * e.Alpha);
-                if (e.whiteFill > 0f) {
-                    Draw.Rect(e.X + shake.X, e.Y + shake.Y, e.Width, e.Height * e.whiteHeight, Color.White * e.whiteFill * e.Alpha);
+                if (e.Whitefill > 0f) {
+                    Draw.Rect(e.X + shake.X, e.Y + shake.Y, e.Width, e.Height * e.WhiteHeight, Color.White * e.Whitefill * e.Alpha);
                 }
                 e.WobbleLine(start, end, 0f, false, true);
             }
 
             foreach (DreamTunnelEntry e in list) {
-                Vector2 shake = e.shake + e.platformShake;
-                e.WobbleLine(shake + e.start, shake + e.end, 0f, true, false);
+                e.WobbleLine(e.Shake + e.Start, e.Shake + e.End, 0f, true, false);
             }
         }
 

--- a/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntryRenderer.cs
+++ b/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntryRenderer.cs
@@ -11,10 +11,10 @@ namespace Celeste.Mod.CommunalHelper.Entities {
     [Tracked(false)]
     class DreamTunnelEntryRenderer : Entity {
 
-        private class CustomDepthDreamTunnelEntryRenderer : Entity{
+        private class CustomDepthRenderer : Entity{
             public List<DreamTunnelEntry> list = new List<DreamTunnelEntry>();
 
-            public CustomDepthDreamTunnelEntryRenderer(int depth) {
+            public CustomDepthRenderer(int depth) {
                 Tag = Tags.Global | Tags.TransitionUpdate;
                 Depth = depth;
             }
@@ -39,35 +39,31 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             }
         }
 
-        private Dictionary<int, CustomDepthDreamTunnelEntryRenderer> renderers = new Dictionary<int, CustomDepthDreamTunnelEntryRenderer>();
+        private Dictionary<int, CustomDepthRenderer> renderers = new Dictionary<int, CustomDepthRenderer>();
 
         public DreamTunnelEntryRenderer() {
             Tag = Tags.Global | Tags.TransitionUpdate;
-            Depth = Depths.FakeWalls;
         }
 
-        public void Track(DreamTunnelEntry entity, int depth, Level level) {
+        public void Track(DreamTunnelEntry entity, int depth) {
             // Create new renderer with specific depth if doesn't exist, or get the older one otherwise.
-            CustomDepthDreamTunnelEntryRenderer renderer;
-            if (renderers.TryGetValue(depth, out CustomDepthDreamTunnelEntryRenderer oldRenderer)) {
-                renderer = oldRenderer;
-            } else {
-                renderers.Add(depth, renderer = new CustomDepthDreamTunnelEntryRenderer(depth));
-                level.Add(renderer);
+            if (!renderers.TryGetValue(depth, out CustomDepthRenderer renderer)) {
+                renderers.Add(depth, renderer = new CustomDepthRenderer(depth));
+                entity.Scene.Add(renderer);
             }
 
             // Add entity
             renderer.list.Add(entity);
         }
 
-        public void Untrack(DreamTunnelEntry entity, int depth, Level level) {
-            if (renderers.TryGetValue(depth, out CustomDepthDreamTunnelEntryRenderer renderer)) {
+        public void Untrack(DreamTunnelEntry entity, int depth) {
+            if (renderers.TryGetValue(depth, out CustomDepthRenderer renderer)) {
                 renderer.list.Remove(entity);
 
                 if (renderer.list.Count == 0) {
                     // No entity with this renderer's depth exist, get rid of it.
                     renderers.Remove(depth);
-                    level.Remove(renderer);
+                    renderer.RemoveSelf();
                 }
             }
         }

--- a/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntryRenderer.cs
+++ b/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntryRenderer.cs
@@ -9,7 +9,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
     /// Added in a LevelLoader.LoadingThread hook in DreamTunnelEntry.
     /// </summary>
     [Tracked(false)]
-    class DreamTunnelEntryRenderer : Entity {
+    public class DreamTunnelEntryRenderer : Entity {
 
         private class CustomDepthRenderer : Entity{
             public List<DreamTunnelEntry> list = new List<DreamTunnelEntry>();

--- a/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntryRenderer.cs
+++ b/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntryRenderer.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.Xna.Framework;
+using Monocle;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Celeste.Mod.CommunalHelper.Entities {
+
+    [Tracked(false)]
+    class DreamTunnelEntryRenderer : Entity {
+
+        private List<DreamTunnelEntry> list = new List<DreamTunnelEntry>();
+
+        public DreamTunnelEntryRenderer() {
+            base.Tag = ((int) Tags.Global | (int) Tags.TransitionUpdate);
+            base.Depth = Depths.FakeWalls;
+        }
+
+        public void Track(DreamTunnelEntry entity) => list.Add(entity);
+
+        public void Untrack(DreamTunnelEntry entity) => list.Remove(entity);
+
+        public override void Render() {
+            foreach(DreamTunnelEntry e in list) {
+
+                Vector2 start = e.shake + e.start;
+                Vector2 end = e.shake + e.end;
+
+                Draw.Rect(e.shake.X + e.X, e.shake.Y + e.Y, e.Width, e.Height, e.PlayerHasDreamDash ? CustomDreamBlock.ActiveBackColor : CustomDreamBlock.DisabledBackColor);
+                if (e.whiteFill > 0f) {
+                    Draw.Rect(e.X + e.shake.X, e.Y + e.shake.Y, e.Width, e.Height * e.whiteHeight, Color.White * e.whiteFill);
+                }
+                e.WobbleLine(start, end, 0f, false, true);
+            }
+
+            foreach (DreamTunnelEntry e in list) {
+                e.WobbleLine(e.shake + e.start, e.shake + e.end, 0f, true, false);
+            }
+        }
+    }
+
+    class DreamTunnelEntryHooks {
+        
+        public static void Hook() {
+            On.Celeste.LevelLoader.LoadingThread += LevelLoader_LoadingThread;
+        }
+
+        public static void Unhook() {
+            On.Celeste.LevelLoader.LoadingThread -= LevelLoader_LoadingThread;
+        }
+
+        private static void LevelLoader_LoadingThread(On.Celeste.LevelLoader.orig_LoadingThread orig, LevelLoader self) {
+            orig(self);
+            self.Level.Add(new DreamTunnelEntryRenderer());
+        }
+           
+    }
+}

--- a/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntryRenderer.cs
+++ b/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntryRenderer.cs
@@ -23,7 +23,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         public void Untrack(DreamTunnelEntry entity) => list.Remove(entity);
 
         public override void Render() {
-            foreach(DreamTunnelEntry e in list) {
+            foreach (DreamTunnelEntry e in list) {
                 Vector2 shake = e.shake + e.platformShake;
 
                 Vector2 start = shake + e.start;
@@ -41,6 +41,6 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                 e.WobbleLine(shake + e.start, shake + e.end, 0f, true, false);
             }
         }
-           
+
     }
 }

--- a/src/Entities/DreamStuff/ConnectedDreamBlock.cs
+++ b/src/Entities/DreamStuff/ConnectedDreamBlock.cs
@@ -364,7 +364,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             }
 
             if (MasterOfGroup) {
-                Color lineColor = PlayerHasDreamDash ? activeLineColor : disabledLineColor;
+                Color lineColor = PlayerHasDreamDash ? ActiveLineColor : DisabledLineColor;
                 Color backColor = Color.Lerp(PlayerHasDreamDash ? baseData.Get<Color>("activeBackColor") : baseData.Get<Color>("disabledBackColor"), Color.White, ColorLerp);
 
                 if (whiteFill > 0f) {

--- a/src/Entities/DreamStuff/CustomDreamBlock.cs
+++ b/src/Entities/DreamStuff/CustomDreamBlock.cs
@@ -77,10 +77,14 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         public bool PlayerHasDreamDash => baseData.Get<bool>("playerHasDreamDash");
 
-        protected Color activeLineColor => baseData.Get<Color>("activeLineColor");
-        protected Color disabledLineColor => baseData.Get<Color>("disabledLineColor");
-        protected Color activeBackColor => baseData.Get<Color>("activeBackColor");
-        protected Color disabledBackColor => baseData.Get<Color>("disabledBackColor");
+        public static Color ActiveLineColor => (Color) f_DreamBlock_activeLineColor.GetValue(null);
+        private static FieldInfo f_DreamBlock_activeLineColor = typeof(DreamBlock).GetField("activeLineColor", BindingFlags.NonPublic | BindingFlags.Static);
+        public static Color DisabledLineColor => (Color) f_DreamBlock_disabledLineColor.GetValue(null);
+        private static FieldInfo f_DreamBlock_disabledLineColor = typeof(DreamBlock).GetField("disabledLineColor", BindingFlags.NonPublic | BindingFlags.Static);
+        public static Color ActiveBackColor => (Color) f_DreamBlock_activeBackColor.GetValue(null);
+        private static FieldInfo f_DreamBlock_activeBackColor = typeof(DreamBlock).GetField("activeBackColor", BindingFlags.NonPublic | BindingFlags.Static);
+        public static Color DisabledBackColor => (Color) f_DreamBlock_disabledBackColor.GetValue(null);
+        private static FieldInfo f_DreamBlock_disabledBackColor = typeof(DreamBlock).GetField("disabledBackColor", BindingFlags.NonPublic | BindingFlags.Static);
 
         public bool FeatherMode;
         protected int RefillCount;
@@ -106,7 +110,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             //    activeLineColor = Calc.HexToColor("FF66D9"); 
             //}
             shakeParticle = new ParticleType(SwitchGate.P_Behind) {
-                Color = activeLineColor,
+                Color = ActiveLineColor,
                 ColorMode = ParticleType.ColorModes.Static,
                 Acceleration = Vector2.Zero,
                 DirectionRange = (float) Math.PI / 2
@@ -290,8 +294,8 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             float whiteFill = baseData.Get<float>("whiteFill");
             float whiteHeight = baseData.Get<float>("whiteHeight");
 
-            Color backColor = Color.Lerp(PlayerHasDreamDash ? activeBackColor : disabledBackColor, Color.White, ColorLerp);
-            Color lineColor = PlayerHasDreamDash ? activeLineColor : disabledLineColor;
+            Color backColor = Color.Lerp(PlayerHasDreamDash ? ActiveBackColor : DisabledBackColor, Color.White, ColorLerp);
+            Color lineColor = PlayerHasDreamDash ? ActiveLineColor : DisabledLineColor;
 
             Draw.Rect(shake.X + X, shake.Y + Y, Width, Height, backColor);
 

--- a/src/Entities/DreamStuff/DreamBlockDebris.cs
+++ b/src/Entities/DreamStuff/DreamBlockDebris.cs
@@ -14,8 +14,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                 Calc.HexToColor("E0564C")
         };
 
-        // TODO: Change this to use a DreamBlockDummy
-        public CustomDreamBlock Block;
+        public DreamBlockDummy Block;
 
         protected Sprite sprite;
 
@@ -29,10 +28,10 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             baseData = new DynData<Debris>(this);
         }
 
-        public DreamBlockDebris Init(Vector2 pos, CustomDreamBlock block) {
+        public DreamBlockDebris Init(Vector2 pos, DreamBlockDummy block = null) {
             orig_Init(pos, '1');
 
-            Block = block;
+            Block = block ?? new DreamBlockDummy(this);
             Image image = baseData.Get<Image>("image");
             Remove(image);
             Sprite sprite = new Sprite(GFX.Game, "objects/CommunalHelper/dreamMoveBlock/");
@@ -57,6 +56,13 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             }
 
             return this;
+        }
+
+        public override void Added(Scene scene) {
+            base.Added(scene);
+
+            if (Block.Scene != scene)
+                scene.Add(Block);
         }
 
         public override void Update() {

--- a/src/Entities/DreamStuff/DreamCrumbleWallOnRumble.cs
+++ b/src/Entities/DreamStuff/DreamCrumbleWallOnRumble.cs
@@ -38,7 +38,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                 for (int x = 0; x < Width / 8f; x++) {
                     for (int y = 0; y < Height / 8f; y++) {
                         if (!Scene.CollideCheck<Solid>(new Rectangle((int) X + x * 8, (int) Y + y * 8, 8, 8))) {
-                            Scene.Add(Engine.Pooler.Create<DreamBlockDebris>().Init(Position + new Vector2(4 + x * 8, 4 + y * 8), this).BlastFrom(TopCenter));
+                            Scene.Add(Engine.Pooler.Create<DreamBlockDebris>().Init(Position + new Vector2(4 + x * 8, 4 + y * 8)).BlastFrom(TopCenter));
                         }
                     }
                 }

--- a/src/Entities/DreamStuff/DreamMoveBlock.cs
+++ b/src/Entities/DreamStuff/DreamMoveBlock.cs
@@ -393,7 +393,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             Position += Shake;
             base.Render();
 
-            Color color = Color.Lerp(activeLineColor, Color.Black, ColorLerp);
+            Color color = Color.Lerp(ActiveLineColor, Color.Black, ColorLerp);
             if (State != MovementState.Breaking) {
                 int value = (int) Math.Floor((0f - angle + (float) Math.PI * 2f) % ((float) Math.PI * 2f) / ((float) Math.PI * 2f) * 8f + 0.5f);
                 MTexture arrow = arrows[Calc.Clamp(value, 0, 7)];

--- a/src/Entities/DreamStuff/DreamRefill.cs
+++ b/src/Entities/DreamStuff/DreamRefill.cs
@@ -1,5 +1,6 @@
 ﻿using Celeste.Mod.Entities;
 using Microsoft.Xna.Framework;
+using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Monocle;
 using MonoMod.Cil;
@@ -166,40 +167,41 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             cursor.GotoNext(instr => instr.Next.MatchLdfld<Refill>("level"));
 
             cursor.Emit(OpCodes.Ldarg_0);
-            cursor.Emit(OpCodes.Isinst, t_DreamRefill);
-            cursor.Emit(OpCodes.Brfalse_S, cursor.Next);
-
-            cursor.Emit(OpCodes.Ldarg_0);
-            cursor.Emit(OpCodes.Castclass, t_DreamRefill);
-            cursor.EmitDelegate(method);
-            cursor.Emit(OpCodes.Br_S, il.Instrs.First(instr => instr.MatchCallvirt<ParticleSystem>("Emit")).Next);
+            cursor.EmitDelegate<Func<Refill, bool>>(r => {
+                if (r is DreamRefill refill) {
+                    method.Invoke(refill);
+                    return true;
+                }
+                return false;
+            });
+            cursor.Emit(OpCodes.Brtrue, il.Instrs.First(instr => instr.MatchCallvirt<ParticleSystem>("Emit")).Next);
         }
 
         private static void Refill_RefillRoutine(ILContext il) {
-            FieldInfo f_this = m_Refill_RefillRoutine.GetStateMachineTarget().DeclaringType.GetField("<>4__this", BindingFlags.Public | BindingFlags.Instance);
+            Type StateMachineType = m_Refill_RefillRoutine.GetStateMachineTarget().DeclaringType;
+            FieldInfo f_this = StateMachineType.GetField("<>4__this", BindingFlags.Public | BindingFlags.Instance);
+            FieldInfo f_player = StateMachineType.GetField("player", BindingFlags.Public | BindingFlags.Instance);
 
             ILCursor cursor = new ILCursor(il);
-            cursor.GotoNext(instr => instr.MatchLdfld<Level>("ParticlesFG"));
-            cursor.GotoPrev(instr => instr.OpCode != OpCodes.Ldfld); // A bit messy but eh
-            Instruction angleLoc = cursor.Prev;
+            cursor.GotoNext(instr => instr.Match(OpCodes.Ldarg_0),
+                instr => instr.MatchLdfld(out FieldReference field) && field.Name == "player");
+            if (cursor.Prev.OpCode == OpCodes.Ldarg_0) // For SteamFNA
+                cursor.Goto(cursor.Prev);
 
             cursor.Emit(OpCodes.Ldarg_0);
             cursor.Emit(OpCodes.Ldfld, f_this);
-            cursor.Emit(OpCodes.Isinst, typeof(DreamRefill).GetTypeInfo());
-            cursor.Emit(OpCodes.Brfalse_S, cursor.Next);
-
             cursor.Emit(OpCodes.Ldarg_0);
-            cursor.Emit(OpCodes.Ldfld, f_this);
-            cursor.Emit(OpCodes.Castclass, t_DreamRefill);
+            cursor.Emit(OpCodes.Ldfld, f_player);
 
-            if (angleLoc.OpCode == OpCodes.Stfld) { // Steam FNA has different il code
-                cursor.Emit(OpCodes.Ldarg_0);
-                cursor.Emit(OpCodes.Ldfld, angleLoc.Operand);
-            } else
-                cursor.Emit(OpCodes.Ldloc_2);
+            cursor.EmitDelegate<Func<Refill, Player, bool>>((r, player) => {
+                if (r is DreamRefill refill) {
+                    refill.EmitShatterParticles(player.Speed.Angle());
+                    return true;
+                }
+                return false;
+            });
 
-            cursor.EmitDelegate<Action<DreamRefill, float>>((refill, angle) => refill.EmitShatterParticles(angle));
-            cursor.Emit(OpCodes.Br_S, il.Instrs.First(instr => instr.MatchCallvirt<ParticleSystem>("Emit")).Next);
+            cursor.Emit(OpCodes.Brtrue, il.Instrs.First(instr => instr.MatchCallvirt<ParticleSystem>("Emit")).Next);
         }
 
         #endregion

--- a/src/Entities/DreamStuff/DreamSwapBlock.cs
+++ b/src/Entities/DreamStuff/DreamSwapBlock.cs
@@ -27,7 +27,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             public override void Render() {
                 float scale = 0.5f * (0.5f + ((float) Math.Sin(timer) + 1f) * 0.25f);
                 scale = Calc.LerpClamp(scale, 1, block.ColorLerp);
-                block.DrawBlockStyle(new Vector2(block.moveRect.X, block.moveRect.Y), block.moveRect.Width, block.moveRect.Height, block.nineSliceTarget, null, block.activeLineColor * scale);
+                block.DrawBlockStyle(new Vector2(block.moveRect.X, block.moveRect.Y), block.moveRect.Width, block.moveRect.Height, block.nineSliceTarget, null, ActiveLineColor * scale);
             }
         }
 

--- a/src/Entities/DreamStuff/DreamZipMover.cs
+++ b/src/Entities/DreamStuff/DreamZipMover.cs
@@ -386,14 +386,15 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                 bool playerHasDreamDash = DreamZipMover.PlayerHasDreamDash;
 
                 float colorLerp = DreamZipMover.ColorLerp;
-                Color colorLerpTarget = DreamZipMover.activeLineColor;
+                Color colorLerpTarget = DreamZipMover.ActiveLineColor;
                 Vector2 travelDir = (to - from).SafeNormalize();
                 Vector2 hOffset1 = travelDir.Perpendicular() * 3f;
                 Vector2 hOffset2 = -travelDir.Perpendicular() * 4f;
                 float rotation = -DreamZipMover.percent * (float) Math.PI * 2f;
 
-                Color dreamRopeColor = playerHasDreamDash ? colorLerpTarget : DreamZipMover.disabledLineColor;
-                Color color = Color.Lerp(dreamAesthetic ? dreamRopeColor : ropeColor, colorLerpTarget, colorLerp);
+                Color dreamRopeColor = playerHasDreamDash ? colorLerpTarget : DreamZipMover.DisabledLineColor;
+                Color color = Color.Lerp(dreamAesthetic ?  dreamRopeColor : ropeColor, colorLerpTarget, colorLerp);
+
                 Draw.Line(from + hOffset1 + offset, to + hOffset1 + offset, colorOverride ?? color);
                 Draw.Line(from + hOffset2 + offset, to + hOffset2 + offset, colorOverride ?? color);
                 float dist = (to - from).Length();

--- a/src/Entities/Misc/DreamBlockDummy.cs
+++ b/src/Entities/Misc/DreamBlockDummy.cs
@@ -1,6 +1,4 @@
-﻿#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value null
-
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using Monocle;
 using MonoMod.Utils;
 using System;
@@ -8,7 +6,8 @@ using System.Collections;
 
 namespace Celeste.Mod.CommunalHelper.Entities {
     [TrackedAs(typeof(DreamBlock))]
-    class DreamBlockDummy : DreamBlock {
+    [Tracked]
+    public class DreamBlockDummy : DreamBlock {
         public Func<IEnumerator> OnActivate;
         public Func<IEnumerator> OnFastActivate;
         public Action OnActivateNoRoutine;
@@ -21,11 +20,36 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         public DynData<DreamBlock> Data;
 
-        public DreamBlockDummy() 
+        private DreamBlockDummy() 
             : base(Vector2.Zero, 0, 0, null, false, false) {
             Collidable = Active = Visible = false;
 
             Data = new DynData<DreamBlock>(this);
+        }
+
+        public static DreamBlockDummy Create(Scene scene) {
+            DreamBlockDummy block = scene.Tracker.GetEntity<DreamBlockDummy>();
+            if (block is null)
+                scene.Add(block = new DreamBlockDummy());
+            return block;
+        }
+
+        public DreamBlockDummy Initialize(
+            Func<IEnumerator> activate = null,
+            Func<IEnumerator> fastActivate = null,
+            Action activateNoRoutine = null,
+            Func<IEnumerator> deactivate = null,
+            Func<IEnumerator> fastDeactivate = null,
+            Action deactivateNoRoutine = null,
+            Action setup = null) {
+            OnActivate = activate;
+            OnFastActivate = fastActivate;
+            OnActivateNoRoutine = activateNoRoutine;
+            OnDeactivate = deactivate;
+            OnFastDeactivate = fastDeactivate;
+            OnDeactivateNoRoutine = deactivateNoRoutine;
+            OnSetup = setup;
+            return this;
         }
 
         public override void Added(Scene scene) { }

--- a/src/Entities/Misc/DreamBlockDummy.cs
+++ b/src/Entities/Misc/DreamBlockDummy.cs
@@ -1,0 +1,94 @@
+﻿#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value null
+
+using Microsoft.Xna.Framework;
+using Monocle;
+using MonoMod.Utils;
+using System;
+using System.Collections;
+
+namespace Celeste.Mod.CommunalHelper.Entities {
+    [TrackedAs(typeof(DreamBlock))]
+    class DreamBlockDummy : DreamBlock {
+        public Func<IEnumerator> OnActivate;
+        public Func<IEnumerator> OnFastActivate;
+        public Action OnActivateNoRoutine;
+
+        public Func<IEnumerator> OnDeactivate;
+        public Func<IEnumerator> OnFastDeactivate;
+        public Action OnDeactivateNoRoutine;
+
+        public Action OnSetup;
+
+        public DynData<DreamBlock> Data;
+
+        public DreamBlockDummy() 
+            : base(Vector2.Zero, 0, 0, null, false, false) {
+            Collidable = Active = Visible = false;
+
+            Data = new DynData<DreamBlock>(this);
+        }
+
+        public override void Added(Scene scene) { }
+
+        public override void Update() { }
+
+        public override void Render() { }
+
+        #region Hooks
+
+        internal static void Load() {
+            On.Celeste.DreamBlock.Activate += DreamBlock_Activate;
+            On.Celeste.DreamBlock.FastActivate += DreamBlock_FastActivate;
+            On.Celeste.DreamBlock.ActivateNoRoutine += DreamBlock_ActivateNoRoutine;
+
+            On.Celeste.DreamBlock.Deactivate += DreamBlock_Deactivate;
+            On.Celeste.DreamBlock.FastDeactivate += DreamBlock_FastDeactivate;
+            On.Celeste.DreamBlock.DeactivateNoRoutine += DreamBlock_DeactivateNoRoutine;
+
+            On.Celeste.DreamBlock.Setup += DreamBlock_Setup;
+        }
+
+        private static IEnumerator DreamBlock_Activate(On.Celeste.DreamBlock.orig_Activate orig, DreamBlock self) {
+            return (self as DreamBlockDummy)?.OnActivate?.Invoke() ?? orig(self);
+        }
+
+        private static IEnumerator DreamBlock_FastActivate(On.Celeste.DreamBlock.orig_FastActivate orig, DreamBlock self) {
+            return (self as DreamBlockDummy)?.OnFastActivate?.Invoke() ?? orig(self);
+        }
+
+        private static void DreamBlock_ActivateNoRoutine(On.Celeste.DreamBlock.orig_ActivateNoRoutine orig, DreamBlock self) {
+            if (self is DreamBlockDummy dummy && dummy.OnActivateNoRoutine != null) {
+                dummy.OnActivateNoRoutine();
+                return;
+            }
+            orig(self);
+        }
+
+        private static IEnumerator DreamBlock_Deactivate(On.Celeste.DreamBlock.orig_Deactivate orig, DreamBlock self) {
+            return (self as DreamBlockDummy)?.OnDeactivate?.Invoke() ?? orig(self);
+        }
+
+        private static IEnumerator DreamBlock_FastDeactivate(On.Celeste.DreamBlock.orig_FastDeactivate orig, DreamBlock self) {
+            return (self as DreamBlockDummy)?.OnFastDeactivate?.Invoke() ?? orig(self);
+        }
+
+        private static void DreamBlock_DeactivateNoRoutine(On.Celeste.DreamBlock.orig_DeactivateNoRoutine orig, DreamBlock self) {
+            if (self is DreamBlockDummy dummy && dummy.OnDeactivateNoRoutine != null) {
+                dummy.OnDeactivateNoRoutine();
+                return;
+            }
+            orig(self);
+        }
+
+        private static void DreamBlock_Setup(On.Celeste.DreamBlock.orig_Setup orig, DreamBlock self) {
+            if (self is DreamBlockDummy dummy && dummy.OnSetup != null) {
+                dummy.OnSetup();
+                return;
+            }
+            orig(self);
+        }
+
+        #endregion
+
+    }
+}

--- a/src/Entities/Misc/DreamBlockDummy.cs
+++ b/src/Entities/Misc/DreamBlockDummy.cs
@@ -20,36 +20,11 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         public DynData<DreamBlock> Data;
 
-        private DreamBlockDummy() 
+        public DreamBlockDummy() 
             : base(Vector2.Zero, 0, 0, null, false, false) {
             Collidable = Active = Visible = false;
 
             Data = new DynData<DreamBlock>(this);
-        }
-
-        public static DreamBlockDummy Create(Scene scene) {
-            DreamBlockDummy block = scene.Tracker.GetEntity<DreamBlockDummy>();
-            if (block is null)
-                scene.Add(block = new DreamBlockDummy());
-            return block;
-        }
-
-        public DreamBlockDummy Initialize(
-            Func<IEnumerator> activate = null,
-            Func<IEnumerator> fastActivate = null,
-            Action activateNoRoutine = null,
-            Func<IEnumerator> deactivate = null,
-            Func<IEnumerator> fastDeactivate = null,
-            Action deactivateNoRoutine = null,
-            Action setup = null) {
-            OnActivate = activate;
-            OnFastActivate = fastActivate;
-            OnActivateNoRoutine = activateNoRoutine;
-            OnDeactivate = deactivate;
-            OnFastDeactivate = fastDeactivate;
-            OnDeactivateNoRoutine = deactivateNoRoutine;
-            OnSetup = setup;
-            return this;
         }
 
         public override void Added(Scene scene) { }

--- a/src/Entities/Misc/DreamBlockDummy.cs
+++ b/src/Entities/Misc/DreamBlockDummy.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Monocle;
+using MonoMod;
 using MonoMod.Utils;
 using System;
 using System.Collections;
@@ -12,6 +13,8 @@ namespace Celeste.Mod.CommunalHelper.Entities {
     [Tracked] // But also track it on it's own as a utility entity
     public class DreamBlockDummy : DreamBlock {
         public Entity Entity;
+
+        public bool PlayerHasDreamDash => Data.Get<bool>("playerHasDreamDash");
 
         public Func<IEnumerator> OnActivate;
         public Func<IEnumerator> OnFastActivate;
@@ -33,7 +36,15 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             Data = new DynData<DreamBlock>(this);
         }
 
-        public override void Added(Scene scene) { }
+        [MonoModLinkTo("Monocle.Entity", "System.Void Added(Monocle.Scene)")]
+        public void base_Added(Scene scene) {
+            base.Added(scene);
+        }
+
+        public override void Added(Scene scene) {
+            base_Added(scene);
+            Data["playerHasDreamDash"] = SceneAs<Level>().Session.Inventory.DreamDash;
+        }
 
         public override void Update() { }
 
@@ -67,6 +78,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         private static IEnumerator DreamBlock_Activate(On.Celeste.DreamBlock.orig_Activate orig, DreamBlock self) {
             if (self is DreamBlockDummy dummy && dummy.OnActivate != null) {
+                dummy.Data["playerHasDreamDash"] = true;
                 dummy.Entity.Add(new Coroutine(dummy.OnActivate()));
                 return null;
             }
@@ -75,6 +87,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         private static IEnumerator DreamBlock_FastActivate(On.Celeste.DreamBlock.orig_FastActivate orig, DreamBlock self) {
             if (self is DreamBlockDummy dummy && dummy.OnFastActivate != null) {
+                dummy.Data["playerHasDreamDash"] = true;
                 dummy.Entity.Add(new Coroutine(dummy.OnFastActivate()));
                 return null;
             }
@@ -83,6 +96,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         private static void DreamBlock_ActivateNoRoutine(On.Celeste.DreamBlock.orig_ActivateNoRoutine orig, DreamBlock self) {
             if (self is DreamBlockDummy dummy && dummy.OnActivateNoRoutine != null) {
+                dummy.Data["playerHasDreamDash"] = true;
                 dummy.OnActivateNoRoutine();
                 return;
             }
@@ -91,6 +105,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         private static IEnumerator DreamBlock_Deactivate(On.Celeste.DreamBlock.orig_Deactivate orig, DreamBlock self) {
             if (self is DreamBlockDummy dummy && dummy.OnDeactivate != null) {
+                dummy.Data["playerHasDreamDash"] = false;
                 dummy.Entity.Add(new Coroutine(dummy.OnDeactivate()));
                 return null;
             }
@@ -99,6 +114,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         private static IEnumerator DreamBlock_FastDeactivate(On.Celeste.DreamBlock.orig_FastDeactivate orig, DreamBlock self) {
             if (self is DreamBlockDummy dummy && dummy.OnFastDeactivate != null) {
+                dummy.Data["playerHasDreamDash"] = false;
                 dummy.Entity.Add(new Coroutine(dummy.OnFastDeactivate()));
                 return null;
             }
@@ -107,6 +123,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         private static void DreamBlock_DeactivateNoRoutine(On.Celeste.DreamBlock.orig_DeactivateNoRoutine orig, DreamBlock self) {
             if (self is DreamBlockDummy dummy && dummy.OnDeactivateNoRoutine != null) {
+                dummy.Data["playerHasDreamDash"] = false;
                 dummy.OnDeactivateNoRoutine();
                 return;
             }

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -154,6 +154,13 @@ namespace Celeste.Mod.CommunalHelper {
             return false;
         }
 
+        // Sort of the inverse of CollideCheckOutside
+        public static bool CollideCheckOutsideInside(this Entity self, Entity other, Vector2 at) {
+            if (Collide.Check(self, other))
+                return !Collide.Check(self, other, at);
+            return false;
+        }
+
         #endregion
 
         #region WallBoosters

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -278,5 +278,21 @@ namespace Celeste.Mod.CommunalHelper {
 
         #endregion
 
+        public static Vector2 PutInside(this Entity entity, Vector2 pos) {
+            while (pos.X < entity.X) {
+                pos.X += entity.Width;
+            }
+            while (pos.X > entity.X + entity.Width) {
+                pos.X -= entity.Width;
+            }
+            while (pos.Y < entity.Y) {
+                pos.Y += entity.Height;
+            }
+            while (pos.Y > entity.Y + entity.Height) {
+                pos.Y -= entity.Height;
+            }
+            return pos;
+        }
+
     }
 }

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -63,8 +63,11 @@ namespace Celeste.Mod.CommunalHelper {
             return list;
         }
 
-        public static List<MethodInfo> GetOverrides(this MethodInfo method) {
+        public static List<MethodInfo> GetOverrides(this MethodInfo method, bool returnBase) {
             List<MethodInfo> list = new List<MethodInfo>();
+            if (returnBase)
+                list.Add(method);
+
             foreach (Type subType in method.DeclaringType.GetSubClasses()) {
                 MethodInfo overrideMethod = subType.GetMethod(method.Name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly);
                 if (overrideMethod != null && overrideMethod.Attributes.HasFlag(MethodAttributes.Virtual) && overrideMethod.GetBaseDefinition() == method)

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -1,4 +1,5 @@
 ﻿using Celeste.Mod.CommunalHelper.Entities;
+using Celeste.Mod.Helpers;
 using Microsoft.Xna.Framework;
 using Monocle;
 using MonoMod.Utils;
@@ -35,6 +36,42 @@ namespace Celeste.Mod.CommunalHelper {
                 dir.X = Math.Sign(dir.X);
             }
             return dir;
+        }
+
+        private static void PutInside(this Vector2 pos, Rectangle bounds) {
+            while (pos.X < bounds.X) {
+                pos.X += bounds.Width;
+            }
+            while (pos.X > bounds.X + bounds.Width) {
+                pos.X -= bounds.Width;
+            }
+            while (pos.Y < bounds.Y) {
+                pos.Y += bounds.Height;
+            }
+            while (pos.Y > bounds.Y + bounds.Height) {
+                pos.Y -= bounds.Height;
+            }
+        }
+
+        public static List<Type> GetSubClasses(this Type type) {
+            List<Type> list = new List<Type>();
+            foreach (Type type2 in FakeAssembly.GetFakeEntryAssembly().GetTypes()) {
+                if (type != type2 && type.IsAssignableFrom(type2)) {
+                    list.Add(type2);
+                }
+            }
+            return list;
+        }
+
+        public static List<MethodInfo> GetOverrides(this MethodInfo method) {
+            List<MethodInfo> list = new List<MethodInfo>();
+            foreach (Type subType in method.DeclaringType.GetSubClasses()) {
+                MethodInfo overrideMethod = subType.GetMethod(method.Name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly);
+                if (overrideMethod != null && overrideMethod.Attributes.HasFlag(MethodAttributes.Virtual) && overrideMethod.GetBaseDefinition() == method)
+                    list.Add(overrideMethod);
+
+            }
+            return list;
         }
 
         // Dream Tunnel Dash related extension methods located in DreamTunnelDash.cs


### PR DESCRIPTION
Minimal implementation of #1. The linked issue has been updated with a TODO list

A Panel that can be attached to any solid that will allow the player to enter the DreamTunnelDash state upon dashing into it.
Uses a separate Render entity to properly allow overlapping entries

`overrideAllowStaticMovers` is necessary to force them to attach to SolidTiles, which allows the collision interaction to work.

Also adds a `DreamBlockDummy` pseudo-dreamblock for hooking into (De)Activation events.

:information_source: *This branch has been rebased*