### PR TITLE
Cleanup of C# code and project

### DIFF
--- a/CommunalHelper.sln
+++ b/CommunalHelper.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30225.117
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommunalHelper", "src/CommunalHelper.csproj", "{4B823A36-051A-46CB-BB86-041DCAE8EE76}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommunalHelper", "src\CommunalHelper.csproj", "{4B823A36-051A-46CB-BB86-041DCAE8EE76}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{878A86E7-186E-4E82-A606-D1F6DC3C35F9}"
 	ProjectSection(SolutionItems) = preProject
@@ -17,7 +17,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Dialog", "Dialog", "{199E1D
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Graphics", "Graphics", "{B1C8E61E-5437-49A4-A988-234A7B12412A}"
 	ProjectSection(SolutionItems) = preProject
-		Graphics\StationBlockSprites.xml = Graphics\StationBlockSprites.xml
+		Graphics\CommunalHelper\Sprites.xml = Graphics\CommunalHelper\Sprites.xml
 	EndProjectSection
 EndProject
 Global

--- a/src/CommunalHelper.csproj
+++ b/src/CommunalHelper.csproj
@@ -1,4 +1,5 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net452</TargetFrameworks>
     <AssemblyName>CommunalHelper</AssemblyName>
@@ -7,17 +8,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="MonoMod" Version="21.4.2.3" PrivateAssets="all" />
-	<PackageReference Include="MonoMod.RuntimeDetour" Version="21.01.11.01" PrivateAssets="all" ExcludeAssets="runtime">
-	  <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	</PackageReference>
+    <PackageReference Include="MonoMod" Version="21.4.2.3" PrivateAssets="all" />
+    <PackageReference Include="MonoMod.RuntimeDetour" Version="21.01.11.01" PrivateAssets="all" ExcludeAssets="runtime">
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
-	
+
   <ItemGroup>
-	<Reference Include="Celeste" HintPath="..\..\..\Celeste.exe" Private="false" />
-	<Reference Include="MMHOOK_Celeste" HintPath="..\..\..\MMHOOK_Celeste.dll" Private="false" />
-	  <Reference Include="FNA" HintPath="..\..\..\FNA.dll" Private="false" />
-	<Reference Include="YamlDotNet" HintPath="..\..\..\YamlDotNet.dll" Private="false" />
+    <Reference Include="Celeste" HintPath="..\..\..\Celeste.exe" Private="false" />
+    <Reference Include="MMHOOK_Celeste" HintPath="..\..\..\MMHOOK_Celeste.dll" Private="false" />
+    <Reference Include="FNA" HintPath="..\..\..\FNA.dll" Private="false" />
+    <Reference Include="YamlDotNet" HintPath="..\..\..\YamlDotNet.dll" Private="false" />
   </ItemGroup>
   
 </Project>

--- a/src/CommunalHelper.csproj
+++ b/src/CommunalHelper.csproj
@@ -7,18 +7,25 @@
     <LangVersion>9</LangVersion>
   </PropertyGroup>
 
+  <!--Disable "Copy Local" for all references-->
+  <ItemDefinitionGroup>
+    <PackageReference ExcludeAssets="runtime" PrivateAssets="all" />
+    <Reference Private="false" />
+  </ItemDefinitionGroup>
+
   <ItemGroup>
-    <PackageReference Include="MonoMod" Version="21.4.2.3" PrivateAssets="all" />
-    <PackageReference Include="MonoMod.RuntimeDetour" Version="21.01.11.01" PrivateAssets="all" ExcludeAssets="runtime">
+    <PackageReference Include="MonoMod" Version="21.4.2.3" />
+    <PackageReference Include="MonoMod.RuntimeDetour" Version="21.01.11.01">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Celeste" HintPath="..\..\..\Celeste.exe" Private="false" />
-    <Reference Include="MMHOOK_Celeste" HintPath="..\..\..\MMHOOK_Celeste.dll" Private="false" />
-    <Reference Include="FNA" HintPath="..\..\..\FNA.dll" Private="false" />
-    <Reference Include="YamlDotNet" HintPath="..\..\..\YamlDotNet.dll" Private="false" />
+    <Reference Include="Celeste" HintPath="..\..\..\Celeste.exe" />
+    <Reference Include="MMHOOK_Celeste" HintPath="..\..\..\MMHOOK_Celeste.dll" />
+    <Reference Include="FNA" HintPath="..\..\..\FNA.dll" />
+    <Reference Include="YamlDotNet" HintPath="..\..\..\YamlDotNet.dll" />
+    <Reference Include="System.ValueTuple" HintPath="..\..\..\System.ValueTuple.dll" />
   </ItemGroup>
   
 </Project>

--- a/src/CommunalHelper.csproj
+++ b/src/CommunalHelper.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>CommunalHelper</AssemblyName>
     <RootNamespace>Celeste.Mod.CommunalHelper</RootNamespace>
     <LangVersion>9</LangVersion>
+    <CelestePath Condition="'$(CELESTEGAMEPATH)' == ''">..\..\..</CelestePath>
   </PropertyGroup>
 
   <!--Disable "Copy Local" for all references-->
@@ -21,11 +22,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Celeste" HintPath="..\..\..\Celeste.exe" />
-    <Reference Include="MMHOOK_Celeste" HintPath="..\..\..\MMHOOK_Celeste.dll" />
-    <Reference Include="FNA" HintPath="..\..\..\FNA.dll" />
-    <Reference Include="YamlDotNet" HintPath="..\..\..\YamlDotNet.dll" />
-    <Reference Include="System.ValueTuple" HintPath="..\..\..\System.ValueTuple.dll" />
+    <Reference Include="Celeste" HintPath="$(CELESTEGAMEPATH)\Celeste.exe" />
+    <Reference Include="MMHOOK_Celeste" HintPath="$(CELESTEGAMEPATH)\MMHOOK_Celeste.dll" />
+      <Reference Include="FNA" HintPath="$(CELESTEGAMEPATH)\FNA.dll" />
+    <Reference Include="YamlDotNet" HintPath="$(CELESTEGAMEPATH)\YamlDotNet.dll" />
+    <Reference Include="System.ValueTuple" HintPath="$(CELESTEGAMEPATH)\System.ValueTuple.dll" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/CommunalHelperModule.cs
+++ b/src/CommunalHelperModule.cs
@@ -100,7 +100,7 @@ namespace Celeste.Mod.CommunalHelper {
             // Because of `Celeste.Tags.Initialize` of all things
             // We create a static CrystalStaticSpinner which needs to access Tags.TransitionUpdate
             // Which wouldn't be loaded in time for EverestModule.Load
-            TimedTriggerSpikes.Load();
+            TimedTriggerSpikes.LoadDelayed();
 
             // Register CustomCassetteBlock types
             CustomCassetteBlock.Initialize();
@@ -238,6 +238,10 @@ namespace Celeste.Mod.CommunalHelper {
             for (int i = 0; i < b.Length; i++)
                 ret |= ToInt(b[i]) << i;
             return ret;
+        }
+
+        public static float Mod(float x, float m) {
+            return (x % m + m) % m;
         }
 
     }

--- a/src/CommunalHelperModule.cs
+++ b/src/CommunalHelperModule.cs
@@ -1,12 +1,7 @@
 ﻿using Celeste.Mod.CommunalHelper.Entities;
-using Celeste.Mod.Entities;
-using Celeste.Mod.Helpers;
 using Microsoft.Xna.Framework;
 using Monocle;
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 
 namespace Celeste.Mod.CommunalHelper {
@@ -40,7 +35,7 @@ namespace Celeste.Mod.CommunalHelper {
 
             DreamTunnelDash.Load();
             DreamRefill.Load();
-            
+
             DreamBlockDummy.Load();
 
             CustomDreamBlock.Load();

--- a/src/Entities/BoosterStuff/DreamBooster.cs
+++ b/src/Entities/BoosterStuff/DreamBooster.cs
@@ -1,7 +1,6 @@
 ﻿using Celeste.Mod.Entities;
 using Microsoft.Xna.Framework;
 using Monocle;
-using MonoMod.Cil;
 using MonoMod.Utils;
 using System;
 using System.Collections;
@@ -93,10 +92,10 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         };
         public static readonly ParticleType[] DreamParticles = new ParticleType[8];
 
-        public DreamBooster(EntityData data, Vector2 offset) 
+        public DreamBooster(EntityData data, Vector2 offset)
             : this(data.Position + offset, data.Nodes[0] + offset, !data.Bool("hidePath")) { }
 
-        public DreamBooster(Vector2 position, Vector2 node, bool showPath) 
+        public DreamBooster(Vector2 position, Vector2 node, bool showPath)
             : base(position, redBoost: true) {
             Depth = Depths.DreamBlocks;
 
@@ -111,7 +110,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             SetParticleColors(BurstColor, AppearColor);
             SetSoundEvent(
                 showPath ? CustomSFX.game_customBoosters_dreamBooster_dreambooster_enter : CustomSFX.game_customBoosters_dreamBooster_dreambooster_enter_cue,
-                CustomSFX.game_customBoosters_dreamBooster_dreambooster_move, 
+                CustomSFX.game_customBoosters_dreamBooster_dreambooster_move,
                 false);
         }
 
@@ -130,7 +129,8 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         protected override void OnPlayerEnter(Player player) {
             base.OnPlayerEnter(player);
             pathRenderer.RainbowLerp = Calc.Random.Range(0, 8);
-            if (!showPath) Add(new Coroutine(HiddenPathReact()));
+            if (!showPath)
+                Add(new Coroutine(HiddenPathReact()));
         }
 
         private IEnumerator HiddenPathReact() {
@@ -237,7 +237,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
             if (currentBooster is DreamBooster booster) {
                 DynData<Player> playerData = new DynData<Player>(self);
-                self.Speed = ((Vector2)(playerData["gliderBoostDir"] = self.DashDir = booster.Dir)) * 240f;
+                self.Speed = ((Vector2) (playerData["gliderBoostDir"] = self.DashDir = booster.Dir)) * 240f;
                 self.SceneAs<Level>().DirectionalShake(self.DashDir, 0.2f);
                 if (self.DashDir.X != 0f) {
                     self.Facing = (Facings) Math.Sign(self.DashDir.X);

--- a/src/Entities/BoosterStuff/DreamBooster.cs
+++ b/src/Entities/BoosterStuff/DreamBooster.cs
@@ -294,7 +294,6 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         private static void Player_OnCollide(Action<Player, CollisionData> orig, Player self, CollisionData data) {
             if (dreamBoostMove) {
-                DreamBooster booster = self.LastBooster as DreamBooster;
                 if (data.Hit is not DreamBlock block) {
                     EmitDreamBurst(self, data.Hit.Collider);
                     return;

--- a/src/Entities/CassetteStuff/CassetteJumpFixController.cs
+++ b/src/Entities/CassetteStuff/CassetteJumpFixController.cs
@@ -2,7 +2,6 @@
 using Microsoft.Xna.Framework;
 using Monocle;
 using MonoMod.Utils;
-using System;
 
 namespace Celeste.Mod.CommunalHelper.Entities {
     [Tracked]
@@ -46,7 +45,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         private static void CassetteBlock_ShiftSize(On.Celeste.CassetteBlock.orig_ShiftSize orig, CassetteBlock self, int amount) {
             if (MustApply(self.Scene)) {
                 self.MoveV(amount, 0f);
-                var data = new DynData<CassetteBlock>(self);
+                DynData<CassetteBlock> data = new DynData<CassetteBlock>(self);
                 data["blockHeight"] = data.Get<int>("blockHeight") - amount;
             } else
                 orig(self, amount);

--- a/src/Entities/CassetteStuff/CassetteMoveBlock.cs
+++ b/src/Entities/CassetteStuff/CassetteMoveBlock.cs
@@ -7,6 +7,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Directions = Celeste.MoveBlock.Directions;
 
 // TODO
 // movement stuff
@@ -33,7 +34,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         private const float RegenTime = 3f;
 
         private float moveSpeed;
-        public MoveBlock.Directions Direction;
+        public Directions Direction;
         private float homeAngle;
         private Vector2 startPosition;
         public MovementState State = MovementState.Idling;
@@ -61,18 +62,13 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         private ParticleType P_Break;
         private ParticleType P_BreakPressed;
 
-        public CassetteMoveBlock(Vector2 position, EntityID id, int width, int height, MoveBlock.Directions direction, float moveSpeed, int index, float tempo, Color? overrideColor)
+        public CassetteMoveBlock(Vector2 position, EntityID id, int width, int height, Directions direction, float moveSpeed, int index, float tempo, Color? overrideColor)
             : base(position, id, width, height, index, tempo, dynamicHitbox: true, overrideColor) {
             startPosition = position;
             Direction = direction;
             this.moveSpeed = moveSpeed;
 
-            homeAngle = targetAngle = angle = direction switch {
-                MoveBlock.Directions.Left => (float) Math.PI,
-                MoveBlock.Directions.Up => -(float) Math.PI / 2f,
-                MoveBlock.Directions.Down => (float) Math.PI / 2f,
-                _ => 0f
-            };
+            homeAngle = targetAngle = angle = direction.Angle();
 
             Add(moveSfx = new SoundSource());
             Add(new Coroutine(Controller()));
@@ -96,7 +92,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         }
 
         public CassetteMoveBlock(EntityData data, Vector2 offset, EntityID id)
-            : this(data.Position + offset, id, data.Width, data.Height, data.Enum("direction", MoveBlock.Directions.Left), data.Bool("fast") ? FastMoveSpeed : data.Float("moveSpeed", MoveSpeed), data.Int("index"), data.Float("tempo", 1f), data.HexColorNullable("customColor")) {
+            : this(data.Position + offset, id, data.Width, data.Height, data.Enum("direction", Directions.Left), data.Bool("fast") ? FastMoveSpeed : data.Float("moveSpeed", MoveSpeed), data.Int("index"), data.Float("tempo", 1f), data.HexColorNullable("customColor")) {
         }
 
         public override void Awake(Scene scene) {
@@ -138,7 +134,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                     angle = Calc.Approach(angle, targetAngle, SteerSpeed * Engine.DeltaTime);
                     Vector2 move = Calc.AngleToVector(angle, speed) * Engine.DeltaTime;
                     bool hit;
-                    if (Direction is MoveBlock.Directions.Right or MoveBlock.Directions.Left) {
+                    if (Direction is Directions.Right or Directions.Left) {
                         hit = MoveCheck(move.XComp());
                         noSquish = Scene.Tracker.GetEntity<Player>();
                         MoveVCollideSolids(move.Y, thruDashBlocks: false);
@@ -162,7 +158,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                                 ScrapeParticles(-Vector2.UnitX);
                             }
                         }
-                        if (Direction == MoveBlock.Directions.Down && Top > SceneAs<Level>().Bounds.Bottom + 32) {
+                        if (Direction == Directions.Down && Top > SceneAs<Level>().Bounds.Bottom + 32) {
                             hit = true;
                         }
                     }
@@ -386,17 +382,17 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             Vector2 positionRange;
             float num;
             float num2;
-            if (Direction == MoveBlock.Directions.Right) {
+            if (Direction == Directions.Right) {
                 position = CenterLeft + Vector2.UnitX;
                 positionRange = Vector2.UnitY * (Height - 4f);
                 num = (float) Math.PI;
                 num2 = Height / 32f;
-            } else if (Direction == MoveBlock.Directions.Left) {
+            } else if (Direction == Directions.Left) {
                 position = CenterRight;
                 positionRange = Vector2.UnitY * (Height - 4f);
                 num = 0f;
                 num2 = Height / 32f;
-            } else if (Direction == MoveBlock.Directions.Down) {
+            } else if (Direction == Directions.Down) {
                 position = TopCenter + Vector2.UnitY;
                 positionRange = Vector2.UnitX * (Width - 4f);
                 num = -(float) Math.PI / 2f;

--- a/src/Entities/CassetteStuff/CassetteMoveBlock.cs
+++ b/src/Entities/CassetteStuff/CassetteMoveBlock.cs
@@ -5,8 +5,6 @@ using Monocle;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using Directions = Celeste.MoveBlock.Directions;
 
 // TODO

--- a/src/Entities/CassetteStuff/CassetteZipMover.cs
+++ b/src/Entities/CassetteStuff/CassetteZipMover.cs
@@ -77,7 +77,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
             public override void Update() {
                 base.Update();
-                Depth = zipMover.Collidable ? 9000 : 9010;
+                Depth = zipMover.Collidable ? Depths.BGDecals : Depths.BGDecals + 10;
             }
 
             public override void Render() {

--- a/src/Entities/CassetteStuff/ManualCassetteController.cs
+++ b/src/Entities/CassetteStuff/ManualCassetteController.cs
@@ -90,7 +90,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                     level.Tracker.GetEntity<CassetteBlockManager>()?.RemoveSelf();
                     level.Add(new ManualCassetteController(data));
                     // Lists were just updated so there's no harm in doing it again (hopefully)
-                    level.Entities.UpdateLists(); 
+                    level.Entities.UpdateLists();
                 }
                 return level;
             });

--- a/src/Entities/CassetteStuff/ManualCassetteController.cs
+++ b/src/Entities/CassetteStuff/ManualCassetteController.cs
@@ -95,7 +95,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                     level.Tracker.GetEntity<CassetteBlockManager>()?.RemoveSelf();
                     level.Add(new ManualCassetteController(data));
                     // Lists were just updated so there's no harm in doing it again (hopefully)
-                    level.Entities.UpdateLists(); 
+                    level.Entities.UpdateLists();
                 }
                 return level;
             });

--- a/src/Entities/ConnectedStuff/ConnectedMoveBlock.cs
+++ b/src/Entities/ConnectedStuff/ConnectedMoveBlock.cs
@@ -92,12 +92,7 @@ namespace Celeste.Mod.CommunalHelper {
             Direction = direction;
             this.moveSpeed = moveSpeed;
 
-            homeAngle = targetAngle = angle = direction switch {
-                MoveBlock.Directions.Left => (float) Math.PI,
-                MoveBlock.Directions.Up => -(float) Math.PI / 2f,
-                MoveBlock.Directions.Down => (float) Math.PI / 2f,
-                _ => 0f,
-            };
+            homeAngle = targetAngle = angle = direction.Angle();
             Add(moveSfx = new SoundSource());
             Add(new Coroutine(Controller()));
             UpdateColors();

--- a/src/Entities/ConnectedStuff/ConnectedMoveBlock.cs
+++ b/src/Entities/ConnectedStuff/ConnectedMoveBlock.cs
@@ -18,7 +18,7 @@ namespace Celeste.Mod.CommunalHelper {
 
             public Border(ConnectedMoveBlock parent) {
                 Parent = parent;
-                Depth = 1;
+                Depth = Depths.Player + 1;
             }
 
             public override void Update() {
@@ -87,7 +87,7 @@ namespace Celeste.Mod.CommunalHelper {
         public ConnectedMoveBlock(Vector2 position, int width, int height, MoveBlock.Directions direction, float moveSpeed)
             : base(position, width, height, safe: false) {
 
-            Depth = -1;
+            Depth = Depths.Player - 1;
             startPosition = position;
             Direction = direction;
             this.moveSpeed = moveSpeed;

--- a/src/Entities/ConnectedStuff/ConnectedSwapBlock.cs
+++ b/src/Entities/ConnectedStuff/ConnectedSwapBlock.cs
@@ -25,7 +25,7 @@ namespace Celeste.Mod.CommunalHelper {
             public PathRenderer(ConnectedSwapBlock block)
                 : base(block.Position) {
                 this.block = block;
-                Depth = 8999;
+                Depth = Depths.BGDecals - 1;
                 timer = Calc.Random.NextFloat();
             }
 
@@ -149,7 +149,7 @@ namespace Celeste.Mod.CommunalHelper {
             middleRed.Position = middleGreen.Position = new Vector2(width, height) / 2f;
 
             Add(new LightOcclude(0.2f));
-            Depth = -9999;
+            Depth = Depths.FGTerrain + 1;
         }
 
         public ConnectedSwapBlock(EntityData data, Vector2 offset)

--- a/src/Entities/ConnectedStuff/ConnectedZipMover.cs
+++ b/src/Entities/ConnectedStuff/ConnectedZipMover.cs
@@ -308,7 +308,7 @@ namespace Celeste.Mod.CommunalHelper {
             for (int i = 4; i <= h + 4; i += 8) {
                 int num3 = num;
                 for (int j = 4; j <= w + 4; j += 8) {
-                    int index = (int) (mod((num2 + num * percent * (float) Math.PI * 4f) / ((float) Math.PI / 2f), 1f) * count);
+                    int index = (int) (Util.Mod((num2 + num * percent * (float) Math.PI * 4f) / ((float) Math.PI / 2f), 1f) * count);
                     MTexture mTexture = innerCogs[index];
                     Rectangle rectangle = new Rectangle(0, 0, mTexture.Width, mTexture.Height);
                     Vector2 zero = Vector2.Zero;
@@ -484,10 +484,6 @@ namespace Celeste.Mod.CommunalHelper {
                     }
                 }
             }
-        }
-
-        private float mod(float x, float m) {
-            return (x % m + m) % m;
         }
     }
 }

--- a/src/Entities/ConnectedStuff/ConnectedZipMover.cs
+++ b/src/Entities/ConnectedStuff/ConnectedZipMover.cs
@@ -157,7 +157,7 @@ namespace Celeste.Mod.CommunalHelper {
 
         public ConnectedZipMover(Vector2 position, int width, int height, Vector2[] nodes, Themes themes, bool perm, bool waits, bool ticking, string customBlockPath)
             : base(position, width, height, safe: false) {
-            Depth = -9999;
+            Depth = Depths.FGTerrain + 1;
 
             start = Position;
             targets = new Vector2[nodes.Length];

--- a/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntry.cs
+++ b/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntry.cs
@@ -123,7 +123,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                         break;
                     case Spikes.Directions.Left when dir.X > 0:
                     case Spikes.Directions.Right when dir.X < 0:
-                        if (player.Top > Top - 4 || !Scene.CollideCheck<Solid>(TopCenter - Vector2.UnitY) && 
+                        if (player.Top > Top - 4 || !Scene.CollideCheck<Solid>(TopCenter - Vector2.UnitY) &&
                             player.Bottom < Bottom + 4 || !Scene.CollideCheck<Solid>(BottomCenter + Vector2.UnitY))
                             return DashCollisionResults.NormalCollision;
                         break;

--- a/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntry.cs
+++ b/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntry.cs
@@ -460,7 +460,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                 foreach (StaticMover sm in new DynData<Platform>(platform).Get<List<StaticMover>>("staticMovers")) {
                     Vector2 origin = player.Position + new Vector2((float) player.Facing * 3, -4f);
                     if (sm.Entity is DreamTunnelEntry entry
-                        && (entry.Orientation == Spikes.Directions.Left || entry.Orientation == Spikes.Directions.Right)
+                        && (entry.Orientation is Spikes.Directions.Left or Spikes.Directions.Right)
                         && entry.CollidePoint(origin + Vector2.UnitX * (float) player.Facing)) {
                         entry.FootstepRipple(origin);
                     }
@@ -494,7 +494,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             cursor.EmitDelegate<Func<Platform, Player, int, Platform>>((platform, player, dir) => {
                 foreach (StaticMover sm in new DynData<Platform>(platform).Get<List<StaticMover>>("staticMovers")) {
                     if (sm.Entity is DreamTunnelEntry entry
-                        && (entry.Orientation == Spikes.Directions.Left || entry.Orientation == Spikes.Directions.Right)
+                        && (entry.Orientation is Spikes.Directions.Left or Spikes.Directions.Right)
                         && entry.CollidePoint(player.Position - Vector2.UnitX * dir * 4f)) {
                         entry.FootstepRipple(player.Position + new Vector2(0, -4f));
                     }

--- a/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntryRenderer.cs
+++ b/src/Entities/DashStates/DreamTunnelDash/DreamTunnelEntryRenderer.cs
@@ -11,7 +11,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
     [Tracked(false)]
     public class DreamTunnelEntryRenderer : Entity {
 
-        private class CustomDepthRenderer : Entity{
+        private class CustomDepthRenderer : Entity {
             public List<DreamTunnelEntry> list = new List<DreamTunnelEntry>();
 
             public CustomDepthRenderer(int depth) {

--- a/src/Entities/DreamStuff/DreamMoveBlock.cs
+++ b/src/Entities/DreamStuff/DreamMoveBlock.cs
@@ -9,7 +9,6 @@ using MonoMod.RuntimeDetour;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 
 namespace Celeste.Mod.CommunalHelper.Entities {

--- a/src/Entities/DreamStuff/DreamMoveBlock.cs
+++ b/src/Entities/DreamStuff/DreamMoveBlock.cs
@@ -93,12 +93,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             noCollide = data.Bool("noCollide");
 
             Direction = data.Enum<MoveBlock.Directions>("direction");
-            homeAngle = targetAngle = angle = Direction switch {
-                MoveBlock.Directions.Left => (float) Math.PI,
-                MoveBlock.Directions.Up => -(float) Math.PI / 2f,
-                MoveBlock.Directions.Down => (float) Math.PI / 2f,
-                _ => 0f,
-            };
+            homeAngle = targetAngle = angle = Direction.Angle();
 
             arrows = GFX.Game.GetAtlasSubtextures("objects/CommunalHelper/dreamMoveBlock/arrow");
             Add(moveSfx = new SoundSource());

--- a/src/Entities/DreamStuff/DreamSwapBlock.cs
+++ b/src/Entities/DreamStuff/DreamSwapBlock.cs
@@ -15,7 +15,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             public PathRenderer(DreamSwapBlock block)
                 : base(block.Position) {
                 this.block = block;
-                Depth = 8999;
+                Depth = Depths.BGDecals - 1;
                 timer = Calc.Random.NextFloat();
             }
 

--- a/src/Entities/DreamStuff/DreamSwitchGate.cs
+++ b/src/Entities/DreamStuff/DreamSwitchGate.cs
@@ -56,7 +56,7 @@ namespace Celeste.Mod.CommunalHelper {
         }
 
         public DreamSwitchGate(EntityData data, Vector2 offset)
-            : this(data.Position + offset, data, data.Width, data.Height, data.Nodes[0] + offset, data.Bool("oneUse"), data.Bool("featherMode"), GetRefillCount(data), data.Bool("below"), data.Bool("permanent"))  { }
+            : this(data.Position + offset, data, data.Width, data.Height, data.Nodes[0] + offset, data.Bool("oneUse"), data.Bool("featherMode"), GetRefillCount(data), data.Bool("below"), data.Bool("permanent")) { }
 
         public DreamSwitchGate(Vector2 position, EntityData data, int width, int height, Vector2 node, bool oneUse, bool featherMode, int refillCount, bool below, bool permanent)
             : base(position, width, height, featherMode, oneUse, refillCount, below) {
@@ -107,8 +107,8 @@ namespace Celeste.Mod.CommunalHelper {
         public override void Awake(Scene scene) {
             base.Awake(scene);
 
-            bool check = isFlagSwitchGate ? 
-                (SceneAs<Level>().Session.GetFlag(Flag + "_gate" + ID) && !allowReturn) || SceneAs<Level>().Session.GetFlag(Flag) : 
+            bool check = isFlagSwitchGate ?
+                (SceneAs<Level>().Session.GetFlag(Flag + "_gate" + ID) && !allowReturn) || SceneAs<Level>().Session.GetFlag(Flag) :
                 Switch.CheckLevelFlag(SceneAs<Level>());
 
             if (check) {

--- a/src/Entities/DreamStuff/DreamZipMover.cs
+++ b/src/Entities/DreamStuff/DreamZipMover.cs
@@ -406,9 +406,9 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                     Color lightColor = ropeLightColor;
                     if (dreamAesthetic) {
                         if (playerHasDreamDash)
-                            lightColor = activeDreamColors[(int) mod((float) Math.Round((lengthProgress - shiftProgress) / 4f), 9f)];
+                            lightColor = activeDreamColors[(int) Util.Mod((float) Math.Round((lengthProgress - shiftProgress) / 4f), 9f)];
                         else
-                            lightColor = disabledDreamColors[(int) mod((float) Math.Round((lengthProgress - shiftProgress) / 4f), 4f)];
+                            lightColor = disabledDreamColors[(int) Util.Mod((float) Math.Round((lengthProgress - shiftProgress) / 4f), 4f)];
                     }
                     lightColor = Color.Lerp(lightColor, colorLerpTarget, colorLerp);
                     Draw.Line(value3 + offset, value3 + travelDir * 2f + offset, colorOverride ?? lightColor);
@@ -423,9 +423,6 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                     cogWhite.DrawCentered(to + offset, tempColor, 1f, rotation);
                 }
             }
-
-            private float mod(float x, float m) =>
-                (x % m + m) % m;
         }
 
     }

--- a/src/Entities/DreamStuff/DreamZipMover.cs
+++ b/src/Entities/DreamStuff/DreamZipMover.cs
@@ -393,7 +393,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                 float rotation = -DreamZipMover.percent * (float) Math.PI * 2f;
 
                 Color dreamRopeColor = playerHasDreamDash ? colorLerpTarget : DreamZipMover.DisabledLineColor;
-                Color color = Color.Lerp(dreamAesthetic ?  dreamRopeColor : ropeColor, colorLerpTarget, colorLerp);
+                Color color = Color.Lerp(dreamAesthetic ? dreamRopeColor : ropeColor, colorLerpTarget, colorLerp);
 
                 Draw.Line(from + hOffset1 + offset, to + hOffset1 + offset, colorOverride ?? color);
                 Draw.Line(from + hOffset2 + offset, to + hOffset2 + offset, colorOverride ?? color);

--- a/src/Entities/HeartGemStuff/CSGEN_HeartGemShards.cs
+++ b/src/Entities/HeartGemStuff/CSGEN_HeartGemShards.cs
@@ -42,7 +42,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                 piece.OnAllCollected();
             }
 
-            heart.Depth = -2000002;
+            heart.Depth = Depths.FormationSequences - 2;
             heart.AddTag(Tags.FrozenUpdate);
             yield return 0.35f;
 

--- a/src/Entities/HeartGemStuff/HeartGemShard.cs
+++ b/src/Entities/HeartGemStuff/HeartGemShard.cs
@@ -138,7 +138,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         public void OnAllCollected() {
             Tag = Tags.FrozenUpdate;
-            Depth = -2000002;
+            Depth = Depths.FormationSequences - 2;
             merging = true;
         }
 

--- a/src/Entities/HeartGemStuff/SummitGemManager.cs
+++ b/src/Entities/HeartGemStuff/SummitGemManager.cs
@@ -192,7 +192,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             public Color ParticleColor;
             public Vector2 Shake;
             public Sprite Sprite;
-            public Image Bg;
+            //public Image Bg; // Unused in favour of providing decals
             public BloomPoint Bloom;
 
             public Gem(string id, Vector2 position)

--- a/src/Entities/HeartGemStuff/SummitGemManager.cs
+++ b/src/Entities/HeartGemStuff/SummitGemManager.cs
@@ -30,7 +30,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         public CustomSummitGemManager(EntityData data, Vector2 offset)
             : base(data.Position + offset) {
-            Depth = -10010;
+            Depth = Depths.FGTerrain - 10;
 
             // Hopefully this always works
             string mapId = AreaData.Get((Engine.Scene as Level)?.Session ?? (Engine.Scene as LevelLoader).Level.Session).SID;
@@ -199,7 +199,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                 : base(position) {
                 ID = id;
                 Index = Calc.Clamp(int.Parse(id.Substring(id.LastIndexOf('/') + 1)), 0, 7);
-                Depth = -10010;
+                Depth = Depths.FGTerrain - 10;
 
                 // Will probably be implemented as Decals
                 //Add(Bg = new Image(GFX.Game["collectables/summitgems/" + id + "/bg"]));

--- a/src/Entities/Misc/DreamBlockDummy.cs
+++ b/src/Entities/Misc/DreamBlockDummy.cs
@@ -28,7 +28,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         public DynData<DreamBlock> Data;
 
-        public DreamBlockDummy(Entity entity) 
+        public DreamBlockDummy(Entity entity)
             : base(Vector2.Zero, 0, 0, null, false, false) {
             Collidable = Active = Visible = false;
             Entity = entity;

--- a/src/Entities/Misc/Melvin.cs
+++ b/src/Entities/Misc/Melvin.cs
@@ -512,11 +512,11 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             base.MoveHExact(move);
             SetSeekerBarriersCollidable(before);
         }
-        
+
         // returns collidable field before calling this function
         private bool SetSeekerBarriersCollidable(bool collidable) {
             bool before = !collidable;
-            foreach(SeekerBarrier entity in Scene.Tracker.GetEntities<SeekerBarrier>()) {
+            foreach (SeekerBarrier entity in Scene.Tracker.GetEntities<SeekerBarrier>()) {
                 before = entity.Collidable;
                 entity.Collidable = collidable;
             }

--- a/src/Entities/Misc/Melvin.cs
+++ b/src/Entities/Misc/Melvin.cs
@@ -4,7 +4,7 @@ using Monocle;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using static Celeste.Mod.CommunalHelper.Entities.StationBlock;
+using ArrowDir = Celeste.Mod.CommunalHelper.Entities.StationBlock.ArrowDir;
 
 namespace Celeste.Mod.CommunalHelper.Entities {
 
@@ -90,6 +90,8 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             Add(new LightOcclude(0.2f));
             Add(returnLoopSfx = new SoundSource());
             Add(attackCoroutine = new Coroutine(false));
+
+            Add(new WaterInteraction(new Rectangle(0, 0, width, height), () => crushDir != Vector2.Zero));
         }
 
         public override void Awake(Scene scene) {

--- a/src/Entities/Misc/MoveBlockRedirect.cs
+++ b/src/Entities/Misc/MoveBlockRedirect.cs
@@ -1,5 +1,4 @@
 ﻿using Celeste.Mod.Entities;
-using FMOD.Studio;
 using Microsoft.Xna.Framework;
 using Mono.Cecil.Cil;
 using Monocle;
@@ -141,7 +140,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         private void UpdateAppearance() {
             Color currentColor = Color.Lerp(startColor, UsedColor, maskAlpha) * alpha;
             icon.Sprite.Color = currentColor;
-            foreach(Image image in borders) {
+            foreach (Image image in borders) {
                 image.Color = currentColor * alpha;
             }
         }

--- a/src/Entities/Misc/MoveBlockRedirectable.cs
+++ b/src/Entities/Misc/MoveBlockRedirectable.cs
@@ -136,7 +136,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             } else {
                 t_Controller = f_Controller_this.DeclaringType;
             }
-            
+
             return orig => {
                 IEnumerator controller;
                 orig.Replace(controller = (IEnumerator) Activator.CreateInstance(t_Controller, 3));

--- a/src/Entities/Misc/MoveBlockRedirectable.cs
+++ b/src/Entities/Misc/MoveBlockRedirectable.cs
@@ -8,6 +8,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Directions = Celeste.MoveBlock.Directions;
 
 namespace Celeste.Mod.CommunalHelper.Entities {
     /// <summary>
@@ -58,10 +59,10 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             }
         }
 
-        public Func<MoveBlock.Directions>? Get_Direction = null;
-        public Action<MoveBlock.Directions>? Set_Direction = null;
-        public MoveBlock.Directions Direction {
-            get => Get_Direction?.Invoke() ?? Data.Get<MoveBlock.Directions>("direction");
+        public Func<Directions>? Get_Direction = null;
+        public Action<Directions>? Set_Direction = null;
+        public Directions Direction {
+            get => Get_Direction?.Invoke() ?? Data.Get<Directions>("direction");
             set {
                 if (Set_Direction != null)
                     Set_Direction.Invoke(value);
@@ -109,7 +110,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         }
 
         public float? InitialAngle;
-        public MoveBlock.Directions? InitialDirection;
+        public Directions? InitialDirection;
 
         public Action<float>? OnStartShaking;
         public Action<Vector2>? OnMoveTo;
@@ -173,7 +174,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             On.Celeste.MoveBlock.ctor_Vector2_int_int_Directions_bool_bool -= MoveBlock_ctor_Vector2_int_int_Directions_bool_bool;
         }
 
-        private static void MoveBlock_ctor_Vector2_int_int_Directions_bool_bool(On.Celeste.MoveBlock.orig_ctor_Vector2_int_int_Directions_bool_bool orig, MoveBlock self, Vector2 position, int width, int height, MoveBlock.Directions direction, bool canSteer, bool fast) {
+        private static void MoveBlock_ctor_Vector2_int_int_Directions_bool_bool(On.Celeste.MoveBlock.orig_ctor_Vector2_int_int_Directions_bool_bool orig, MoveBlock self, Vector2 position, int width, int height, Directions direction, bool canSteer, bool fast) {
             orig(self, position, width, height, direction, canSteer, fast);
             if (self.GetType() == typeof(MoveBlock))
                 self.Add(new MoveBlockRedirectable(new DynamicData(typeof(MoveBlock), self)));

--- a/src/Entities/Misc/MoveSwapBlock.cs
+++ b/src/Entities/Misc/MoveSwapBlock.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
+using Directions = Celeste.MoveBlock.Directions;
 
 namespace Celeste.Mod.CommunalHelper.Entities {
     [TrackedAs(typeof(SwapBlock))]
@@ -61,7 +62,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         public bool Triggered { get; set; }
 
         public MovementState State { get; protected set; }
-        public MoveBlock.Directions MoveDirection { get; protected set; }
+        public Directions MoveDirection { get; protected set; }
 
         private bool canSteer;
 
@@ -143,37 +144,21 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
             canSteer = data.Bool("canSteer", false);
             moveAcceleration = data.Float("moveAcceleration", Accel);
-            MoveDirection = data.Enum("direction", MoveBlock.Directions.Left);
-            switch (MoveDirection) {
-                default:
-                    homeAngle = (targetAngle = (angle = 0f));
-                    angleSteerSign = 1;
-                    break;
-                case MoveBlock.Directions.Left:
-                    homeAngle = (targetAngle = (angle = (float) Math.PI));
-                    angleSteerSign = -1;
-                    break;
-                case MoveBlock.Directions.Up:
-                    homeAngle = (targetAngle = (angle = -(float) Math.PI / 2f));
-                    angleSteerSign = 1;
-                    break;
-                case MoveBlock.Directions.Down:
-                    homeAngle = (targetAngle = (angle = (float) Math.PI / 2f));
-                    angleSteerSign = -1;
-                    break;
-            }
+            MoveDirection = data.Enum("direction", Directions.Left);
+            homeAngle = targetAngle = angle = MoveDirection.Angle();
+            angleSteerSign = angle > 0f ? -1 : 1;
 
             int tilesX = (int) Width / 8;
             int tilesY = (int) Height / 8;
             MTexture buttonTexture = GFX.Game["objects/moveBlock/button"];
             MTexture buttonPressedTexture = GFX.Game["objects/CommunalHelper/moveSwapBlock/buttonPressed"];
-            if (canSteer && (MoveDirection == MoveBlock.Directions.Left || MoveDirection == MoveBlock.Directions.Right)) {
+            if (canSteer && (MoveDirection == Directions.Left || MoveDirection == Directions.Right)) {
                 for (int x = 0; x < tilesX; x++) {
                     int offsetX = (x != 0) ? ((x < tilesX - 1) ? 1 : 2) : 0;
                     AddImage(buttonTexture.GetSubtexture(offsetX * 8, 0, 8, 8), new Vector2(x * 8, -4f), 0f, new Vector2(1f, 1f), topButton);
                     AddImage(buttonPressedTexture.GetSubtexture(offsetX * 8, 0, 8, 8), new Vector2(x * 8, -4f), 0f, new Vector2(1f, 1f), topButton);
                 }
-            } else if (canSteer && (MoveDirection == MoveBlock.Directions.Up || MoveDirection == MoveBlock.Directions.Down)) {
+            } else if (canSteer && (MoveDirection == Directions.Up || MoveDirection == Directions.Down)) {
                 for (int y = 0; y < tilesY; y++) {
                     int offsetY = (y != 0) ? ((y < tilesY - 1) ? 1 : 2) : 0;
                     AddImage(buttonTexture.GetSubtexture(offsetY * 8, 0, 8, 8), new Vector2(-4f, y * 8), (float) Math.PI / 2f, new Vector2(1f, -1f), leftButton);
@@ -312,13 +297,13 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                     if (!Swapping || !freezeOnSwap) {
                         if (canSteer) {
                             targetAngle = homeAngle;
-                            bool hasPlayer = (MoveDirection is not MoveBlock.Directions.Right and not 0) ? HasPlayerClimbing() : HasPlayerOnTop();
+                            bool hasPlayer = (MoveDirection is not Directions.Right and not Directions.Left) ? HasPlayerClimbing() : HasPlayerOnTop();
                             if (hasPlayer && noSteerTimer > 0f) {
                                 noSteerTimer -= Engine.DeltaTime;
                             }
                             if (hasPlayer) {
                                 if (noSteerTimer <= 0f) {
-                                    if (MoveDirection is MoveBlock.Directions.Right or MoveBlock.Directions.Left) {
+                                    if (MoveDirection is Directions.Right or Directions.Left) {
                                         targetAngle = homeAngle + MaxAngle * angleSteerSign * Input.MoveY.Value;
                                     } else {
                                         targetAngle = homeAngle + MaxAngle * angleSteerSign * Input.MoveX.Value;
@@ -339,7 +324,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                         Vector2 vector = Calc.AngleToVector(angle, moveSpeed) * Engine.DeltaTime;
                         bool shouldBreak;
                         moveSwapPoints = true; // Tells MoveExact to move start and end points too
-                        if (MoveDirection is MoveBlock.Directions.Right or MoveBlock.Directions.Left) {
+                        if (MoveDirection is Directions.Right or Directions.Left) {
                             shouldBreak = MoveCheck(vector.XComp());
 
                             noSquish = Scene.Tracker.GetEntity<Player>();
@@ -367,7 +352,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                                     ScrapeParticles(-Vector2.UnitX);
                                 }
                             }
-                            if (MoveDirection == MoveBlock.Directions.Down && Top > SceneAs<Level>().Bounds.Bottom + 32) {
+                            if (MoveDirection == Directions.Down && Top > SceneAs<Level>().Bounds.Bottom + 32) {
                                 shouldBreak = true;
                             }
                         }
@@ -536,7 +521,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         }
 
         private void ActivateParticles() {
-            bool vertical = MoveDirection is MoveBlock.Directions.Down or MoveBlock.Directions.Up;
+            bool vertical = MoveDirection is Directions.Down or Directions.Up;
             bool left = (!canSteer || !vertical) && !CollideCheck<Player>(Position - Vector2.UnitX);
             bool right = (!canSteer || !vertical) && !CollideCheck<Player>(Position + Vector2.UnitX);
             bool top = (!canSteer | vertical) && !CollideCheck<Player>(Position - Vector2.UnitY);
@@ -567,17 +552,17 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             Vector2 positionRange;
             float angle;
             float particleNum;
-            if (MoveDirection == MoveBlock.Directions.Right) {
+            if (MoveDirection == Directions.Right) {
                 position = CenterLeft + Vector2.UnitX;
                 positionRange = Vector2.UnitY * (Height - 4f);
                 angle = (float) Math.PI;
                 particleNum = Height / 32f;
-            } else if (MoveDirection == MoveBlock.Directions.Left) {
+            } else if (MoveDirection == Directions.Left) {
                 position = CenterRight;
                 positionRange = Vector2.UnitY * (Height - 4f);
                 angle = 0f;
                 particleNum = Height / 32f;
-            } else if (MoveDirection == MoveBlock.Directions.Down) {
+            } else if (MoveDirection == Directions.Down) {
                 position = TopCenter + Vector2.UnitY;
                 positionRange = Vector2.UnitX * (Width - 4f);
                 angle = -(float) Math.PI / 2f;
@@ -737,9 +722,9 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
             if (self is MoveSwapBlock block) {
                 if (block.canSteer) {
-                    bool playerLeft = (block.MoveDirection == MoveBlock.Directions.Up || block.MoveDirection == MoveBlock.Directions.Down) && block.CollideCheck<Player>(block.Position + new Vector2(-1f, 0f));
-                    bool playerRight = (block.MoveDirection == MoveBlock.Directions.Up || block.MoveDirection == MoveBlock.Directions.Down) && block.CollideCheck<Player>(block.Position + new Vector2(1f, 0f));
-                    bool playerTop = (block.MoveDirection == MoveBlock.Directions.Left || block.MoveDirection == MoveBlock.Directions.Right) && block.CollideCheck<Player>(block.Position + new Vector2(0f, -1f));
+                    bool playerLeft = (block.MoveDirection == Directions.Up || block.MoveDirection == Directions.Down) && block.CollideCheck<Player>(block.Position + new Vector2(-1f, 0f));
+                    bool playerRight = (block.MoveDirection == Directions.Up || block.MoveDirection == Directions.Down) && block.CollideCheck<Player>(block.Position + new Vector2(1f, 0f));
+                    bool playerTop = (block.MoveDirection == Directions.Left || block.MoveDirection == Directions.Right) && block.CollideCheck<Player>(block.Position + new Vector2(0f, -1f));
 
                     if ((playerLeft && !block.leftPressed) || (playerTop && !block.topPressed) || (playerRight && !block.rightPressed)) {
                         Audio.Play(SFX.game_04_arrowblock_side_depress, block.Position);

--- a/src/Entities/Misc/PlayerBubbleRegion.cs
+++ b/src/Entities/Misc/PlayerBubbleRegion.cs
@@ -25,7 +25,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         private void OnPlayer(Player player) {
             if (!player.Dead && player.StateMachine.State != Player.StCassetteFly) {
-                Audio.Play("event:/game/general/cassette_bubblereturn", SceneAs<Level>().Camera.Position + new Vector2(160f, 90f));
+                Audio.Play(SFX.game_gen_cassette_bubblereturn, SceneAs<Level>().Camera.Position + new Vector2(160f, 90f));
                 player.StartCassetteFly(end, control);
             }
         }

--- a/src/Entities/Misc/PlayerBubbleRegion.cs
+++ b/src/Entities/Misc/PlayerBubbleRegion.cs
@@ -1,7 +1,6 @@
 ﻿using Celeste.Mod.Entities;
 using Microsoft.Xna.Framework;
 using Monocle;
-using System;
 
 namespace Celeste.Mod.CommunalHelper.Entities {
     [CustomEntity("CommunalHelper/PlayerBubbleRegion")]
@@ -9,7 +8,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         private Vector2 control, end;
 
-        public PlayerBubbleRegion(EntityData data, Vector2 offset) 
+        public PlayerBubbleRegion(EntityData data, Vector2 offset)
             : this(data.Position + offset, data.Width, data.Height, data.NodesOffset(offset)) { }
 
         public PlayerBubbleRegion(Vector2 position, int width, int height, Vector2[] nodes)

--- a/src/Entities/Misc/ShieldedRefill.cs
+++ b/src/Entities/Misc/ShieldedRefill.cs
@@ -172,7 +172,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             if (!oneUse) {
                 outline.Visible = true;
             }
-            Depth = 8999;
+            Depth = Depths.BGDecals * 1;
             yield return 0.05f;
 
             float num = player.Speed.Angle();

--- a/src/Entities/Misc/SyncedZipMoverActivationController.cs
+++ b/src/Entities/Misc/SyncedZipMoverActivationController.cs
@@ -1,7 +1,6 @@
 ﻿using Celeste.Mod.Entities;
 using Microsoft.Xna.Framework;
 using Monocle;
-using MonoMod.Utils;
 
 namespace Celeste.Mod.CommunalHelper.Entities {
     [CustomEntity("CommunalHelper/SyncedZipMoverActivationController")]

--- a/src/Entities/Misc/TimedTriggerSpikes.cs
+++ b/src/Entities/Misc/TimedTriggerSpikes.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using Directions = Celeste.Spikes.Directions;
 
 namespace Celeste.Mod.CommunalHelper.Entities {
 
@@ -19,12 +20,6 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         "CommunalHelper/TimedTriggerSpikesRight = LoadRight"
     })]
     public class TimedTriggerSpikes : Entity {
-        public enum Directions {
-            Up,
-            Down,
-            Left,
-            Right
-        }
 
         protected struct SpikeInfo {
             public TimedTriggerSpikes Parent;
@@ -366,7 +361,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         private static IDetour hook_TimedTriggerSpikes_GetHue;
 
-        internal static void Load() {
+        internal static void LoadDelayed() {
             hook_TimedTriggerSpikes_GetHue = new ILHook(
                 typeof(TimedTriggerSpikes).GetMethod("GetHue"),
                 TimedTriggerSpikes_GetHue);

--- a/src/Entities/Panels/AbstractPanel.cs
+++ b/src/Entities/Panels/AbstractPanel.cs
@@ -49,10 +49,8 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             this.overrideAllowStaticMovers = overrideAllowStaticMovers;
 
             Collider = orientation switch {
-                Directions.Up => new Hitbox(size, 8f),
-                Directions.Down => new Hitbox(size, 8f),
-                Directions.Left => new Hitbox(8f, size),
-                Directions.Right => new Hitbox(8f, size),
+                Directions.Up or Directions.Down => new Hitbox(size, 8f),
+                Directions.Left or Directions.Right => new Hitbox(8f, size),
                 _ => null
             };
 

--- a/src/Entities/Panels/SurfaceSoundPanel.cs
+++ b/src/Entities/Panels/SurfaceSoundPanel.cs
@@ -15,7 +15,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         #endregion
 
-        public SurfaceSoundPanel(Vector2 position, float size, Spikes.Directions orientation, int soundIndex) 
+        public SurfaceSoundPanel(Vector2 position, float size, Spikes.Directions orientation, int soundIndex)
             : base(position, size, orientation, false) {
             surfaceSoundIndex = soundIndex;
         }

--- a/src/Entities/StationBlock/StationBlock.cs
+++ b/src/Entities/StationBlock/StationBlock.cs
@@ -59,7 +59,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         public StationBlock(EntityData data, Vector2 offset)
             : base(data.Position + offset, data.Width, data.Height, safe: true) {
-            Depth = -9999;
+            Depth = Depths.FGTerrain + 1;
             Add(new LightOcclude());
 
             this.offset = new Vector2(Width, Height) / 2f;

--- a/src/Entities/StationBlock/StationBlockTrack.cs
+++ b/src/Entities/StationBlock/StationBlockTrack.cs
@@ -327,7 +327,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
             int trackpercent = (int) (trackStatePercent * (length + 2));
 
-            for (int i = (int) mod(trackConstantLooping ? Scene.TimeActive * 14 : trackOffset, 8) + trackpercent; i <= length; i += 8) {
+            for (int i = (int) Util.Mod(trackConstantLooping ? Scene.TimeActive * 14 : trackOffset, 8) + trackpercent; i <= length; i += 8) {
                 trackSprite.Draw(Position + new Vector2(horizontal ? i : 0, horizontal ? 0 : i));
             }
 
@@ -338,10 +338,6 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             SceneAs<Level>().ParticlesBG.Emit(p, position - sparkAdd + Calc.Random.Range(-Vector2.One, Vector2.One), sparkDirFromB);
             SceneAs<Level>().ParticlesBG.Emit(p, position + sparkAdd + Calc.Random.Range(-Vector2.One, Vector2.One), sparkDirToA);
             SceneAs<Level>().ParticlesBG.Emit(p, position - sparkAdd + Calc.Random.Range(-Vector2.One, Vector2.One), sparkDirToB);
-        }
-
-        private static float mod(float x, float m) {
-            return (x % m + m) % m;
         }
 
         public static void SwitchTracks(Scene scene, TrackSwitchState state) {

--- a/src/Entities/StationBlock/TrackSwitchBox.cs
+++ b/src/Entities/StationBlock/TrackSwitchBox.cs
@@ -214,7 +214,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             Draw.Rect(rect, Color.Lerp(OnColor, OffColor, colorLerp));
 
             for (int i = rect.Y; (float) i < rect.Bottom; i += 2) {
-                float scale = 0.05f + (1f + (float) Math.Sin((float) i / 16f + Scene.TimeActive * 2f)) / 2f * 0.2f;
+                float scale = 0.05f + (1f + (float) Math.Sin(i / 16f + Scene.TimeActive * 2f)) / 2f * 0.2f;
                 Draw.Line(rect.X, i, rect.X + rect.Width, i, Color.White * 0.55f * scale);
             }
 

--- a/src/Entities/StationBlock/TrackSwitchBox.cs
+++ b/src/Entities/StationBlock/TrackSwitchBox.cs
@@ -50,7 +50,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
             this.global = global;
 
-            SurfaceSoundIndex = 9;
+            SurfaceSoundIndex = SurfaceIndex.ZipMover;
             start = Position;
             sprite = CommunalHelperModule.SpriteBank.Create("trackSwitchBox");
             sprite.Position = new Vector2(Width, Height) / 2f;

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -48,7 +48,7 @@ namespace Celeste.Mod.CommunalHelper {
             return dir;
         }
 
-        private static void PutInside(this Vector2 pos, Rectangle bounds) {
+        public static void PutInside(this Vector2 pos, Rectangle bounds) {
             while (pos.X < bounds.X) {
                 pos.X += bounds.Width;
             }
@@ -217,6 +217,8 @@ namespace Celeste.Mod.CommunalHelper {
             holdable.Release(vector);
         }
 
+        #region EnumExtensions
+
         public static StationBlockTrack.TrackSwitchState Invert(this StationBlockTrack.TrackSwitchState state) {
             return state switch {
                 StationBlockTrack.TrackSwitchState.On => StationBlockTrack.TrackSwitchState.Off,
@@ -224,6 +226,55 @@ namespace Celeste.Mod.CommunalHelper {
                 _ => throw new NotImplementedException(),
             };
         }
+
+        /// <summary>
+        /// Returns the angle corresponding to the appropriate <see cref="MoveBlock.Directions"/> as defined in the <see cref="MoveBlock"/> constructor.
+        /// </summary>
+        /// <param name="dir"></param>
+        /// <returns>Angle in Radians</returns>
+        public static float Angle(this MoveBlock.Directions dir) {
+            return dir switch {
+                MoveBlock.Directions.Left => (float) Math.PI,
+                MoveBlock.Directions.Up => -(float) Math.PI / 2f,
+                MoveBlock.Directions.Down => (float) Math.PI / 2f,
+                _ => 0f
+            };
+        }
+
+        /// <summary>
+        /// Returns the <see cref="Vector2"/> corresponding to the <see cref="MoveBlock.Directions"/>. Defaults to <see cref="Vector2.UnitX"/>.
+        /// </summary>
+        /// <param name="dir"></param>
+        /// <param name="factor">Factor to multiply the resulting vector by.</param>
+        /// <returns></returns>
+        public static Vector2 Vector(this MoveBlock.Directions dir, float factor = 1f) {
+            Vector2 result = dir switch {
+                MoveBlock.Directions.Up => -Vector2.UnitY,
+                MoveBlock.Directions.Down => Vector2.UnitY,
+                MoveBlock.Directions.Left => -Vector2.UnitX,
+                _ => Vector2.UnitX
+            };
+
+            return result * factor;
+        }
+
+        /// <summary>
+        /// Perform the specified <see cref="MoveBlockRedirect.Operations"/> on a <paramref name="value"/> with the second argument of <paramref name="modifier"/>. Defaults to no-op.
+        /// </summary>
+        /// <param name="op"></param>
+        /// <param name="value"></param>
+        /// <param name="modifier"></param>
+        /// <returns></returns>
+        public static float ApplyTo(this MoveBlockRedirect.Operations op, float value, float modifier) {
+            return op switch {
+                MoveBlockRedirect.Operations.Add => value + modifier,
+                MoveBlockRedirect.Operations.Subtract => value - modifier,
+                MoveBlockRedirect.Operations.Multiply => value * modifier,
+                _ => value
+            };
+        }
+
+        #endregion
 
         private static MethodInfo m_TagLists_EntityAdded = typeof(TagLists).GetMethod("EntityAdded", BindingFlags.NonPublic | BindingFlags.Instance);
         private static MethodInfo m_Tracker_EntityAdded = typeof(Tracker).GetMethod("EntityAdded", BindingFlags.NonPublic | BindingFlags.Instance);


### PR DESCRIPTION
Some manual and automated cleanup of C# code.

Also adds an optional environment variable, `CELESTEGAMEPATH`, that can be set to specify the path for assembly references provided by Celeste/Everest.