### PR TITLE
Auto-Format and clean up Ahorn plugins

### DIFF
--- a/Ahorn/.JuliaFormatter.toml
+++ b/Ahorn/.JuliaFormatter.toml
@@ -1,0 +1,9 @@
+style = "default"
+indent = 4
+always_for_in = true
+remove_extra_newlines = true
+whitespace_in_kwargs = false
+align_struct_field = true
+align_conditional = true
+align_assignment = true
+align_pair_arrow = true

--- a/Ahorn/entities/AttachedWallBooster.jl
+++ b/Ahorn/entities/AttachedWallBooster.jl
@@ -1,27 +1,31 @@
 module CommunalHelperAttachedWallBooster
+
 using ..Ahorn, Maple
 
 @mapdef Entity "CommunalHelper/AttachedWallBooster" AttachedWallBooster(
-                        x::Integer, y::Integer,
-                        width::Integer = 8, height::Integer = 8,
-                        left::Bool = false, notCoreMode::Bool = false)
+    x::Integer,
+    y::Integer,
+    width::Integer=8,
+    height::Integer=8,
+    left::Bool=false,
+    notCoreMode::Bool=false,
+)
 
-                        
 const placements = Ahorn.PlacementDict(
     "Attached Wall Booster (Right) (Communal Helper)" => Ahorn.EntityPlacement(
         AttachedWallBooster,
         "rectangle",
-        Dict{String, Any}(
-            "left" => true
-        )
+        Dict{String,Any}(
+            "left" => true,
+        ),
     ),
     "Attached Wall Booster (Left) (Communal Helper)" => Ahorn.EntityPlacement(
         AttachedWallBooster,
         "rectangle",
-        Dict{String, Any}(
-            "left" => false
-        )
-    )
+        Dict{String,Any}(
+            "left" => false,
+        ),
+    ),
 )
 
 Ahorn.minimumSize(entity::AttachedWallBooster) = 8, 8
@@ -37,15 +41,11 @@ end
 function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::AttachedWallBooster)
     left = get(entity.data, "left", false)
 
-    # Values need to be system specific integer
-    x = Int(get(entity.data, "x", 0))
-    y = Int(get(entity.data, "y", 0))
-
     height = Int(get(entity.data, "height", 8))
     tileHeight = div(height, 8)
 
     if left
-        for i in 2:tileHeight - 1
+        for i in 2:tileHeight-1
             Ahorn.drawImage(ctx, "objects/wallBooster/fireMid00", 0, (i - 1) * 8)
         end
 
@@ -56,7 +56,7 @@ function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::AttachedWallBooster
         Ahorn.Cairo.save(ctx)
         Ahorn.scale(ctx, -1, 1)
 
-        for i in 2:tileHeight - 1
+        for i in 2:tileHeight-1
             Ahorn.drawImage(ctx, "objects/wallBooster/fireMid00", -8, (i - 1) * 8)
         end
 

--- a/Ahorn/entities/DreamRefill.jl
+++ b/Ahorn/entities/DreamRefill.jl
@@ -2,13 +2,17 @@ module CommunalHelperDreamRefill
 
 using ..Ahorn, Maple
 
-@mapdef Entity "CommunalHelper/DreamRefill" DreamRefill(x::Integer, y::Integer, oneUse::Bool=false, respawnTime::Number=2.5)
+@mapdef Entity "CommunalHelper/DreamRefill" DreamRefill(
+    x::Integer,
+    y::Integer,
+    oneUse::Bool=false,
+    respawnTime::Number=2.5,
+)
 
 const placements = Ahorn.PlacementDict(
     "Dream Refill (Communal Helper)" => Ahorn.EntityPlacement(
         DreamRefill,
-        "point"
-    )
+    ),
 )
 
 const sprite = "objects/CommunalHelper/dreamRefill/idle02"

--- a/Ahorn/entities/HeartGemShards.jl
+++ b/Ahorn/entities/HeartGemShards.jl
@@ -2,75 +2,77 @@ module CommunalHelperCrystalHeart
 
 using ..Ahorn, Maple
 
-@mapdef Entity "CommunalHelper/CrystalHeart" CrystalHeart(x::Integer, y::Integer, 
-	removeCameraTriggers::Bool=false)
+@mapdef Entity "CommunalHelper/CrystalHeart" CrystalHeart(
+    x::Integer,
+    y::Integer,
+    removeCameraTriggers::Bool=false,
+)
 
 const placements = Ahorn.PlacementDict(
-	"Crystal Heart (Shards) (Communal Helper)" => Ahorn.EntityPlacement(
-	CrystalHeart,
-	"point",
-	Dict{String, Any}(),
-	function(entity)
-		entity.data["nodes"] = [
-			(Int(entity.data["x"]) - 20, Int(entity.data["y"]) - 20),
-			(Int(entity.data["x"]), Int(entity.data["y"]) - 20),
-			(Int(entity.data["x"]) + 20, Int(entity.data["y"]) - 20),
-		]
-	end
-	),
+    "Crystal Heart (Shards) (Communal Helper)" => Ahorn.EntityPlacement(
+        CrystalHeart,
+        "point",
+        Dict{String,Any}(),
+        function (entity)
+            entity.data["nodes"] = [
+                (Int(entity.data["x"]) - 20, Int(entity.data["y"]) - 20),
+                (Int(entity.data["x"]), Int(entity.data["y"]) - 20),
+                (Int(entity.data["x"]) + 20, Int(entity.data["y"]) - 20),
+            ]
+        end,
+    ),
 )
 
 Ahorn.nodeLimits(entity::CrystalHeart) = 1, -1
 
-const sprite = "collectables/heartGem/ghost00.png"
+const sprite = "collectables/heartGem/ghost00"
 
-const shardSprites = Tuple{String, String}[
-	("collectables/CommunalHelper/heartGemShard/shard_outline0$i.png",
-	"collectables/CommunalHelper/heartGemShard/shard0$i.png"
-	) for i=0:2
+const shardSprites = Tuple{String,String}[(
+        "collectables/CommunalHelper/heartGemShard/shard_outline0$i",
+        "collectables/CommunalHelper/heartGemShard/shard0$i",
+    ) for i in 0:2
 ]
 
 function Ahorn.selection(entity::CrystalHeart)
-	x, y = Ahorn.position(entity)
+    x, y = Ahorn.position(entity)
 
-	nodes = get(entity.data, "nodes", ())
+    nodes = get(entity.data, "nodes", ())
 
-	res = Ahorn.Rectangle[Ahorn.getSpriteRectangle(sprite, x, y)]
+    res = Ahorn.Rectangle[Ahorn.getSpriteRectangle(sprite, x, y)]
 
-	for i = 1:length(nodes)
-		nx, ny = nodes[i]
-		push!(res, Ahorn.getSpriteRectangle(shardSprites[mod1(i, 3)][1], nx, ny))
-	end
+    for i in 1:length(nodes)
+        nx, ny = nodes[i]
+        push!(res, Ahorn.getSpriteRectangle(shardSprites[mod1(i, 3)][1], nx, ny))
+    end
 
-	return res
+    return res
 end
 
 function Ahorn.renderSelectedAbs(ctx::Ahorn.Cairo.CairoContext, entity::CrystalHeart)
-	x, y = Ahorn.position(entity)
-	
-	nodes = get(entity.data, "nodes", ())
-	
-	for i = 1:length(nodes)
-		nx, ny = nodes[i]
+    x, y = Ahorn.position(entity)
 
-		Ahorn.drawLines(ctx, Tuple{Number, Number}[(x, y), (nx, ny)], Ahorn.colors.selection_selected_fc)
-	end
+    nodes = get(entity.data, "nodes", ())
+
+    for i in 1:length(nodes)
+        nx, ny = nodes[i]
+
+        Ahorn.drawLines(ctx, Tuple{Number, Number}[(x, y), (nx, ny)], Ahorn.colors.selection_selected_fc)
+    end
 end
 
 function Ahorn.renderAbs(ctx::Ahorn.Cairo.CairoContext, entity::CrystalHeart)
-	x, y = Ahorn.position(entity)
+    x, y = Ahorn.position(entity)
 
-	nodes = get(entity.data, "nodes", ())
+    nodes = get(entity.data, "nodes", ())
 
-	for i = 1:length(nodes)
-		nx, ny = nodes[i]
-		sprIdx = mod1(i, 3)
-		Ahorn.drawSprite(ctx, shardSprites[sprIdx][1], nx, ny)
-		Ahorn.drawSprite(ctx, shardSprites[sprIdx][2], nx, ny)
-	end
+    for i in 1:length(nodes)
+        nx, ny = nodes[i]
+        sprIdx = mod1(i, 3)
+        Ahorn.drawSprite(ctx, shardSprites[sprIdx][1], nx, ny)
+        Ahorn.drawSprite(ctx, shardSprites[sprIdx][2], nx, ny)
+    end
 
-	Ahorn.drawSprite(ctx, sprite, x, y)
+    Ahorn.drawSprite(ctx, sprite, x, y)
 end
-
 
 end

--- a/Ahorn/entities/HeartGemShards_AdventureHelper.jl
+++ b/Ahorn/entities/HeartGemShards_AdventureHelper.jl
@@ -4,103 +4,117 @@ using ..Ahorn, Maple
 using Ahorn.CommunalHelper
 
 # Stolen from AdventureHelper
-@mapdef Entity "CommunalHelper/AdventureHelper/CustomCrystalHeart" CustomCrystalHeart(x::Integer, y::Integer, 
-	color::String="00a81f", path::String="", 
-	nodes::Array{Tuple{Integer, Integer}, 1}=Tuple{Integer, Integer}[])
+@mapdef Entity "CommunalHelper/AdventureHelper/CustomCrystalHeart" CustomCrystalHeart(
+    x::Integer,
+    y::Integer,
+    color::String="00a81f",
+    path::String="",
+    nodes::Array{Tuple{Integer,Integer},1}=Tuple{Integer,Integer}[],
+)
 
-function getPlacements() 
-	# Check if there's an adventurehelper folder/zip in the mods folder
-	# This is bad and can easily fail, but whatever
-	if CommunalHelper.detectMod("adventurehelper")
-		return Ahorn.PlacementDict(
-			"Crystal Heart (Communal Helper, Adventure Helper)" => Ahorn.EntityPlacement(
-				CustomCrystalHeart,
-				"point",
-				Dict{String, Any}(),
-				function(entity)
-					entity.data["nodes"] = [
-						(Int(entity.data["x"]) - 20, Int(entity.data["y"]) - 20),
-						(Int(entity.data["x"]), Int(entity.data["y"]) - 20),
-						(Int(entity.data["x"]) + 20, Int(entity.data["y"]) - 20),
-					]
-				end
-			)
-		)
-	else
-		@warn "AdventureHelper not detected: CommunalHelper+AdventureHelper plugins not loaded."
-		return Ahorn.PlacementDict()
-	end
+function getPlacements()
+    # Check if there's an adventurehelper folder/zip in the mods folder
+    # This is bad and can easily fail, but whatever
+    if CommunalHelper.detectMod("adventurehelper")
+        return Ahorn.PlacementDict(
+            "Crystal Heart (Communal Helper, Adventure Helper)" => Ahorn.EntityPlacement(
+                CustomCrystalHeart,
+                "point",
+                Dict{String,Any}(),
+                function (entity)
+                    entity.data["nodes"] = [
+                        (Int(entity.data["x"]) - 20, Int(entity.data["y"]) - 20),
+                        (Int(entity.data["x"]), Int(entity.data["y"]) - 20),
+                        (Int(entity.data["x"]) + 20, Int(entity.data["y"]) - 20),
+                    ]
+                end,
+            ),
+        )
+    else
+        @warn "AdventureHelper not detected: CommunalHelper+AdventureHelper plugins not loaded."
+        return Ahorn.PlacementDict()
+    end
 end
 
 placements = getPlacements()
 
 Ahorn.nodeLimits(entity::CustomCrystalHeart) = 1, -1
 
-const shardSprites = Tuple{String, String}[
-	("collectables/CommunalHelper/heartGemShard/shard_outline0$i.png",
-	"collectables/CommunalHelper/heartGemShard/shard0$i.png"
-	) for i=0:2
+const shardSprites = Tuple{String,String}[(
+        "collectables/CommunalHelper/heartGemShard/shard_outline0$i",
+        "collectables/CommunalHelper/heartGemShard/shard0$i",
+    ) for i in 0:2
 ]
 
 function Ahorn.selection(entity::CustomCrystalHeart)
-	x, y = Ahorn.position(entity)
+    x, y = Ahorn.position(entity)
 
-	nodes = get(entity.data, "nodes", ())
+    nodes = get(entity.data, "nodes", ())
 
-	res = Ahorn.Rectangle[Ahorn.getSpriteRectangle("collectables/heartGem/3/00.png", x, y)]
+    res = Ahorn.Rectangle[Ahorn.getSpriteRectangle("collectables/heartGem/3/00", x, y)]
 
-	for i = 1:length(nodes)
-		nx, ny = nodes[i]
-		
-		push!(res, Ahorn.getSpriteRectangle(shardSprites[mod1(i, 3)][1], nx, ny))
-	end
+    for i in 1:length(nodes)
+        nx, ny = nodes[i]
 
-	return res
+        push!(res, Ahorn.getSpriteRectangle(shardSprites[mod1(i, 3)][1], nx, ny))
+    end
+
+    return res
 end
 
 function Ahorn.renderSelectedAbs(ctx::Ahorn.Cairo.CairoContext, entity::CustomCrystalHeart)
-	x, y = Ahorn.position(entity)
-	
-	nodes = get(entity.data, "nodes", ())
-	
-	for i = 1:length(nodes)
-		nx, ny = nodes[i]
+    x, y = Ahorn.position(entity)
 
-		Ahorn.drawLines(ctx, Tuple{Number, Number}[(x, y), (nx, ny)], Ahorn.colors.selection_selected_fc)
-	end
+    nodes = get(entity.data, "nodes", ())
+
+    for i in 1:length(nodes)
+        nx, ny = nodes[i]
+
+        Ahorn.drawLines(
+            ctx,
+            Tuple{Number,Number}[(x, y), (nx, ny)],
+            Ahorn.colors.selection_selected_fc,
+        )
+    end
 end
 
 function Ahorn.renderAbs(ctx::Ahorn.Cairo.CairoContext, entity::CustomCrystalHeart, room::Maple.Room)
-	x, y = Ahorn.position(entity)
-	path = get(entity.data, "path", "")
-	tint = CommunalHelper.hexToRGBA(get(entity.data, "color", "663931"))
-	sprite = String
-	
-	if path == "heartgem0"
-		sprite = "collectables/heartGem/0/00.png"
-	elseif path == "heartgem1"
-		sprite = "collectables/heartGem/1/00.png"
-	elseif path == "heartgem2"
-		sprite = "collectables/heartGem/2/00.png"
-	elseif path == "heartgem3"
-		sprite = "collectables/heartGem/3/00.png"
-	elseif path == ""
-		sprite = "collectables/AdventureHelper/RecolorHeart_Outline/00.png"
-		tint = CommunalHelper.hexToRGBA(get(entity.data, "color", "663931"))
-		Ahorn.drawSprite(ctx, "collectables/AdventureHelper/RecolorHeart/00.png", x, y, tint=tint)
-	else
-		sprite = "collectables/heartGem/3/00.png"
-	end
-	
-	nodes = get(entity.data, "nodes", ())
-	for i = 1:length(nodes)
-		nx, ny = nodes[i]
-		sprIdx = mod1(i, 3)
-		Ahorn.drawSprite(ctx, shardSprites[sprIdx][1], nx, ny)
-		Ahorn.drawSprite(ctx, shardSprites[sprIdx][2], nx, ny, tint=tint)
-	end
-	
-	Ahorn.drawSprite(ctx, sprite, x, y)
+    x, y = Ahorn.position(entity)
+    path = get(entity.data, "path", "")
+    tint = CommunalHelper.hexToRGBA(get(entity.data, "color", "663931"))
+    sprite = String
+
+    if path == "heartgem0"
+        sprite = "collectables/heartGem/0/00"
+    elseif path == "heartgem1"
+        sprite = "collectables/heartGem/1/00"
+    elseif path == "heartgem2"
+        sprite = "collectables/heartGem/2/00"
+    elseif path == "heartgem3"
+        sprite = "collectables/heartGem/3/00"
+    elseif path == ""
+        sprite = "collectables/AdventureHelper/RecolorHeart_Outline/00"
+        tint = CommunalHelper.hexToRGBA(get(entity.data, "color", "663931"))
+        Ahorn.drawSprite(
+            ctx,
+            "collectables/AdventureHelper/RecolorHeart/00",
+            x,
+            y,
+            tint=tint,
+        )
+    else
+        sprite = "collectables/heartGem/3/00"
+    end
+
+    nodes = get(entity.data, "nodes", ())
+    for i in 1:length(nodes)
+        nx, ny = nodes[i]
+        sprIdx = mod1(i, 3)
+        Ahorn.drawSprite(ctx, shardSprites[sprIdx][1], nx, ny)
+        Ahorn.drawSprite(ctx, shardSprites[sprIdx][2], nx, ny, tint=tint)
+    end
+
+    Ahorn.drawSprite(ctx, sprite, x, y)
 end
 
 end

--- a/Ahorn/entities/InputFlagController.jl
+++ b/Ahorn/entities/InputFlagController.jl
@@ -2,18 +2,27 @@ module CommunalHelperInputFlagController
 
 using ..Ahorn, Maple
 
-@mapdef Entity "CommunalHelper/InputFlagController" Controller(x::Int, y::Int, flags::String="", toggle::Bool=true, resetFlags::Bool=false, delay::Float64=0.0, 
-   grabOverride::Bool=false)
+@mapdef Entity "CommunalHelper/InputFlagController" Controller(
+    x::Int,
+    y::Int,
+    flags::String="",
+    toggle::Bool=true,
+    resetFlags::Bool=false,
+    delay::Float64=0.0,
+    grabOverride::Bool=false,
+)
 
 const placements = Ahorn.PlacementDict(
-   "Input Flag Controller (Communal Helper)" => Ahorn.EntityPlacement(
-      Controller
-   )
+    "Input Flag Controller (Communal Helper)" => Ahorn.EntityPlacement(
+        Controller,
+    ),
 )
 
 const sprite = "objects/CommunalHelper/inputFlagController/icon"
 
 Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::Controller) = Ahorn.drawSprite(ctx, sprite, 0, 0)
+
 Ahorn.selection(entity::Controller) = Ahorn.getSpriteRectangle(sprite, Ahorn.position(entity)...)
 
-end 
+end
+

--- a/Ahorn/entities/Melvin.jl
+++ b/Ahorn/entities/Melvin.jl
@@ -1,42 +1,49 @@
 module CommunalHelperMelvin
+
 using ..Ahorn, Maple
 
 @mapdef Entity "CommunalHelper/Melvin" Melvin(
-			x::Integer, y::Integer,
-            width::Integer=24, height::Integer=24,
-            weakTop::Bool = false, weakRight::Bool = false, weakBottom::Bool = false, weakLeft::Bool = false)
-           
+    x::Integer,
+    y::Integer,
+    width::Integer=24,
+    height::Integer=24,
+    weakTop::Bool=false,
+    weakRight::Bool=false,
+    weakBottom::Bool=false,
+    weakLeft::Bool=false,
+)
+
 const placements = Ahorn.PlacementDict(
     "Melvin (All Strong) (Communal Helper)" => Ahorn.EntityPlacement(
         Melvin,
-        "rectangle"
+        "rectangle",
     ),
     "Melvin (All Weak) (Communal Helper)" => Ahorn.EntityPlacement(
         Melvin,
         "rectangle",
-        Dict{String, Any}(
+        Dict{String,Any}(
             "weakTop" => true,
             "weakRight" => true,
             "weakBottom" => true,
-            "weakLeft" => true
-        )
+            "weakLeft" => true,
+        ),
     ),
     "Melvin (Horizontally Weak) (Communal Helper)" => Ahorn.EntityPlacement(
         Melvin,
         "rectangle",
-        Dict{String, Any}(
+        Dict{String,Any}(
             "weakRight" => true,
-            "weakLeft" => true
-        )
+            "weakLeft" => true,
+        ),
     ),
     "Melvin (Vertically Weak) (Communal Helper)" => Ahorn.EntityPlacement(
         Melvin,
         "rectangle",
-        Dict{String, Any}(
+        Dict{String,Any}(
             "weakTop" => true,
-            "weakBottom" => true
-        )
-    )
+            "weakBottom" => true,
+        ),
+    ),
 )
 
 Ahorn.minimumSize(entity::Melvin) = 24, 24
@@ -57,7 +64,7 @@ const kevinColor = (98, 34, 43) ./ 255
 function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::Melvin, room::Maple.Room)
     width = Int(get(entity.data, "width", 24))
     height = Int(get(entity.data, "height", 24))
-    
+
     eyeSprite = Ahorn.getSprite(eye, "Gameplay")
 
     tileRands = Ahorn.getDrawableRoom(Ahorn.loadedState.map, room).fgTileStates.rands
@@ -83,7 +90,7 @@ function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::Melvin, room::Maple
         isEdge = (i == 1 || i == tileWidth || j == 1 || j == tileHeight)
         isCorner = ((i == 1 || i == tileWidth) && (j == 1 || j == tileHeight))
         tileChoice = mod(get(tileRands, (rty + j, rtx + i), 0), 4)
-        
+
         if tx == 8
             if tileChoice == 1 || tileChoice == 3
                 tx += 8

--- a/Ahorn/entities/MoveBlockRedirect.jl
+++ b/Ahorn/entities/MoveBlockRedirect.jl
@@ -2,39 +2,49 @@ module CommunalHelperMoveBlockRedirect
 
 using ..Ahorn, Maple
 
-@mapdef Entity "CommunalHelper/MoveBlockRedirect" MoveBlockRedirect(x::Integer, y::Integer, 
-	width::Integer=Maple.defaultBlockWidth, height::Integer=Maple.defaultBlockHeight, 
-	direction::String="Up", fastRedirect::Bool=false, deleteBlock::Bool=false, oneUse::Bool=false,
-	modifier::Number=0.0, operation::String="Add")
+@mapdef Entity "CommunalHelper/MoveBlockRedirect" MoveBlockRedirect(
+    x::Integer,
+    y::Integer,
+    width::Integer=Maple.defaultBlockWidth,
+    height::Integer=Maple.defaultBlockHeight,
+    direction::String="Up",
+    fastRedirect::Bool=false,
+    deleteBlock::Bool=false,
+    oneUse::Bool=false,
+    modifier::Number=0.0,
+    operation::String="Add",
+)
 
 const placements = Ahorn.PlacementDict(
-	"Move Block Redirect (Communal Helper)" => Ahorn.EntityPlacement(
-		MoveBlockRedirect,
-		"rectangle"
-	),
-	"Move Block Redirect (One Use) (Communal Helper)" => Ahorn.EntityPlacement(
-		MoveBlockRedirect,
-		"rectangle",
-		Dict{String, Any}(
-			"oneUse" => true
-		)
-	),
-	"Move Block Redirect (Delete Block) (Communal Helper)" => Ahorn.EntityPlacement(
-		MoveBlockRedirect,
-		"rectangle",
-		Dict{String, Any}(
-			"deleteBlock" => true
-		)
-	)
+    "Move Block Redirect (Communal Helper)" => Ahorn.EntityPlacement(
+        MoveBlockRedirect,
+        "rectangle",
+    ),
+    "Move Block Redirect (One Use) (Communal Helper)" => Ahorn.EntityPlacement(
+        MoveBlockRedirect,
+        "rectangle",
+        Dict{String,Any}(
+            "oneUse" => true,
+        ),
+    ),
+    "Move Block Redirect (Delete Block) (Communal Helper)" => Ahorn.EntityPlacement(
+        MoveBlockRedirect,
+        "rectangle",
+        Dict{String,Any}(
+            "deleteBlock" => true,
+        ),
+    ),
 )
 
 const opTypes = ["Add", "Subtract", "Multiply"]
 
 Ahorn.editingOptions(entity::MoveBlockRedirect) = Dict{String, Any}(
     "direction" => Maple.move_block_directions,
-	"operation" => opTypes
+    "operation" => opTypes,
 )
-Ahorn.minimumSize(entity::MoveBlockRedirect) = Maple.defaultBlockWidth, Maple.defaultBlockHeight 
+
+Ahorn.minimumSize(entity::MoveBlockRedirect) = Maple.defaultBlockWidth, Maple.defaultBlockHeight
+
 Ahorn.resizable(entity::MoveBlockRedirect) = true, true
 
 Ahorn.selection(entity::MoveBlockRedirect) = Ahorn.getEntityRectangle(entity)
@@ -46,111 +56,89 @@ const slowColor = (28, 91, 179, 255) ./ 255
 
 const block = "objects/CommunalHelper/moveBlockRedirect/block"
 
+const clockwise = ["Up", "Right", "Down", "Left"]
 function Ahorn.rotated(entity::MoveBlockRedirect, steps::Int)
-	if steps == 0
-		return entity
-	end
+    dir = get(entity.data, "direction", "Up")
+    idx = findall(d -> d == dir, clockwise)[1]
+    entity.data["direction"] = clockwise[mod1(idx + steps, 4)]
 
-	dir = get(entity.data, "direction", "Up")
-	
-	if steps > 0
-		if dir == "Up"
-			dir = "Right"
-		elseif dir == "Right"
-			dir = "Down"
-		elseif dir == "Down"
-			dir = "Left"
-		elseif dir == "Left"
-			dir = "Up"
-		end
-	elseif steps < 0
-		if dir == "Up"
-			dir = "Left"
-		elseif dir == "Right"
-			dir = "Up"
-		elseif dir == "Down"
-			dir = "Right"
-		elseif dir == "Left"
-			dir = "Down"
-		end
-	end
-
-	return MoveBlockRedirect(entity.x, entity.y, entity.width, entity.height, dir, get(entity.data, "fastRedirect", false))
+    return entity
 end
 
+const rotations = Dict{String,Float64}(
+    "Up" => pi * 1.5,
+    "Right" => 0,
+    "Down" => pi / 2,
+    "Left" => pi,
+)
+
 function getRotation(dir::String)
-	if dir == "Up"
-		return pi * 1.5
-	elseif dir == "Right"
-		return 0
-	elseif dir == "Down"
-		return pi/2
-	elseif dir == "Left"
-		return pi
-	elseif (fAngle = tryparse(Float64, dir)) !== nothing
-		return fAngle
-	else 
-		return 0
-	end
+    if haskey(rotations, dir)
+        return rotations[dir]
+    elseif (fAngle = tryparse(Float64, dir)) !== nothing
+        return fAngle
+    else
+        return 0
+    end
 end
 
 function getIconTextureAndColor(entity::MoveBlockRedirect)
-	path = "objects/CommunalHelper/moveBlockRedirect/"
-	deleteBlock = Bool(get(entity.data, "deleteBlock", false))
-	if deleteBlock
-		return path * "x", deleteColor
-	end
+    path = "objects/CommunalHelper/moveBlockRedirect/"
+    deleteBlock = Bool(get(entity.data, "deleteBlock", false))
+    if deleteBlock
+        return path * "x", deleteColor
+    end
 
-	operation = String(get(entity.data, "operation", "Add"))
-	modifier = abs(get(entity.data, "modifier", 0.0))
-	if operation == "Add"
-		if modifier == 0.0
-			return path * "arrow", defaultColor
-		end
-		return path * "fast", fastColor
-	elseif operation == "Subtract"
-		if modifier == 0.0
-			return path * "arrow", defaultColor
-		end
-		return path * "slow", slowColor
-	elseif operation == "Multiply"
-		if modifier == 0.0
-			return path * "x", deleteColor
-		elseif modifier > 1.0
-			return path * "fast", fastColor
-		elseif modifier < 1.0
-			return path * "slow", slowColor
-		end
-	end
+    operation = get(entity.data, "operation", "Add")
+    modifier = abs(get(entity.data, "modifier", 0.0))
+    if operation == "Add"
+        if modifier != 0.0
+            return path * "fast", fastColor
+        end
+    elseif operation == "Subtract"
+        if modifier != 0
+            return path * "slow", slowColor
+        end
+    elseif operation == "Multiply"
+        if modifier == 0.0
+            return path * "x", deleteColor
+        elseif modifier > 1.0
+            return path * "fast", fastColor
+        elseif modifier < 1.0
+            return path * "slow", slowColor
+        end
+    end
 
-	return path * "arrow", defaultColor
+    return path * "arrow", defaultColor
 end
 
-function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::MoveBlockRedirect) 
-	width = Int(get(entity.data, "width", 32))
-   	height = Int(get(entity.data, "height", 32))
-	
-	direction = String(get(entity.data, "direction", "Up"))
-	sprite, color = getIconTextureAndColor(entity)
+function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::MoveBlockRedirect)
+    width = Int(get(entity.data, "width", 32))
+    height = Int(get(entity.data, "height", 32))
+
+    direction = String(get(entity.data, "direction", "Up"))
+    sprite, color = getIconTextureAndColor(entity)
 
     tileWidth = ceil(Int, width / 8)
     tileHeight = ceil(Int, height / 8)
 
-	for i in -1 : tileWidth, j in -1 : tileHeight
+    for i in -1:tileWidth, j in -1:tileHeight
         tx = (i == -1) ? 0 : ((i == tileWidth) ? 16 : 8)
         ty = (j == -1) ? 0 : ((j == tileHeight) ? 16 : 8)
-		if i == -1 || i == tileWidth || j == -1 || j == tileHeight
-			Ahorn.drawImage(ctx, block, i * 8, j * 8, tx, ty, 8, 8, tint=color)
-		end
-	end
-	
-	# finicky
-	Ahorn.Cairo.save(ctx)
-	Ahorn.Cairo.translate(ctx, width/2, height/2)
-	Ahorn.Cairo.rotate(ctx, getRotation(direction))
-	Ahorn.Cairo.translate(ctx, -8, -8) # sprite always has a 16 x 16 size
-	Ahorn.drawImage(ctx, sprite, 0, 0, tint=color)
-	Ahorn.Cairo.restore(ctx)
+        if i == -1 || i == tileWidth || j == -1 || j == tileHeight
+            Ahorn.drawImage(ctx, block, i * 8, j * 8, tx, ty, 8, 8, tint=color)
+        end
+    end
+
+    # finicky
+    Ahorn.Cairo.save(ctx)
+    Ahorn.Cairo.translate(ctx, width / 2, height / 2)
+    Ahorn.Cairo.rotate(ctx, getRotation(direction))
+    Ahorn.Cairo.translate(ctx, -8, -8) # sprite always has a 16 x 16 size
+    Ahorn.drawImage(ctx, sprite, 0, 0, tint=color)
+    Ahorn.Cairo.restore(ctx)
 end
 
-end 
+end
+
+

--- a/Ahorn/entities/MoveSwapBlock.jl
+++ b/Ahorn/entities/MoveSwapBlock.jl
@@ -1,26 +1,35 @@
 module CommunalHelperMoveSwapBlock
 using ..Ahorn, Maple
 
-@mapdef Entity "CommunalHelper/MoveSwapBlock" MoveSwapBlock(x::Integer, y::Integer, 
-	width::Integer=Maple.defaultBlockWidth, height::Integer=Maple.defaultBlockHeight,
-	direction::String="Left", canSteer::Bool=false, returns::Bool=true, freezeOnSwap::Bool=true,
-	moveSpeed::Number=60.0, moveAcceleration::Number=300.0, swapSpeedMultiplier::Number=1.0)
-
-const placements = Ahorn.PlacementDict(
-	"Move Swap Block (Communal Helper)" => Ahorn.EntityPlacement(
-		MoveSwapBlock,
-		"rectangle",
-		Dict{String, Any}(),
-		Ahorn.SwapBlock.swapFinalizer
-	)
+@mapdef Entity "CommunalHelper/MoveSwapBlock" MoveSwapBlock(
+    x::Integer,
+    y::Integer,
+    width::Integer=Maple.defaultBlockWidth,
+    height::Integer=Maple.defaultBlockHeight,
+    direction::String="Left",
+    canSteer::Bool=false,
+    returns::Bool=true,
+    freezeOnSwap::Bool=true,
+    moveSpeed::Number=60.0,
+    moveAcceleration::Number=300.0,
+    swapSpeedMultiplier::Number=1.0,
 )
 
-Ahorn.editingOptions(entity::MoveSwapBlock) = Dict{String, Any}(
-	"direction" => Maple.move_block_directions,
-	"moveSpeed" => Dict{String, Number}(
-		"Slow" => 60.0,
-		"Fast" => 75.0
-	)
+const placements = Ahorn.PlacementDict(
+    "Move Swap Block (Communal Helper)" => Ahorn.EntityPlacement(
+        MoveSwapBlock,
+        "rectangle",
+        Dict{String,Any}(),
+        Ahorn.SwapBlock.swapFinalizer,
+    ),
+)
+
+Ahorn.editingOptions(entity::MoveSwapBlock) = Dict{String,Any}(
+    "direction" => Maple.move_block_directions,
+    "moveSpeed" => Dict{String,Number}(
+        "Slow" => 60.0,
+        "Fast" => 75.0,
+    ),
 )
 
 Ahorn.minimumSize(entity::MoveSwapBlock) = 16, 16
@@ -28,131 +37,129 @@ Ahorn.resizable(entity::MoveSwapBlock) = true, true
 Ahorn.nodeLimits(entity::MoveSwapBlock) = 1, 1
 
 function Ahorn.selection(entity::MoveSwapBlock)
-	x, y = Ahorn.position(entity)
-	stopX, stopY = Int.(entity.data["nodes"][1])
+    x, y = Ahorn.position(entity)
+    stopX, stopY = Int.(entity.data["nodes"][1])
 
-	width = Int(get(entity.data, "width", 8))
-	height = Int(get(entity.data, "height", 8))
+    width = Int(get(entity.data, "width", 8))
+    height = Int(get(entity.data, "height", 8))
 
-	return [Ahorn.Rectangle(x, y, width, height), Ahorn.Rectangle(stopX, stopY, width, height)]
+    return [
+        Ahorn.Rectangle(x, y, width, height),
+        Ahorn.Rectangle(stopX, stopY, width, height),
+    ]
 end
 
 const midColor = (4, 3, 23) ./ 255
 const highlightColor = (59, 50, 101) ./ 255
 
 const arrow = "objects/CommunalHelper/moveSwapBlock/midBlockCardinal"
-const arrowRotations = Dict{String, Number}(
-	"Up" => 0,
-	"Right" => pi / 2,
-	"Down" => pi,
-	"Left" => pi / 2 * 3
+const arrowRotations = Dict{String,Number}(
+    "Up" => 0,
+    "Right" => pi / 2,
+    "Down" => pi,
+    "Left" => pi / 2 * 3,
 )
 
 const gem = "objects/CommunalHelper/moveSwapBlock/midBlockOrange"
-const gemOffsets = Dict{String, Tuple{Int, Int}}(
-	"Up" => (0, -1),
-	"Right" => (1, 0),
-	"Down" => (0, 1),
-	"Left" => (-1, 0),
+const gemOffsets = Dict{String,Tuple{Int,Int}}(
+    "Up" => (0, -1),
+    "Right" => (1, 0),
+    "Down" => (0, 1),
+    "Left" => (-1, 0),
 )
 
 const button = "objects/moveBlock/button"
 const buttonColor = (255, 126, 16, 255) ./ 255
 
-
-getTextures(entity::MoveSwapBlock) = "objects/swapblock/blockRed", "objects/swapblock/target", "objects/swapblock/midBlockRed00"
-
 function Ahorn.renderSelectedAbs(ctx::Ahorn.Cairo.CairoContext, entity::MoveSwapBlock)
-   sprite = get(entity.data, "sprite", "block")
-   startX, startY = Int(entity.data["x"]), Int(entity.data["y"])
-   stopX, stopY = Int.(entity.data["nodes"][1])
+    startX, startY = Int(entity.data["x"]), Int(entity.data["y"])
+    stopX, stopY = Int.(entity.data["nodes"][1])
 
-   width = Int(get(entity.data, "width", 32))
-   height = Int(get(entity.data, "height", 32))
-	direction = get(entity.data, "direction", "Up")
+    width = Int(get(entity.data, "width", 32))
+    height = Int(get(entity.data, "height", 32))
+    direction = get(entity.data, "direction", "Up")
 
-   renderSwapBlock(ctx, stopX, stopY, width, height, direction)
-   Ahorn.drawArrow(ctx, startX + width / 2, startY + height / 2, stopX + width / 2, stopY + height / 2, Ahorn.colors.selection_selected_fc, headLength=6)
+    renderSwapBlock(ctx, stopX, stopY, width, height, direction)
+    Ahorn.drawArrow(ctx, startX + width / 2, startY + height / 2, stopX + width / 2, stopY + height / 2, Ahorn.colors.selection_selected_fc, headLength=6)
 end
 
 function Ahorn.renderAbs(ctx::Ahorn.Cairo.CairoContext, entity::MoveSwapBlock)
-	startX, startY = Int(entity.data["x"]), Int(entity.data["y"])
-	stopX, stopY = Int.(entity.data["nodes"][1])
-	width = Int(get(entity.data, "width", 32))
-	height = Int(get(entity.data, "height", 32))
-	direction = get(entity.data, "direction", "Up")
-	
-	frame, trail, mid = getTextures(entity)
-	Ahorn.SwapBlock.renderTrail(ctx, min(startX, stopX), min(startY, stopY), abs(startX - stopX) + width, abs(startY - stopY) + height, "objects/swapblock/moon/target")
-	renderSwapBlock(ctx, startX, startY, width, height, direction)
-	renderMoveBlockButtons(ctx, entity, startX, startY, width, height)
+    startX, startY = Int(entity.data["x"]), Int(entity.data["y"])
+    stopX, stopY = Int.(entity.data["nodes"][1])
+    width = Int(get(entity.data, "width", 32))
+    height = Int(get(entity.data, "height", 32))
+    direction = get(entity.data, "direction", "Up")
+
+    Ahorn.SwapBlock.renderTrail(ctx, min(startX, stopX), min(startY, stopY), abs(startX - stopX) + width, abs(startY - stopY) + height, "objects/swapblock/moon/target")
+    renderSwapBlock(ctx, startX, startY, width, height, direction)
+    renderMoveBlockButtons(ctx, entity, startX, startY, width, height)
 end
 
 function renderSwapBlock(ctx::Ahorn.Cairo.CairoContext, x::Number, y::Number, width::Number, height::Number, dir::String)
-	Ahorn.SwapBlock.renderSwapBlock(ctx, x, y, width, height, "objects/swapblock/midBlockRed00", "objects/swapblock/blockRed")
-	
-	# I don't really trust the way Ahorn handles rotation in sprites
-	arrowSprite = Ahorn.getSprite(arrow, "Gameplay")
-	Ahorn.Cairo.save(ctx)
-	Ahorn.Cairo.translate(ctx, x + div(width, 2), y + div(height, 2))
-	Ahorn.Cairo.rotate(ctx, arrowRotations[dir])
-	Ahorn.Cairo.translate(ctx, -div(arrowSprite.width, 2), -div(arrowSprite.height, 2))
-	Ahorn.drawImage(ctx, arrowSprite, 0, 0)
-	Ahorn.Cairo.restore(ctx)
-	
-	gemSprite = Ahorn.getSprite(gem, "Gameplay")
-	gemX, gemY = gemOffsets[dir]
-	Ahorn.drawImage(ctx, gemSprite, x + div(width - gemSprite.width, 2) + gemX, y + div(height - gemSprite.height, 2) + gemY)
+    Ahorn.SwapBlock.renderSwapBlock(ctx, x, y, width, height, "objects/swapblock/midBlockRed00", "objects/swapblock/blockRed")
+
+    # I don't really trust the way Ahorn handles rotation in sprites
+    arrowSprite = Ahorn.getSprite(arrow, "Gameplay")
+    Ahorn.Cairo.save(ctx)
+    Ahorn.Cairo.translate(ctx, x + div(width, 2), y + div(height, 2))
+    Ahorn.Cairo.rotate(ctx, arrowRotations[dir])
+    Ahorn.Cairo.translate(ctx, -div(arrowSprite.width, 2), -div(arrowSprite.height, 2))
+    Ahorn.drawImage(ctx, arrowSprite, 0, 0)
+    Ahorn.Cairo.restore(ctx)
+
+    gemSprite = Ahorn.getSprite(gem, "Gameplay")
+    gemX, gemY = gemOffsets[dir]
+    Ahorn.drawImage(ctx, gemSprite, x + div(width - gemSprite.width, 2) + gemX, y + div(height - gemSprite.height, 2) + gemY)
 end
 
 function renderMoveBlockButtons(ctx, entity::MoveSwapBlock, x::Integer, y::Integer, width::Integer, height::Integer)
-	tilesWidth = div(width, 8)
-	tilesHeight = div(height, 8)
+    tilesWidth = div(width, 8)
+    tilesHeight = div(height, 8)
 
-	canSteer = get(entity.data, "canSteer", false)
-	direction = (get(entity.data, "direction", "Up"))
+    canSteer = get(entity.data, "canSteer", false)
+    direction = (get(entity.data, "direction", "Up"))
 
-	for i in 2:tilesWidth - 1
-		if canSteer && (direction != "Up" && direction != "Down")
-			Ahorn.drawImage(ctx, button, x + (i - 1) * 8, y - 2, 6, 0, 8, 6, tint=buttonColor)
-		end
-	end
+    for i in 2:tilesWidth-1
+        if canSteer && (direction != "Up" && direction != "Down")
+            Ahorn.drawImage(ctx, button, x + (i - 1) * 8, y - 2, 6, 0, 8, 6, tint=buttonColor)
+        end
+    end
 
-	for i in 2:tilesHeight - 1
-		if canSteer && (direction == "Up" || direction == "Down")
-			Ahorn.Cairo.save(ctx)
+    for i in 2:tilesHeight-1
+        if canSteer && (direction == "Up" || direction == "Down")
+            Ahorn.Cairo.save(ctx)
 
-			Ahorn.rotate(ctx, -pi / 2)
-			Ahorn.drawImage(ctx, button, i * 8 - height - 8 - y, x-2, 6, 0, 8, 6, tint=buttonColor)
-			Ahorn.scale(ctx, 1, -1)
-			Ahorn.drawImage(ctx, button, i * 8 - height - 8 - y, -2 - width - x, 6, 0, 8, 6, tint=buttonColor)
+            Ahorn.rotate(ctx, -pi / 2)
+            Ahorn.drawImage(ctx, button, i * 8 - height - 8 - y, x-2, 6, 0, 8, 6, tint=buttonColor)
+            Ahorn.scale(ctx, 1, -1)
+            Ahorn.drawImage(ctx, button, i * 8 - height - 8 - y, -2 - width - x, 6, 0, 8, 6, tint=buttonColor)
 
-			Ahorn.Cairo.restore(ctx)
-		end
-	end
+            Ahorn.Cairo.restore(ctx)
+        end
+    end
 
-	if canSteer && (direction != "Up" && direction != "Down")
-		Ahorn.Cairo.save(ctx)
+    if canSteer && (direction != "Up" && direction != "Down")
+        Ahorn.Cairo.save(ctx)
 
-		Ahorn.drawImage(ctx, button, x+2, y-2, 0, 0, 6, 6, tint=buttonColor)
-		Ahorn.scale(ctx, -1, 1)
-		Ahorn.drawImage(ctx, button, 2 - width - x, y-2, 0, 0, 6, 6, tint=buttonColor)
+        Ahorn.drawImage(ctx, button, x + 2, y - 2, 0, 0, 6, 6, tint=buttonColor)
+        Ahorn.scale(ctx, -1, 1)
+        Ahorn.drawImage(ctx, button, 2 - width - x, y - 2, 0, 0, 6, 6, tint=buttonColor)
 
-		Ahorn.Cairo.restore(ctx)
-	end
+        Ahorn.Cairo.restore(ctx)
+    end
 
-	if canSteer && (direction == "Up" || direction == "Down")
-		Ahorn.Cairo.save(ctx)
+    if canSteer && (direction == "Up" || direction == "Down")
+        Ahorn.Cairo.save(ctx)
 
-		Ahorn.rotate(ctx, -pi / 2)
-		Ahorn.drawImage(ctx, button, 2-height - y, x-2, 0, 0, 8, 6, tint=buttonColor)
-		Ahorn.drawImage(ctx, button, -10-y, x-2, 14, 0, 8, 6, tint=buttonColor)
-		Ahorn.scale(ctx, 1, -1)
-		Ahorn.drawImage(ctx, button, 2-height-y, - 2 -width - x, 0, 0, 8, 6, tint=buttonColor)
-		Ahorn.drawImage(ctx, button, -10-y, -2 -width - x, 14, 0, 8, 6, tint=buttonColor)
+        Ahorn.rotate(ctx, -pi / 2)
+        Ahorn.drawImage(ctx, button, 2 - height - y, x - 2, 0, 0, 8, 6, tint=buttonColor)
+        Ahorn.drawImage(ctx, button, -10 - y, x - 2, 14, 0, 8, 6, tint=buttonColor)
+        Ahorn.scale(ctx, 1, -1)
+        Ahorn.drawImage(ctx, button, 2-height-y, - 2 -width - x, 0, 0, 8, 6, tint=buttonColor)
+        Ahorn.drawImage(ctx, button, -10-y, -2 -width - x, 14, 0, 8, 6, tint=buttonColor)
 
-		Ahorn.Cairo.restore(ctx)
-	end
+        Ahorn.Cairo.restore(ctx)
+    end
 end
 
 end

--- a/Ahorn/entities/PlayerBubbleRegion.jl
+++ b/Ahorn/entities/PlayerBubbleRegion.jl
@@ -2,24 +2,25 @@ module CommunalHelperPlayerBubbleRegion
 
 using ..Ahorn, Maple
 
-@mapdef Entity "CommunalHelper/PlayerBubbleRegion" PlayerBubbleRegion(x::Integer, y::Integer, 
-    width::Integer=24, height::Integer=24,
-    nodes::Array{Tuple{Integer, Integer}, 1}=Tuple{Integer, Integer}[])
+@mapdef Entity "CommunalHelper/PlayerBubbleRegion" PlayerBubbleRegion(
+    x::Integer,
+    y::Integer,
+    width::Integer=24,
+    height::Integer=24,
+    nodes::Array{Tuple{Integer,Integer},1}=Tuple{Integer,Integer}[],
+)
 
 const placements = Ahorn.PlacementDict(
     "Player Bubble Region (Communal Helper)" => Ahorn.EntityPlacement(
         PlayerBubbleRegion,
         "rectangle",
-        Dict{String, Any}(),
-        function(entity)
+        Dict{String,Any}(),
+        function (entity)
             cx = Int(entity.data["x"]) + Int(entity.data["width"]) / 2
             cy = Int(entity.data["y"]) + Int(entity.data["height"]) / 2
-            entity.data["nodes"] = [
-                (cx + 32, cy),
-                (cx + 64, cy)
-            ]
-        end
-    )
+            entity.data["nodes"] = [(cx + 32, cy), (cx + 64, cy)]
+        end,
+    ),
 )
 
 Ahorn.nodeLimits(entity::PlayerBubbleRegion) = 2, 2
@@ -30,7 +31,6 @@ const sprite = "characters/player/bubble"
 const color = (45, 103, 111, 200) ./ 255
 
 function Ahorn.selection(entity::PlayerBubbleRegion)
-    x, y = Ahorn.position(entity)
     nodes = entity.data["nodes"]
     controllX, controllY = Int.(nodes[1])
     endX, endY = Int.(nodes[2])
@@ -38,11 +38,11 @@ function Ahorn.selection(entity::PlayerBubbleRegion)
     return [
         Ahorn.getEntityRectangle(entity),
         Ahorn.getSpriteRectangle(sprite, controllX, controllY),
-        Ahorn.getSpriteRectangle(sprite, endX, endY)
+        Ahorn.getSpriteRectangle(sprite, endX, endY),
     ]
 end
 
-function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::PlayerBubbleRegion, room::Maple.Room) 
+function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::PlayerBubbleRegion, room::Maple.Room)
     width = Int(entity.data["width"])
     height = Int(entity.data["height"])
 
@@ -54,7 +54,7 @@ end
 function Ahorn.renderSelectedAbs(ctx::Ahorn.Cairo.CairoContext, entity::PlayerBubbleRegion)
     px, py = Ahorn.position(entity)
     nodes = entity.data["nodes"]
-    
+
     width = Int(entity.data["width"])
     height = Int(entity.data["height"])
     px += width / 2
@@ -62,7 +62,7 @@ function Ahorn.renderSelectedAbs(ctx::Ahorn.Cairo.CairoContext, entity::PlayerBu
 
     cx, cy = Int.(nodes[1])
     ex, ey = Int.(nodes[2])
-    
+
     Ahorn.drawArrow(ctx, px, py, cx, cy, Ahorn.colors.selection_selected_fc, headLength=6)
     Ahorn.drawArrow(ctx, cx, cy, ex, ey, Ahorn.colors.selection_selected_fc, headLength=6)
     Ahorn.drawSprite(ctx, sprite, ex, ey)

--- a/Ahorn/entities/ResetStateCrystal.jl
+++ b/Ahorn/entities/ResetStateCrystal.jl
@@ -1,17 +1,20 @@
 module CommunalHelperResetCrystal
+
 using ..Ahorn, Maple
 
-@mapdef Entity "CommunalHelper/ResetStateCrystal" ResetCrystal(x::Integer, y::Integer, 
-	oneUse::Bool=false)
+@mapdef Entity "CommunalHelper/ResetStateCrystal" ResetCrystal(
+    x::Integer,
+    y::Integer,
+    oneUse::Bool=false,
+)
 
 const placements = Ahorn.PlacementDict(
     "Reset State Crystal (Communal Helper)" => Ahorn.EntityPlacement(
         ResetCrystal,
-        "point"
-    )
+    ),
 )
 
-const sprite = "objects/CommunalHelper/resetStateCrystal/ghostIdle00.png"
+const sprite = "objects/CommunalHelper/resetStateCrystal/ghostIdle00"
 
 function Ahorn.selection(entity::ResetCrystal)
     x, y = Ahorn.position(entity)
@@ -20,5 +23,6 @@ function Ahorn.selection(entity::ResetCrystal)
 end
 
 Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::ResetCrystal) =
-    Ahorn.drawSprite(ctx, sprite, 0, 0; tint=(.35, .35, .35, 1.0))
+    Ahorn.drawSprite(ctx, sprite, 0, 0; tint=(0.35, 0.35, 0.35, 1.0))
+
 end

--- a/Ahorn/entities/ShieldedRefill.jl
+++ b/Ahorn/entities/ShieldedRefill.jl
@@ -1,24 +1,26 @@
 module CommunalHelperShieldedRefill
+
 using ..Ahorn, Maple
 
-@mapdef Entity "CommunalHelper/ShieldedRefill" ShieldedRefill(x::Integer, y::Integer, 
-	twoDashes::Bool = false, oneUse::Bool = false, bubbleRepel::Bool = true)    
+@mapdef Entity "CommunalHelper/ShieldedRefill" ShieldedRefill(
+    x::Integer,
+    y::Integer,
+    twoDashes::Bool=false,
+    oneUse::Bool=false,
+    bubbleRepel::Bool=true,
+)
 
 const placements = Ahorn.PlacementDict(
+    "Shielded Refill (Communal Helper)" => Ahorn.EntityPlacement(
+        ShieldedRefill,
+    ),
     "Shielded Refill (Two Dashes) (Communal Helper)" => Ahorn.EntityPlacement(
         ShieldedRefill,
         "point",
-        Dict{String, Any}(
+        Dict{String,Any}(
             "twoDashes" => true
-        )
+        ),
     ),
-    "Shielded Refill (Communal Helper)" => Ahorn.EntityPlacement(
-        ShieldedRefill,
-        "point",
-        Dict{String, Any}(
-            "twoDashes" => false
-        )
-    )    
 )
 
 const spriteOneDash = "objects/refill/idle00"
@@ -36,7 +38,7 @@ end
 function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::ShieldedRefill)
     Ahorn.Cairo.save(ctx)
     Ahorn.set_antialias(ctx, 1)
-    Ahorn.set_line_width(ctx, 1);
+    Ahorn.set_line_width(ctx, 1)
 
     Ahorn.drawCircle(ctx, 0, 0, 8, (1.0, 1.0, 1.0, 1.0))
     Ahorn.Cairo.restore(ctx)

--- a/Ahorn/entities/StationBlock.jl
+++ b/Ahorn/entities/StationBlock.jl
@@ -7,28 +7,35 @@ const themes = ["Normal", "Moon"]
 const behaviors = ["Pulling", "Pushing"]
 
 @mapdef Entity "CommunalHelper/StationBlock" StationBlock(
-			x::Integer, y::Integer,
-			width::Integer=16, height::Integer=16,
-            theme::String="Normal", behavior::String="Pulling",
-            customBlockPath::String="", customArrowPath::String="", customTrackPath::String="",
-            speedFactor::Number=1.0,
-            allowWavedash::Bool = false,
-            wavedashButtonColor="5BF75B", wavedashButtonPressedColor="F25EFF")
+    x::Integer,
+    y::Integer,
+    width::Integer=16,
+    height::Integer=16,
+    theme::String="Normal",
+    behavior::String="Pulling",
+    customBlockPath::String="",
+    customArrowPath::String="",
+    customTrackPath::String="",
+    speedFactor::Number=1.0,
+    allowWavedash::Bool=false,
+    wavedashButtonColor="5BF75B",
+    wavedashButtonPressedColor="F25EFF",
+)
 
 const placements = Ahorn.PlacementDict(
     "Station Block ($theme, $behavior) (Communal Helper)" => Ahorn.EntityPlacement(
         StationBlock,
-		"rectangle",
-		Dict{String, Any}(
-			"theme" => theme,
-			"behavior" => behavior,
-		)
+        "rectangle",
+        Dict{String,Any}(
+            "theme" => theme,
+            "behavior" => behavior,
+        ),
     ) for theme in themes, behavior in behaviors
 )
 
-Ahorn.editingOptions(entity::StationBlock) = Dict{String, Any}(
-   "theme" => themes,
-	"behavior" => behaviors
+Ahorn.editingOptions(entity::StationBlock) = Dict{String,Any}(
+    "theme" => themes,
+    "behavior" => behaviors,
 )
 
 Ahorn.minimumSize(entity::StationBlock) = 16, 16
@@ -46,32 +53,39 @@ end
 Ahorn.renderAbs(ctx::Ahorn.Cairo.CairoContext, entity::StationBlock) = renderStationBlock(ctx, entity)
 
 function getSprites(blockSize::Integer, entity::StationBlock)
-	theme = lowercase(get(entity, "theme", "normal"))
-	behavior = lowercase(get(entity, "behavior", "pulling"))
+    theme = lowercase(get(entity, "theme", "normal"))
+    behavior = lowercase(get(entity, "behavior", "pulling"))
 
-	path = "objects/CommunalHelper/stationBlock/"
-	arrowDirectory, block = (theme == "normal") ? 
-					   ((behavior == "pulling") ? ("arrow/", "/block") : ("altArrow/", "/alt_block")) : 
-					   ((behavior == "pulling") ? ("moonArrow/", "/moon_block") : ("altMoonArrow/", "/alt_moon_block"))
-	
+    path = "objects/CommunalHelper/stationBlock/"
+    if theme == "normal"
+        arrowDirectory, block = (behavior == "pulling") ? ("arrow/", "/block") : ("altArrow/", "/alt_block")
+    else
+        arrowDirectory, block = (behavior == "pulling") ? ("moonArrow/", "/moon_block") : ("altMoonArrow/", "/alt_moon_block")
+    end
+
     arrow = (blockSize <= 16) ? "small00" : ((blockSize <= 24) ? "med00" : "big00")
     button = (Bool(get(entity.data, "allowWavedash", false)) ? "_button" : "")
-    
-    return (path * arrowDirectory * arrow), (path * "blocks" * block * button), (path * "button"), (path * "button_outline")
+
+    return (
+        (path * arrowDirectory * arrow),
+        (path * "blocks" * block * button),
+        (path * "button"),
+        (path * "button_outline"),
+    )
 end
 
 function renderStationBlock(ctx::Ahorn.Cairo.CairoContext, entity::StationBlock)
-	x, y = Ahorn.position(entity)
+    x, y = Ahorn.position(entity)
 
     width = Int(get(entity.data, "width", 16))
     height = Int(get(entity.data, "height", 16))
-	
-	arrow, block, button, buttonOutline = getSprites(Integer(min(width, height)), entity)
-	arrowSprite = Ahorn.getSprite(arrow, "Gameplay")
-	
+
+    arrow, block, button, buttonOutline = getSprites(Integer(min(width, height)), entity)
+    arrowSprite = Ahorn.getSprite(arrow, "Gameplay")
+
     tilesWidth = div(width, 8)
     tilesHeight = div(height, 8)
-    
+
     # Button
     if Bool(get(entity.data, "allowWavedash", false))
         hexColor = String(get(entity.data, "wavedashButtonColor", "FFFFFF"))
@@ -92,8 +106,8 @@ function renderStationBlock(ctx::Ahorn.Cairo.CairoContext, entity::StationBlock)
 
         Ahorn.drawImage(ctx, block, x + (i - 1) * 8, y + (j - 1) * 8, tx, ty, 8, 8)
     end
-	
-	Ahorn.drawImage(ctx, arrowSprite, x + floor(Int, (width - arrowSprite.width) / 2), y + floor(Int, (height - arrowSprite.height) / 2))
+
+    Ahorn.drawImage(ctx, arrowSprite, x + floor(Int, (width - arrowSprite.width) / 2), y + floor(Int, (height - arrowSprite.height) / 2))
 end
 
 end

--- a/Ahorn/entities/StationBlockTrack.jl
+++ b/Ahorn/entities/StationBlockTrack.jl
@@ -1,37 +1,48 @@
 module CommunalHelperStationBlockTrack
+
 using ..Ahorn, Maple
 
 const switchStates = ["None", "On", "Off"]
 
-@mapdef Entity "CommunalHelper/StationBlockTrack" StationBlockTrack(x::Integer, y::Integer,
-    width::Integer = 24, height::Integer = 24,
-    horizontal::Bool = false,
-    trackSwitchState::String = "None",
-    offrampNode1::Bool = false, offrampNode2::Bool = false, multiBlockTrack::Bool = false)
+@mapdef Entity "CommunalHelper/StationBlockTrack" StationBlockTrack(
+    x::Integer,
+    y::Integer,
+    width::Integer=24,
+    height::Integer=24,
+    horizontal::Bool=false,
+    trackSwitchState::String="None",
+    offrampNode1::Bool=false,
+    offrampNode2::Bool=false,
+    multiBlockTrack::Bool=false,
+)
 
 const placements = Ahorn.PlacementDict(
     "Station Block Track ($orientation, $stateLabel) (Communal Helper)" => Ahorn.EntityPlacement(
         StationBlockTrack,
         "rectangle",
-        Dict{String, Any}(
+        Dict{String,Any}(
             "horizontal" => orientation == "Horizontal",
             "trackSwitchState" => state,
-        )
+        ),
     ) for orientation in ["Vertical", "Horizontal"], (state, stateLabel) in zip(switchStates, ["No Switching", "Switch On", "Switch Off"])
-) 
+)
 
-Ahorn.editingIgnored(entity::StationBlockTrack, multiple::Bool=false) = multiple ? String["x", "y", "width", "height", "nodes", "offrampNode1", "offrampNode2"] : String["offrampNode1", "offrampNode2"]
+Ahorn.editingIgnored(entity::StationBlockTrack, multiple::Bool=false) =
+    multiple ? String["x", "y", "width", "height", "nodes", "offrampNode1", "offrampNode2"] : String["offrampNode1", "offrampNode2"]
 
 Ahorn.minimumSize(entity::StationBlockTrack) = 24, 24
 
-Ahorn.resizable(entity::StationBlockTrack) = Bool(get(entity.data, "horizontal", false)), !(Bool(get(entity.data, "horizontal", false)))
+function Ahorn.resizable(entity::StationBlockTrack) 
+    horiz = Bool(get(entity.data, "horizontal", false))
+    return (horiz, !horiz)
+end
 
-Ahorn.editingOptions(entity::StationBlockTrack) = Dict{String, Any}(
-    "trackSwitchState" => switchStates
+Ahorn.editingOptions(entity::StationBlockTrack) = Dict{String,Any}(
+    "trackSwitchState" => switchStates,
 )
 
 # very weird rotation
-function Ahorn.rotated(entity::StationBlockTrack, steps::Int) 
+function Ahorn.rotated(entity::StationBlockTrack, steps::Int)
     horiz = Bool(get(entity.data, "horizontal", false))
     trackSwitchState = get(entity.data, "trackSwitchState", "None")
     return StationBlockTrack(entity.x, entity.y, entity.height, entity.width, !horiz, trackSwitchState)
@@ -43,7 +54,7 @@ function Ahorn.selection(entity::StationBlockTrack)
     width = Int(get(entity.data, "width", 24))
     height = Int(get(entity.data, "height", 24))
     horiz = Bool(get(entity.data, "horizontal", false))
-	
+
     return horiz ? Ahorn.Rectangle(x, y, width, 8) : Ahorn.Rectangle(x, y, 8, height)
 end
 
@@ -79,11 +90,11 @@ function Ahorn.renderAbs(ctx::Ahorn.Cairo.CairoContext, entity::StationBlockTrac
 
     offramp1 = Bool(get(entity.data, "offrampNode1", false))
     offramp2 = Bool(get(entity.data, "offrampNode2", false))
-    
+
     if horiz
         tilesWidth = div(width, 8)
 
-        for i in 2:tilesWidth - 1
+        for i in 2:tilesWidth-1
             Ahorn.drawImage(ctx, hTrack, x + (i - 1) * 8, y, tint=color)
         end
 
@@ -98,7 +109,7 @@ function Ahorn.renderAbs(ctx::Ahorn.Cairo.CairoContext, entity::StationBlockTrac
     else
         tilesHeight = div(height, 8)
 
-        for i in 2:tilesHeight - 1
+        for i in 2:tilesHeight-1
             Ahorn.drawImage(ctx, vTrack, x, y + (i - 1) * 8, tint=color)
         end
 
@@ -111,7 +122,6 @@ function Ahorn.renderAbs(ctx::Ahorn.Cairo.CairoContext, entity::StationBlockTrac
             Ahorn.drawImage(ctx, arrows, x, y + height - 2, 8, 8, 8, 8)
         end
     end
-
 end
 
 end

--- a/Ahorn/entities/SummitGem.jl
+++ b/Ahorn/entities/SummitGem.jl
@@ -2,40 +2,44 @@ module CommunalHelperCustomSummitGem
 
 using ..Ahorn, Maple
 
-@mapdef Entity "CommunalHelper/CustomSummitGem" CustomSummitGem(x::Integer, y::Integer, 
-	index::Integer=0)
-	
-const placements = Ahorn.PlacementDict(
-	"Summit Gem (Communal Helper)" => Ahorn.EntityPlacement(
-		CustomSummitGem
-	)
+@mapdef Entity "CommunalHelper/CustomSummitGem" CustomSummitGem(
+    x::Integer,
+    y::Integer,
+    index::Integer=0,
 )
 
-const sprites = ["collectables/summitgems/$i/gem00" for i = 0:7]
+const placements = Ahorn.PlacementDict(
+    "Summit Gem (Communal Helper)" => Ahorn.EntityPlacement(
+        CustomSummitGem,
+    ),
+)
+
+const sprites = ["collectables/summitgems/$i/gem00" for i in 0:7]
 
 function getSprite(index)
-	if index > length(sprites)
-		return sprites[end]
-	end
-	return sprites[index]
+    if index > length(sprites)
+        return sprites[end]
+    end
+    return sprites[index]
 end
 
 # positive numbers only
 function getClampedIndex(entity::CustomSummitGem)
-	index = Int(get(entity.data, "index", 0))
-	if index < 0
-		index = 0
-	end
-	entity.data["index"] = index
-	return index
+    index = Int(get(entity.data, "index", 0))
+    if index < 0
+        index = 0
+    end
+    entity.data["index"] = index
+    return index
 end
 
 function Ahorn.selection(entity::CustomSummitGem)
-	x, y = Ahorn.position(entity)
-	
-	return Ahorn.getSpriteRectangle(getSprite(getClampedIndex(entity) + 1) , x, y)
+    x, y = Ahorn.position(entity)
+
+    return Ahorn.getSpriteRectangle(getSprite(getClampedIndex(entity) + 1), x, y)
 end
 
-Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::CustomSummitGem) = Ahorn.drawSprite(ctx, getSprite(getClampedIndex(entity) + 1), 0, 0)
+Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::CustomSummitGem) =
+    Ahorn.drawSprite(ctx, getSprite(getClampedIndex(entity) + 1), 0, 0)
 
-end 
+end

--- a/Ahorn/entities/SummitGemManager.jl
+++ b/Ahorn/entities/SummitGemManager.jl
@@ -2,129 +2,138 @@ module CommunalHelperCustomSummitGemManager
 
 using ..Ahorn, Maple
 
-@mapdef Entity "CommunalHelper/CustomSummitGemManager" SummitGemManager(x::Integer, y::Integer, 
-	gemIds::String="", melody::String="", heartOffset::String="0.0,0.0", nodes::Array{Tuple{Integer, Integer}, 1}=Tuple{Integer, Integer}[])
-	
+@mapdef Entity "CommunalHelper/CustomSummitGemManager" SummitGemManager(
+    x::Integer,
+    y::Integer,
+    gemIds::String="",
+    melody::String="",
+    heartOffset::String="0.0,0.0",
+    nodes::Array{Tuple{Integer,Integer},1}=Tuple{Integer,Integer}[],
+)
+
 const placements = Ahorn.PlacementDict(
-	"Summit Gem Manager (Communal Helper)" => Ahorn.EntityPlacement(
-		SummitGemManager
-	)
+    "Summit Gem Manager (Communal Helper)" => Ahorn.EntityPlacement(
+        SummitGemManager,
+    ),
 )
 
 Ahorn.nodeLimits(entity::SummitGemManager) = 0, -1
 
 const gemSprite = "collectables/summitgems/0/gem00"
 
-const smallGemSprites = String["collectables/summitgems/$i/small00" for i=0:7]
+const smallGemSprites = String["collectables/summitgems/$i/small00" for i in 0:7]
 
 function Ahorn.selection(entity::SummitGemManager)
-	x, y = Ahorn.position(entity)
+    x, y = Ahorn.position(entity)
 
-	nodes = get(entity.data, "nodes", ())
+    nodes = get(entity.data, "nodes", ())
 
-	res = Ahorn.Rectangle[Ahorn.Rectangle(x - 15, y - 15, 30, 30)]
-	
-	for node in nodes
-		nx, ny = node
-		push!(res, Ahorn.getSpriteRectangle(gemSprite, nx, ny))
-	end
-	
-	hx, hy = getHeartOffset(entity)
-	if hx + hy != 0
-		push!(res, Ahorn.getSpriteRectangle("collectables/heartGem/ghost00.png", x + hx, y + hy))
-	end
+    res = Ahorn.Rectangle[Ahorn.Rectangle(x - 15, y - 15, 30, 30)]
 
-	return res
+    for node in nodes
+        nx, ny = node
+        push!(res, Ahorn.getSpriteRectangle(gemSprite, nx, ny))
+    end
+
+    hx, hy = getHeartOffset(entity)
+    if hx + hy != 0
+        push!(res, Ahorn.getSpriteRectangle("collectables/heartGem/ghost00", x + hx, y + hy))
+    end
+
+    return res
 end
 
 # Cruor please don't yell at me
 function Ahorn.Selection.applyMovement!(target::SummitGemManager, ox, oy, node=0)
-	if node == 0
-		target.data["x"] += ox
-		target.data["y"] += oy
-	else
-		nodes = get(target.data, "nodes", ())
+    if node == 0
+        target.data["x"] += ox
+        target.data["y"] += oy
+    else
+        nodes = get(target.data, "nodes", ())
 
-		if length(nodes) >= node
-			nodes[node] = nodes[node] .+ (ox, oy)
-		elseif node == length(nodes) + 1
-			heartOffset = getHeartOffset(target)
-			(hx, hy) = heartOffset .+ (ox, oy)
-			target.data["heartOffset"] = string(hx, ",", hy)
-		end
-	end
+        if length(nodes) >= node
+            nodes[node] = nodes[node] .+ (ox, oy)
+        elseif node == length(nodes) + 1
+            heartOffset = getHeartOffset(target)
+            (hx, hy) = heartOffset .+ (ox, oy)
+            target.data["heartOffset"] = string(hx, ",", hy)
+        end
+    end
 
-	return true
+    return true
 end
 
 # not currently working
 function Ahorn.deleted(target::SummitGemManager, node::Int64)
-	nodes = get(target.data, "nodes", ())
+    nodes = get(target.data, "nodes", ())
 
-	if node == length(nodes) + 1
-		target.data["heartOffset"] = "0.0,0.0"
-	end
+    if node == length(nodes) + 1
+        target.data["heartOffset"] = "0.0,0.0"
+    end
 end
 
 function getHeartOffset(entity::SummitGemManager)
-	heartOffset = get(entity.data, "heartOffset", "")
-	if length(heartOffset) > 3
-		heartOffset = (split(heartOffset, ","))
-		heartOffset = tryparse.(Float64, heartOffset)
-		if all(f -> isnothing(f), heartOffset)
-			return (0, 0)
-		end
-		return (heartOffset[1], heartOffset[2])
-	end
-	return (0, 0)
+    heartOffset = get(entity.data, "heartOffset", "")
+    if length(heartOffset) > 3
+        heartOffset = (split(heartOffset, ","))
+        heartOffset = tryparse.(Float64, heartOffset)
+        if all(f -> isnothing(f), heartOffset)
+            return (0, 0)
+        end
+        return (heartOffset[1], heartOffset[2])
+    end
+    return (0, 0)
 end
 
 function Ahorn.renderSelectedAbs(ctx::Ahorn.Cairo.CairoContext, entity::SummitGemManager)
-	x, y = Ahorn.position(entity)
-	
-	nodes = get(entity.data, "nodes", ())
-	
-	for node in nodes
-		nx, ny = node
+    x, y = Ahorn.position(entity)
 
-		Ahorn.drawLines(ctx, Tuple{Number, Number}[(x, y), (nx, ny)], Ahorn.colors.selection_selected_fc)
-	end
-	
-	hx, hy = getHeartOffset(entity)
-	if hx + hy != 0
-		Ahorn.drawArrow(ctx, x, y, x + hx, y + hy, Ahorn.colors.selection_selected_fc; headLength=6, headTheta=pi/8)
-	end
+    nodes = get(entity.data, "nodes", ())
+
+    for node in nodes
+        nx, ny = node
+
+        Ahorn.drawLines(ctx, Tuple{Number, Number}[(x, y), (nx, ny)], Ahorn.colors.selection_selected_fc)
+    end
+
+    hx, hy = getHeartOffset(entity)
+    if hx + hy != 0
+        Ahorn.drawArrow(ctx, x, y, x + hx, y + hy, Ahorn.colors.selection_selected_fc; headLength=6, headTheta=pi/8)
+    end
 end
 
 function Ahorn.renderAbs(ctx::Ahorn.Cairo.CairoContext, entity::SummitGemManager)
-	x, y = Ahorn.position(entity)
-	
-	hx, hy = getHeartOffset(entity)
-	if hx + hy != 0
-		Ahorn.drawSprite(ctx, "collectables/heartGem/ghost00.png", x + hx, y + hy)
-	end
-		
-	Ahorn.Cairo.save(ctx)
-	Ahorn.set_antialias(ctx, 1)
-	Ahorn.set_line_width(ctx, 1)
-	Ahorn.Cairo.arc(ctx, x, y, 20, 0, pi * 2)
-	Ahorn.Cairo.set_source_rgba(ctx, 0.0, 0.0, 0.0, 0.4)
-	Ahorn.Cairo.fill_preserve(ctx)
-	Ahorn.Cairo.set_source_rgba(ctx, 1.0, 1.0, 1.0, 1.0)
-	Ahorn.Cairo.stroke(ctx)
-	Ahorn.restore(ctx)
-	
-	for i = 1:length(smallGemSprites)
-		gx, gy = Base.Math.cospi((i / length(smallGemSprites)) * 2) * 14 , Base.Math.sinpi((i / length(smallGemSprites)) * 2) * 14
-		Ahorn.drawSprite(ctx, smallGemSprites[i], x + gx, y + gy)
-	end
-	
-	nodes = get(entity.data, "nodes", ())
+    x, y = Ahorn.position(entity)
 
-	for node in nodes
-		nx, ny = node
-		Ahorn.drawSprite(ctx, gemSprite, nx, ny)
-	end
+    hx, hy = getHeartOffset(entity)
+    if hx + hy != 0
+        Ahorn.drawSprite(ctx, "collectables/heartGem/ghost00", x + hx, y + hy)
+    end
+
+    Ahorn.Cairo.save(ctx)
+    Ahorn.set_antialias(ctx, 1)
+    Ahorn.set_line_width(ctx, 1)
+    Ahorn.Cairo.arc(ctx, x, y, 20, 0, pi * 2)
+    Ahorn.Cairo.set_source_rgba(ctx, 0.0, 0.0, 0.0, 0.4)
+    Ahorn.Cairo.fill_preserve(ctx)
+    Ahorn.Cairo.set_source_rgba(ctx, 1.0, 1.0, 1.0, 1.0)
+    Ahorn.Cairo.stroke(ctx)
+    Ahorn.restore(ctx)
+
+    for i in 1:length(smallGemSprites)
+        gx, gy = Base.Math.cospi((i / length(smallGemSprites)) * 2) * 14,
+        Base.Math.sinpi((i / length(smallGemSprites)) * 2) * 14
+        Ahorn.drawSprite(ctx, smallGemSprites[i], x + gx, y + gy)
+    end
+
+    nodes = get(entity.data, "nodes", ())
+
+    for node in nodes
+        nx, ny = node
+        Ahorn.drawSprite(ctx, gemSprite, nx, ny)
+    end
 end
 
-end 
+end
+
+

--- a/Ahorn/entities/SyncedZipMoverActivationController.jl
+++ b/Ahorn/entities/SyncedZipMoverActivationController.jl
@@ -2,18 +2,20 @@ module CommunalHelperSyncedZipMoverActivationController
 
 using ..Ahorn, Maple
 
-@mapdef Entity "CommunalHelper/SyncedZipMoverActivationController" Controller(x::Integer, y::Integer, 
-    colorCode::String="ff00ff", zipMoverSpeedMultiplier::Number=1.0) 
-
-const placements = Ahorn.PlacementDict(
-    "Synced Zip Mover Activation Controller (Communal Helper)" => Ahorn.EntityPlacement(
-        Controller,
-        "point",
-        Dict{String, Any}(),
-    )
+@mapdef Entity "CommunalHelper/SyncedZipMoverActivationController" Controller(
+    x::Integer,
+    y::Integer,
+    colorCode::String="ff00ff",
+    zipMoverSpeedMultiplier::Number=1.0,
 )
 
-const sprite = "objects/CommunalHelper/syncedZipMoverActivationController/syncedZipMoverActivationController.png"
+const placements = Ahorn.PlacementDict(
+    "Synced Zip Mover Activator (Communal Helper)" => Ahorn.EntityPlacement(
+        Controller,
+    ),
+)
+
+const sprite = "objects/CommunalHelper/syncedZipMoverActivationController/syncedZipMoverActivationController"
 
 function Ahorn.selection(entity::Controller)
     x, y = Ahorn.position(entity)
@@ -21,7 +23,7 @@ function Ahorn.selection(entity::Controller)
 end
 
 function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::Controller)
-	Ahorn.drawSprite(ctx, sprite, 0, 0)
+    Ahorn.drawSprite(ctx, sprite, 0, 0)
 end
 
 end

--- a/Ahorn/entities/TimedTriggerSpikes.jl
+++ b/Ahorn/entities/TimedTriggerSpikes.jl
@@ -3,19 +3,19 @@ module CommunalHelperTimedTriggerSpikes
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
 
-pos = :(spike(
+const pos = :(spike(
     x::Integer,
     y::Integer,
 )) 
-data = :(
+const data = :(
     type::String="default",
     Delay::Number=0.4,
     WaitForPlayer::Bool=false,
     Grouped::Bool=false,
     Rainbow::Bool=false,
 )
-heightData = appendkwargs(pos, :(height::Integer=Maple.defaultSpikeHeight), data)
-widthData = appendkwargs(pos, :(width::Integer=Maple.defaultSpikeWidth), data)
+const heightData = appendkwargs(pos, :(height::Integer=Maple.defaultSpikeHeight), data)
+const widthData = appendkwargs(pos, :(width::Integer=Maple.defaultSpikeWidth), data)
 
 @mapdefdata Entity "CommunalHelper/TimedTriggerSpikesLeft" TimedTriggerSpikesLeft heightData
 @mapdefdata Entity "CommunalHelper/TimedTriggerSpikesUp" TimedTriggerSpikesUp widthData

--- a/Ahorn/entities/TimedTriggerSpikes.jl
+++ b/Ahorn/entities/TimedTriggerSpikes.jl
@@ -1,102 +1,117 @@
 module CommunalHelperTimedTriggerSpikes
-using ..Ahorn, Maple
 
-@mapdef Entity "CommunalHelper/TimedTriggerSpikesUp" TimedTriggerSpikesUp(x::Integer, y::Integer, width::Integer=Maple.defaultSpikeWidth, type::String="default", Delay::Number=0.4, WaitForPlayer::Bool=false, Grouped::Bool=false, Rainbow::Bool=false)
-@mapdef Entity "CommunalHelper/TimedTriggerSpikesDown" TimedTriggerSpikesDown(x::Integer, y::Integer, width::Integer=Maple.defaultSpikeWidth, type::String="default", Delay::Number=0.4, WaitForPlayer::Bool=false, Grouped::Bool=false, Rainbow::Bool=false)
-@mapdef Entity "CommunalHelper/TimedTriggerSpikesLeft" TimedTriggerSpikesLeft(x::Integer, y::Integer, height::Integer=Maple.defaultSpikeHeight, type::String="default", Delay::Number=0.4, WaitForPlayer::Bool=false, Grouped::Bool=false, Rainbow::Bool=false)
-@mapdef Entity "CommunalHelper/TimedTriggerSpikesRight" TimedTriggerSpikesRight(x::Integer, y::Integer, height::Integer=Maple.defaultSpikeHeight, type::String="default", Delay::Number=0.4, WaitForPlayer::Bool=false, Grouped::Bool=false, Rainbow::Bool=false)
+using ..Ahorn, Maple
+using Ahorn.CommunalHelper
+
+pos = :(spike(
+    x::Integer,
+    y::Integer,
+)) 
+data = :(
+    type::String="default",
+    Delay::Number=0.4,
+    WaitForPlayer::Bool=false,
+    Grouped::Bool=false,
+    Rainbow::Bool=false,
+)
+heightData = appendkwargs(pos, :(height::Integer=Maple.defaultSpikeHeight), data)
+widthData = appendkwargs(pos, :(width::Integer=Maple.defaultSpikeWidth), data)
+
+@mapdefdata Entity "CommunalHelper/TimedTriggerSpikesLeft" TimedTriggerSpikesLeft heightData
+@mapdefdata Entity "CommunalHelper/TimedTriggerSpikesUp" TimedTriggerSpikesUp widthData
+@mapdefdata Entity "CommunalHelper/TimedTriggerSpikesRight" TimedTriggerSpikesRight heightData
+@mapdefdata Entity "CommunalHelper/TimedTriggerSpikesDown" TimedTriggerSpikesDown widthData
 
 const placements = Ahorn.PlacementDict()
 
-const TimedTriggerSpikes = Dict{String, Type}(
+const TimedTriggerSpikes = Dict{String,Type}(
     "up" => TimedTriggerSpikesUp,
     "down" => TimedTriggerSpikesDown,
     "left" => TimedTriggerSpikesLeft,
-    "right" => TimedTriggerSpikesRight
+    "right" => TimedTriggerSpikesRight,
 )
 
-const spikeTypes = String[
-    "default",
-    "outline",
-    "cliffside",
-    "dust",
-    "reflection"
-]
+const spikeTypes = String["default", "outline", "cliffside", "dust", "reflection"]
 
 const triggerSpikeColors = [
     (242, 90, 16, 255) ./ 255,
     (255, 0, 0, 255) ./ 255,
-    (242, 16, 103, 255) ./ 255
+    (242, 16, 103, 255) ./ 255,
 ]
 
-const triggerSpikesUnion = Union{TimedTriggerSpikesUp, TimedTriggerSpikesDown, TimedTriggerSpikesLeft, TimedTriggerSpikesRight}
+const TriggerSpikesUnion = Union{
+    TimedTriggerSpikesUp,
+    TimedTriggerSpikesDown,
+    TimedTriggerSpikesLeft,
+    TimedTriggerSpikesRight,
+}
 
 for variant in spikeTypes, (dir, entity) in TimedTriggerSpikes
     key = "Timed Trigger Spikes ($(uppercasefirst(dir)), $(uppercasefirst(variant))) (Communal Helper)"
     placements[key] = Ahorn.EntityPlacement(
         entity,
         "rectangle",
-        Dict{String, Any}(
-            "type" => variant
+        Dict{String,Any}(
+            "type" => variant,
         )
     )
 end
 
-Ahorn.editingOptions(entity::triggerSpikesUnion) = Dict{String, Any}(
+Ahorn.editingOptions(entity::TriggerSpikesUnion) = Dict{String,Any}(
     "type" => spikeTypes,
-    "Grouped" => Dict{String, Bool}(
-	"Not Grouped" => false,
-	"Grouped (Require's Max's Helping Hand)" => true
+    "Grouped" => Dict{String,Bool}(
+        "Not Grouped" => false,
+        "Grouped (Requires Max's Helping Hand)" => true,
     ),
-    "Rainbow" => Dict{String, Bool}(
-	"Default" => false,
-	"Rainbow (Require's Viv's Helper)" => true
-    )
+    "Rainbow" => Dict{String,Bool}(
+        "Default" => false,
+        "Rainbow (Requires Viv's Helper)" => true,
+    ),
 )
 
-const directions = Dict{String, String}(
+const directions = Dict{String,String}(
     "CommunalHelper/TimedTriggerSpikesUp" => "up",
     "CommunalHelper/TimedTriggerSpikesDown" => "down",
     "CommunalHelper/TimedTriggerSpikesLeft" => "left",
     "CommunalHelper/TimedTriggerSpikesRight" => "right",
 )
 
-const offsets = Dict{String, Tuple{Integer, Integer}}(
+const offsets = Dict{String,Tuple{Integer,Integer}}(
     "up" => (4, -4),
     "down" => (4, 4),
     "left" => (-4, 4),
     "right" => (4, 4),
 )
 
-const triggerSpikesOffsets = Dict{String, Tuple{Integer, Integer}}(
+const renderOffsets = Dict{String,Tuple{Integer,Integer}}(
     "up" => (0, 5),
     "down" => (0, -4),
     "left" => (5, 0),
     "right" => (-4, 0),
 )
 
-const rotations = Dict{String, Number}(
+const rotations = Dict{String,Number}(
     "up" => 0,
     "right" => pi / 2,
     "down" => pi,
-    "left" => 3 * pi / 2
+    "left" => 3 * pi / 2,
 )
 
-const triggerRotationOffsets = Dict{String, Tuple{Number, Number}}(
+const rotationOffsets = Dict{String,Tuple{Number,Number}}(
     "up" => (3, -1),
     "right" => (4, 3),
     "down" => (5, 5),
     "left" => (-1, 4),
 )
 
-const resizeDirections = Dict{String, Tuple{Bool, Bool}}(
+const resizeDirections = Dict{String,Tuple{Bool,Bool}}(
     "up" => (true, false),
     "down" => (true, false),
     "left" => (false, true),
     "right" => (false, true),
 )
 
-function Ahorn.renderSelectedAbs(ctx::Ahorn.Cairo.CairoContext, entity::triggerSpikesUnion)
+function Ahorn.renderSelectedAbs(ctx::Ahorn.Cairo.CairoContext, entity::TriggerSpikesUnion)
     direction = get(directions, entity.name, "up")
     theta = rotations[direction] - pi / 2
 
@@ -104,110 +119,92 @@ function Ahorn.renderSelectedAbs(ctx::Ahorn.Cairo.CairoContext, entity::triggerS
     height = Int(get(entity.data, "height", 0))
 
     x, y = Ahorn.position(entity)
-    cx, cy = x + floor(Int, width / 2) - 8 * (direction == "left"), y + floor(Int, height / 2) - 8 * (direction == "up")
+    cx, cy = x + floor(Int, width / 2) - 8 * (direction == "left"),
+    y + floor(Int, height / 2) - 8 * (direction == "up")
 
     Ahorn.drawArrow(ctx, cx, cy, cx + cos(theta) * 24, cy + sin(theta) * 24, Ahorn.colors.selection_selected_fc, headLength=6)
 end
 
-function Ahorn.selection(entity::triggerSpikesUnion)
-    if haskey(directions, entity.name)
-        x, y = Ahorn.position(entity)
+function Ahorn.selection(entity::TriggerSpikesUnion)
+    x, y = Ahorn.position(entity)
 
-        width = Int(get(entity.data, "width", 8))
-        height = Int(get(entity.data, "height", 8))
+    width = Int(get(entity.data, "width", 8))
+    height = Int(get(entity.data, "height", 8))
 
-        direction = get(directions, entity.name, "up")
+    direction = get(directions, entity.name, "up")
 
-        ox, oy = offsets[direction]
+    ox, oy = offsets[direction]
 
-        return Ahorn.Rectangle(x + ox - 4, y + oy - 4, width, height)
-    end
+    return Ahorn.Rectangle(x + ox - 4, y + oy - 4, width, height)
 end
 
-Ahorn.minimumSize(entity::triggerSpikesUnion) = 8, 8
+Ahorn.minimumSize(entity::TriggerSpikesUnion) = 8, 8
 
-function Ahorn.resizable(entity::triggerSpikesUnion)
-    if haskey(directions, entity.name)
-        direction = get(directions, entity.name, "up")
-
-        return resizeDirections[direction]
-    end
+function Ahorn.resizable(entity::TriggerSpikesUnion)
+    direction = get(directions, entity.name, "up")
+    return resizeDirections[direction]
 end
 
-function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::triggerSpikesUnion)
-    if haskey(directions, entity.name)
-        variant = get(entity.data, "type", "default")
-        direction = get(directions, entity.name, "up")
-        TriggerSpikesOffset = triggerSpikesOffsets[direction]
+function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::TriggerSpikesUnion)
+    variant = get(entity.data, "type", "default")
+    direction = get(directions, entity.name, "up")
+    TriggerSpikesOffset = renderOffsets[direction]
 
-        if variant == "dust"
-            rng = Ahorn.getSimpleEntityRng(entity)
+    width = get(entity.data, "width", 8)
+    height = get(entity.data, "height", 8)
 
-            width = get(entity.data, "width", 8)
-            height = get(entity.data, "height", 8)
+    if variant == "dust"
+        rng = Ahorn.getSimpleEntityRng(entity)
 
-            updown = direction == "up" || direction == "down"
+        updown = direction == "up" || direction == "down"
 
-            for ox in 0:8:width - 8, oy in 0:8:height - 8
-                color1 = rand(rng, triggerSpikeColors)
-                color2 = rand(rng, triggerSpikeColors)
+        for ox in 0:8:width-8, oy in 0:8:height-8
+            color1 = rand(rng, triggerSpikeColors)
+            color2 = rand(rng, triggerSpikeColors)
 
-                drawX = ox + triggerRotationOffsets[direction][1]
-                drawY = oy + triggerRotationOffsets[direction][2]
+            drawX = ox + rotationOffsets[direction][1]
+            drawY = oy + rotationOffsets[direction][2]
 
-                Ahorn.drawSprite(ctx, "danger/triggertentacle/wiggle_v06", drawX, drawY, rot=rotations[direction], tint=color1)
-                Ahorn.drawSprite(ctx, "danger/triggertentacle/wiggle_v03", drawX + 3 * updown, drawY + 3 * !updown, rot=rotations[direction], tint=color2)
-            end
-        else
-
-            width = get(entity.data, "width", 8)
-            height = get(entity.data, "height", 8)
-
-            for ox in 0:8:width - 8, oy in 0:8:height - 8
-                drawX, drawY = (ox, oy) .+ offsets[direction] .+ TriggerSpikesOffset
-                Ahorn.drawSprite(ctx, "danger/spikes/$(variant)_$(direction)00", drawX, drawY)
-            end
+            Ahorn.drawSprite(ctx, "danger/triggertentacle/wiggle_v06", drawX, drawY, rot=rotations[direction], tint=color1)
+            Ahorn.drawSprite(ctx, "danger/triggertentacle/wiggle_v03", drawX + 3 * updown, drawY + 3 * !updown, rot=rotations[direction], tint=color2)
+        end
+    else
+        for ox in 0:8:width-8, oy in 0:8:height-8
+            drawX, drawY = (ox, oy) .+ offsets[direction] .+ TriggerSpikesOffset
+            Ahorn.drawSprite(ctx, "danger/spikes/$(variant)_$(direction)00", drawX, drawY)
         end
     end
 end
 
-function Ahorn.flipped(entity::TimedTriggerSpikesUp, horizontal::Bool)
-    if !horizontal
-        return TimedTriggerSpikesDown(entity.x, entity.y, entity.width, entity.type)
-    end
-end
+const spikes = [
+    TimedTriggerSpikesLeft,
+    TimedTriggerSpikesUp,
+    TimedTriggerSpikesRight,
+    TimedTriggerSpikesDown,
+]
 
-function Ahorn.flipped(entity::TimedTriggerSpikesDown, horizontal::Bool)
-    if !horizontal
-        return TimedTriggerSpikesUp(entity.x, entity.y, entity.width, entity.type)
-    end
-end
+for i in 0:3
+    left, current, right, opposite = circshift(spikes, i)
+    size = iseven(i) ? :(entity.width) : :(entity.height)
+    dirCheck = isodd(i) ? :(horizontal) : :(!horizontal)
 
-function Ahorn.flipped(entity::TimedTriggerSpikesLeft, horizontal::Bool)
-    if horizontal
-        return TimedTriggerSpikesRight(entity.x, entity.y, entity.height, entity.type)
-    end
-end
-
-function Ahorn.flipped(entity::TimedTriggerSpikesRight, horizontal::Bool)
-    if horizontal
-        return TimedTriggerSpikesLeft(entity.x, entity.y, entity.height, entity.type)
-    end
-end
-
-const spikes = [TimedTriggerSpikesLeft, TimedTriggerSpikesUp, TimedTriggerSpikesRight, TimedTriggerSpikesDown]
-for i in 1:length(spikes)
-    left, normal, right = getindex(spikes, mod1.(collect(i-1:i+1), 4))
-    size = i % 2 == 0 ? :(entity.width) : :(entity.height)
-    @eval function Ahorn.rotated(entity::$normal, steps::Int)
-        if steps > 0
-            return Ahorn.rotated($right(entity.x, entity.y, $size, entity.type), steps - 1)
-
-        elseif steps < 0
-            return Ahorn.rotated($left(entity.x, entity.y, $size, entity.type), steps + 1)
+    @eval begin
+        function Ahorn.flipped(entity::$current, horizontal::Bool)
+            if $dirCheck
+                return $opposite(entity.x, entity.y, $size, entity.type)
+            end
         end
 
-        return entity
+        function Ahorn.rotated(entity::$current, steps::Int)
+            if steps > 0
+                return Ahorn.rotated($right(entity.x, entity.y, $size, entity.type), steps - 1)
+
+            elseif steps < 0
+                return Ahorn.rotated($left(entity.x, entity.y, $size, entity.type), steps + 1)
+            end
+
+            return entity
+        end
     end
 end
 

--- a/Ahorn/entities/boosters/DreamBooster.jl
+++ b/Ahorn/entities/boosters/DreamBooster.jl
@@ -2,20 +2,24 @@ module CommunalHelperDreamBooster
 
 using ..Ahorn, Maple
 
-@mapdef Entity "CommunalHelper/DreamBooster" DreamBooster(x::Integer, y::Integer, hidePath::Bool = false)
+@mapdef Entity "CommunalHelper/DreamBooster" DreamBooster(
+    x::Integer,
+    y::Integer,
+    hidePath::Bool=false,
+)
 
 const placements = Ahorn.PlacementDict(
     "Dream Booster (Communal Helper)" => Ahorn.EntityPlacement(
         DreamBooster,
-        "line"
+        "line",
     ),
     "Dream Booster (Hidden Path) (Communal Helper)" => Ahorn.EntityPlacement(
         DreamBooster,
         "line",
-        Dict{String, Any}(
-            "hidePath" => true
-        )
-    )
+        Dict{String,Any}(
+            "hidePath" => true,
+        ),
+    ),
 )
 
 Ahorn.nodeLimits(entity::DreamBooster) = 1, 1
@@ -24,7 +28,10 @@ function Ahorn.selection(entity::DreamBooster)
     x, y = Ahorn.position(entity)
     endX, endY = Int.(entity.data["nodes"][1])
 
-    return [Ahorn.Rectangle(x - 9, y - 9, 18, 18), Ahorn.Rectangle(endX - 9, endY - 9, 18, 18)]
+    return [
+        Ahorn.Rectangle(x - 9, y - 9, 18, 18),
+        Ahorn.Rectangle(endX - 9, endY - 9, 18, 18),
+    ]
 end
 
 const dreamBoosterSprite = "objects/CommunalHelper/boosters/dreamBooster/idle00"

--- a/Ahorn/entities/cassetteBlocks/CassetteFallingBlock.jl
+++ b/Ahorn/entities/cassetteBlocks/CassetteFallingBlock.jl
@@ -3,25 +3,27 @@ module CommunalHelperCassetteFallingBlock
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
 
-@mapdef Entity "CommunalHelper/CassetteFallingBlock" CassetteFallingBlock(x::Integer, 
-                                                                  y::Integer, 
-                                                                  width::Integer=Maple.defaultBlockWidth, 
-                                                                  height::Integer=Maple.defaultBlockHeight,
-                                                                  index::Integer=0,
-                                                                  tempo::Number=1.0,
-                                                                  customColor="") 
+@mapdef Entity "CommunalHelper/CassetteFallingBlock" CassetteFallingBlock(
+    x::Integer,
+    y::Integer,
+    width::Integer=Maple.defaultBlockWidth,
+    height::Integer=Maple.defaultBlockHeight,
+    index::Integer=0,
+    tempo::Number=1.0,
+    customColor="",
+)
 
 const placements = Ahorn.PlacementDict(
     "Cassette Falling Block ($index - $color) (Communal Helper)" => Ahorn.EntityPlacement(
         CassetteFallingBlock,
         "rectangle",
-        Dict{String, Any}(
+        Dict{String,Any}(
             "index" => index,
-        )
+        ),
     ) for (color, index) in cassetteColorNames
 )
 
-Ahorn.editingOptions(entity::CassetteFallingBlock) = Dict{String, Any}(
+Ahorn.editingOptions(entity::CassetteFallingBlock) = Dict{String,Any}(
     "index" => cassetteColorNames
 )
 
@@ -39,7 +41,7 @@ function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::CassetteFallingBloc
     height = Int(get(entity.data, "height", 32))
 
     index = Int(get(entity.data, "index", 0))
-    
+
     hexColor = String(get(entity.data, "customColor", ""))
     if hexColor != "" && length(hexColor) == 6
         renderCassetteBlock(ctx, 0, 0, width, height, index, hexToRGBA(hexColor))

--- a/Ahorn/entities/cassetteBlocks/CassetteJumpFixController.jl
+++ b/Ahorn/entities/cassetteBlocks/CassetteJumpFixController.jl
@@ -3,12 +3,17 @@ module CommunalHelperCassetteJumpFixController
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
 
-@mapdef Entity "CommunalHelper/CassetteJumpFixController" CassetteJumpFixController(x::Integer, y::Integer, persistent::Bool=false, off::Bool=false) 
+@mapdef Entity "CommunalHelper/CassetteJumpFixController" CassetteJumpFixController(
+    x::Integer,
+    y::Integer,
+    persistent::Bool=false,
+    off::Bool=false,
+)
 
 const placements = Ahorn.PlacementDict(
     "Cassette Jump Fix Controller (Communal Helper)" => Ahorn.EntityPlacement(
-        CassetteJumpFixController
-    )
+        CassetteJumpFixController,
+    ),
 )
 
 const sprite = "objects/CommunalHelper/cassetteJumpFixController/icon"

--- a/Ahorn/entities/cassetteBlocks/CassetteMoveBlock.jl
+++ b/Ahorn/entities/cassetteBlocks/CassetteMoveBlock.jl
@@ -3,39 +3,46 @@ module CommunalHelperCassetteMoveBlock
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
 
-@mapdef Entity "CommunalHelper/CassetteMoveBlock" CassetteMoveBlock(x::Integer, y::Integer,
-	width::Integer=Maple.defaultBlockWidth, height::Integer=Maple.defaultBlockHeight,
-    direction::String="Right", moveSpeed::Number=60.0, index::Integer=0, tempo::Number=1.0,
-    customColor="")
+@mapdef Entity "CommunalHelper/CassetteMoveBlock" CassetteMoveBlock(
+    x::Integer,
+    y::Integer,
+    width::Integer=Maple.defaultBlockWidth,
+    height::Integer=Maple.defaultBlockHeight,
+    direction::String="Right",
+    moveSpeed::Number=60.0,
+    index::Integer=0,
+    tempo::Number=1.0,
+    customColor="",
+)
 
 const placements = Ahorn.PlacementDict(
     "Cassette Move Block ($index - $color) (Communal Helper)" => Ahorn.EntityPlacement(
         CassetteMoveBlock,
         "rectangle",
-        Dict{String, Any}(
+        Dict{String,Any}(
             "index" => index,
-        )
+        ),
     ) for (color, index) in cassetteColorNames
 )
 
-Ahorn.editingOptions(entity::CassetteMoveBlock) = Dict{String, Any}(
-    "index" => cassetteColorNames,
+Ahorn.editingOptions(entity::CassetteMoveBlock) = Dict{String,Any}(
+    "index"     => cassetteColorNames,
     "direction" => Maple.move_block_directions,
-	"moveSpeed" => Dict{String, Number}(
-		"Slow" => 60.0,
-		"Fast" => 75.0
-	)
+    "moveSpeed" => Dict{String,Number}(
+        "Slow" => 60.0,
+        "Fast" => 75.0,
+    ),
 )
 Ahorn.minimumSize(entity::CassetteMoveBlock) = 16, 16
 Ahorn.resizable(entity::CassetteMoveBlock) = true, true
 
 Ahorn.selection(entity::CassetteMoveBlock) = Ahorn.getEntityRectangle(entity)
 
-const arrows = Dict{String, String}(
-    "up" => "objects/CommunalHelper/cassetteMoveBlock/arrow02",
-    "left" => "objects/CommunalHelper/cassetteMoveBlock/arrow04",
+const arrows = Dict{String,String}(
+    "up"    => "objects/CommunalHelper/cassetteMoveBlock/arrow02",
+    "left"  => "objects/CommunalHelper/cassetteMoveBlock/arrow04",
     "right" => "objects/CommunalHelper/cassetteMoveBlock/arrow00",
-    "down" => "objects/CommunalHelper/cassetteMoveBlock/arrow06",
+    "down"  => "objects/CommunalHelper/cassetteMoveBlock/arrow06",
 )
 
 const block = "objects/cassetteblock/solid"

--- a/Ahorn/entities/cassetteBlocks/CassetteSwapBlock.jl
+++ b/Ahorn/entities/cassetteBlocks/CassetteSwapBlock.jl
@@ -5,40 +5,43 @@ using Ahorn.CommunalHelper
 
 function swapFinalizer(entity)
     x, y = Ahorn.position(entity)
-
     width = Int(get(entity.data, "width", 8))
-    height = Int(get(entity.data, "height", 8))
 
     entity.data["nodes"] = [(x + width, y)]
 end
 
-@mapdef Entity "CommunalHelper/CassetteSwapBlock" CassetteSwapBlock(x::Integer, y::Integer, 
-    width::Integer=Maple.defaultBlockWidth, height::Integer=Maple.defaultBlockHeight,
-    index::Integer=0, tempo::Number=1.0, noReturn::Bool=false,
-    customColor="") 
+@mapdef Entity "CommunalHelper/CassetteSwapBlock" CassetteSwapBlock(
+    x::Integer,
+    y::Integer,
+    width::Integer=Maple.defaultBlockWidth,
+    height::Integer=Maple.defaultBlockHeight,
+    index::Integer=0,
+    tempo::Number=1.0,
+    noReturn::Bool=false,
+    customColor="",
+)
 
-const ropeColors = Dict{Int, Ahorn.colorTupleType}(
+const ropeColors = Dict{Int,Ahorn.colorTupleType}(
     1 => (194, 116, 171, 255) ./ 255,
-	2 => (227, 214, 148, 255) ./ 255,
-	3 => (128, 224, 141, 255) ./ 255
+    2 => (227, 214, 148, 255) ./ 255,
+    3 => (128, 224, 141, 255) ./ 255,
 )
 
 const defaultRopeColor = (110, 189, 245, 255) ./ 255
-
 
 const placements = Ahorn.PlacementDict(
     "Cassette Swap Block ($index - $color) (Communal Helper)" => Ahorn.EntityPlacement(
         CassetteSwapBlock,
         "rectangle",
-        Dict{String, Any}(
+        Dict{String,Any}(
             "index" => index,
         ),
-        swapFinalizer
+        swapFinalizer,
     ) for (color, index) in cassetteColorNames
 )
 
-Ahorn.editingOptions(entity::CassetteSwapBlock) = Dict{String, Any}(
-    "index" => cassetteColorNames
+Ahorn.editingOptions(entity::CassetteSwapBlock) = Dict{String,Any}(
+    "index" => cassetteColorNames,
 )
 
 Ahorn.nodeLimits(entity::Maple.SwapBlock) = 1, 1
@@ -53,7 +56,10 @@ function Ahorn.selection(entity::CassetteSwapBlock)
     width = Int(get(entity.data, "width", 8))
     height = Int(get(entity.data, "height", 8))
 
-    return [Ahorn.Rectangle(x, y, width, height), Ahorn.Rectangle(stopX, stopY, width, height)]
+    return [
+        Ahorn.Rectangle(x, y, width, height),
+        Ahorn.Rectangle(stopX, stopY, width, height),
+    ]
 end
 
 const block = "objects/cassetteblock/solid"
@@ -104,8 +110,11 @@ function Ahorn.renderSelectedAbs(ctx::Ahorn.Cairo.CairoContext, entity::Cassette
     Ahorn.drawArrow(ctx, startX + width / 2, startY + height / 2, stopX + width / 2, stopY + height / 2, Ahorn.colors.selection_selected_fc, headLength=6)
 end
 
-
-function Ahorn.renderAbs(ctx::Ahorn.Cairo.CairoContext, entity::CassetteSwapBlock, room::Maple.Room)
+function Ahorn.renderAbs(
+    ctx::Ahorn.Cairo.CairoContext,
+    entity::CassetteSwapBlock,
+    room::Maple.Room,
+)
     startX, startY = Ahorn.position(entity)
     stopX, stopY = Int.(entity.data["nodes"][1])
 

--- a/Ahorn/entities/cassetteBlocks/CassetteZipMover.jl
+++ b/Ahorn/entities/cassetteBlocks/CassetteZipMover.jl
@@ -3,16 +3,24 @@ module CommunalHelperCassetteZipMover
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
 
-@mapdef Entity "CommunalHelper/CassetteZipMover" CassetteZipMover(x::Integer, y::Integer, 
-    width::Integer=Maple.defaultBlockWidth, height::Integer=Maple.defaultBlockHeight,
-    index::Integer=0, tempo::Number=1.0, permanent::Bool=false,
-    waiting::Bool=false, ticking::Bool=false, noReturn::Bool=false,
-    customColor="") 
+@mapdef Entity "CommunalHelper/CassetteZipMover" CassetteZipMover(
+    x::Integer,
+    y::Integer,
+    width::Integer=Maple.defaultBlockWidth,
+    height::Integer=Maple.defaultBlockHeight,
+    index::Integer=0,
+    tempo::Number=1.0,
+    permanent::Bool=false,
+    waiting::Bool=false,
+    ticking::Bool=false,
+    noReturn::Bool=false,
+    customColor="",
+)
 
-const ropeColors = Dict{Int, Ahorn.colorTupleType}(
+const ropeColors = Dict{Int,Ahorn.colorTupleType}(
     1 => (194, 116, 171, 255) ./ 255,
-	2 => (227, 214, 148, 255) ./ 255,
-	3 => (128, 224, 141, 255) ./ 255
+    2 => (227, 214, 148, 255) ./ 255,
+    3 => (128, 224, 141, 255) ./ 255,
 )
 
 const defaultRopeColor = (110, 189, 245, 255) ./ 255
@@ -21,17 +29,20 @@ const placements = Ahorn.PlacementDict(
     "Cassette Zip Mover ($index - $color) (Communal Helper)" => Ahorn.EntityPlacement(
         CassetteZipMover,
         "rectangle",
-        Dict{String, Any}(
+        Dict{String,Any}(
             "index" => index,
         ),
-        function(entity)
-            entity.data["nodes"] = [(Int(entity.data["x"]) + Int(entity.data["width"]) + 8, Int(entity.data["y"]))]
-        end
+        function (entity)
+            entity.data["nodes"] = [(
+                Int(entity.data["x"]) + Int(entity.data["width"]) + 8,
+                Int(entity.data["y"]),
+            )]
+        end,
     ) for (color, index) in cassetteColorNames
 )
 
-Ahorn.editingOptions(entity::CassetteZipMover) = Dict{String, Any}(
-    "index" => cassetteColorNames
+Ahorn.editingOptions(entity::CassetteZipMover) = Dict{String,Any}(
+    "index" => cassetteColorNames,
 )
 
 Ahorn.nodeLimits(entity::CassetteZipMover) = 1, -1
@@ -46,17 +57,17 @@ function Ahorn.selection(entity::CassetteZipMover)
     height = Int(get(entity.data, "height", 8))
 
     res = [Ahorn.Rectangle(x, y, width, height)]
-	
-	for node in get(entity.data, "nodes", ())
+
+    for node in get(entity.data, "nodes", ())
         nx, ny = Int.(node)
-		
-		push!(res, Ahorn.Rectangle(nx + floor(Int, width / 2) - 5, ny + floor(Int, height / 2) - 5, 10, 10))
-	end
-	
-	return res
+
+        push!(res, Ahorn.Rectangle(nx + floor(Int, width / 2) - 5, ny + floor(Int, height / 2) - 5, 10, 10))
+    end
+
+    return res
 end
 
-const textures = "objects/cassetteblock/solid", "objects/CommunalHelper/cassetteZipMover/cog"
+const cog = "objects/CommunalHelper/cassetteZipMover/cog"
 const crossSprite = "objects/CommunalHelper/cassetteMoveBlock/x"
 
 function renderCassetteZipMover(ctx::Ahorn.Cairo.CairoContext, entity::CassetteZipMover)
@@ -65,8 +76,6 @@ function renderCassetteZipMover(ctx::Ahorn.Cairo.CairoContext, entity::CassetteZ
 
     width = Int(get(entity.data, "width", 32))
     height = Int(get(entity.data, "height", 32))
-
-    block, cog = textures
 
     index = Int(get(entity.data, "index", 0))
 
@@ -82,39 +91,39 @@ function renderCassetteZipMover(ctx::Ahorn.Cairo.CairoContext, entity::CassetteZ
     ropeColor = hasCustomColor ? color : get(ropeColors, index, defaultRopeColor)
 
     # Iteration through all the nodes
-	for node in get(entity.data, "nodes", ())
+    for node in get(entity.data, "nodes", ())
         nx, ny = Int.(node)
-		cx, cy = px + width / 2, py + height / 2
-		cnx, cny = nx + width / 2, ny + height / 2
+        cx, cy = px + width / 2, py + height / 2
+        cnx, cny = nx + width / 2, ny + height / 2
 
-		length = sqrt((px - nx)^2 + (py - ny)^2)
-		theta = atan(cny - cy, cnx - cx)
+        length = sqrt((px - nx)^2 + (py - ny)^2)
+        theta = atan(cny - cy, cnx - cx)
 
-		Ahorn.Cairo.save(ctx)
+        Ahorn.Cairo.save(ctx)
 
-		Ahorn.translate(ctx, cx, cy)
-		Ahorn.rotate(ctx, theta)
+        Ahorn.translate(ctx, cx, cy)
+        Ahorn.rotate(ctx, theta)
 
-		Ahorn.setSourceColor(ctx, ropeColor)
-		Ahorn.set_antialias(ctx, 1)
-		Ahorn.set_line_width(ctx, 1);
+        Ahorn.setSourceColor(ctx, ropeColor)
+        Ahorn.set_antialias(ctx, 1)
+        Ahorn.set_line_width(ctx, 1)
 
-		# Offset for rounding errors
-		Ahorn.move_to(ctx, 0, 4 + (theta <= 0))
-		Ahorn.line_to(ctx, length, 4 + (theta <= 0))
+        # Offset for rounding errors
+        Ahorn.move_to(ctx, 0, 4 + (theta <= 0))
+        Ahorn.line_to(ctx, length, 4 + (theta <= 0))
 
-		Ahorn.move_to(ctx, 0, -4 - (theta > 0))
-		Ahorn.line_to(ctx, length, -4 - (theta > 0))
+        Ahorn.move_to(ctx, 0, -4 - (theta > 0))
+        Ahorn.line_to(ctx, length, -4 - (theta > 0))
 
-		Ahorn.stroke(ctx)
+        Ahorn.stroke(ctx)
 
-		Ahorn.Cairo.restore(ctx)
-		
-		Ahorn.drawSprite(ctx, cog, cnx, cny, tint=color)
-		
-		px, py = nx, ny
-	end
-    
+        Ahorn.Cairo.restore(ctx)
+
+        Ahorn.drawSprite(ctx, cog, cnx, cny, tint=color)
+
+        px, py = nx, ny
+    end
+
     renderCassetteBlock(ctx, x, y, width, height, index, color)
 
     if Bool(get(entity.data, "noReturn", false))

--- a/Ahorn/entities/cassetteBlocks/CustomCassetteBlock.jl
+++ b/Ahorn/entities/cassetteBlocks/CustomCassetteBlock.jl
@@ -3,26 +3,28 @@ module CommunalHelperCustomCassetteBlock
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
 
-@mapdef Entity "CommunalHelper/CustomCassetteBlock" CustomCassetteBlock(x::Integer, 
-                                                                  y::Integer, 
-                                                                  width::Integer=Maple.defaultBlockWidth, 
-                                                                  height::Integer=Maple.defaultBlockHeight,
-                                                                  index::Integer=0,
-                                                                  tempo::Number=1.0,
-                                                                  customColor="") 
+@mapdef Entity "CommunalHelper/CustomCassetteBlock" CustomCassetteBlock(
+    x::Integer,
+    y::Integer,
+    width::Integer=Maple.defaultBlockWidth,
+    height::Integer=Maple.defaultBlockHeight,
+    index::Integer=0,
+    tempo::Number=1.0,
+    customColor="",
+)
 
 const placements = Ahorn.PlacementDict(
     "Custom Cassette Block ($index - $color) (Communal Helper)" => Ahorn.EntityPlacement(
         CustomCassetteBlock,
         "rectangle",
-        Dict{String, Any}(
+        Dict{String,Any}(
             "index" => index,
-        )
+        ),
     ) for (color, index) in cassetteColorNames
 )
 
-Ahorn.editingOptions(entity::CustomCassetteBlock) = Dict{String, Any}(
-    "index" => cassetteColorNames
+Ahorn.editingOptions(entity::CustomCassetteBlock) = Dict{String,Any}(
+    "index" => cassetteColorNames,
 )
 
 Ahorn.nodeLimits(entity::CustomCassetteBlock) = 1, 1

--- a/Ahorn/entities/cassetteBlocks/ManualCassetteController.jl
+++ b/Ahorn/entities/cassetteBlocks/ManualCassetteController.jl
@@ -3,16 +3,20 @@ module CommunalHelperManualCassetteController
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
 
-@mapdef Entity "CommunalHelper/ManualCassetteController" ManualCassetteController(x::Integer, y::Integer, startIndex::Int=0) 
+@mapdef Entity "CommunalHelper/ManualCassetteController" ManualCassetteController(
+    x::Integer,
+    y::Integer,
+    startIndex::Int=0,
+)
 
 const placements = Ahorn.PlacementDict(
     "Manual Cassette Controller (Communal Helper)" => Ahorn.EntityPlacement(
-        ManualCassetteController
-    )
+        ManualCassetteController,
+    ),
 )
 
-Ahorn.editingOptions(entity::ManualCassetteController) = Dict{String, Any}(
-    "startIndex" => cassetteColorNames
+Ahorn.editingOptions(entity::ManualCassetteController) = Dict{String,Any}(
+    "startIndex" => cassetteColorNames,
 )
 
 const alt = rand(1:100) == 42

--- a/Ahorn/entities/connectedBlocks/ConnectedMoveBlock.jl
+++ b/Ahorn/entities/connectedBlocks/ConnectedMoveBlock.jl
@@ -3,34 +3,39 @@ module CommunalHelperConnectedMoveBlock
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
 
-@mapdef Entity "CommunalHelper/ConnectedMoveBlock" ConnectedMoveBlock(x::Integer, y::Integer,
-	width::Integer = Maple.defaultBlockWidth, height::Integer = Maple.defaultBlockWidth,
-    direction::String="Right", moveSpeed::Number=60.0,
-    customBlockTexture::String = "")
+@mapdef Entity "CommunalHelper/ConnectedMoveBlock" ConnectedMoveBlock(
+    x::Integer,
+    y::Integer,
+    width::Integer=Maple.defaultBlockWidth,
+    height::Integer=Maple.defaultBlockWidth,
+    direction::String="Right",
+    moveSpeed::Number=60.0,
+    customBlockTexture::String="",
+)
 
 const placements = Ahorn.PlacementDict(
     "Connected Move Block ($direction) (Communal Helper)" => Ahorn.EntityPlacement(
         ConnectedMoveBlock,
         "rectangle",
-        Dict{String, Any}(
-            "direction" => direction
-        )
+        Dict{String,Any}(
+            "direction" => direction,
+        ),
     ) for direction in Maple.move_block_directions
 )
 
-Ahorn.editingOptions(entity::ConnectedMoveBlock) = Dict{String, Any}(
+Ahorn.editingOptions(entity::ConnectedMoveBlock) = Dict{String,Any}(
     "direction" => Maple.move_block_directions,
-	"moveSpeed" => Dict{String, Number}(
-		"Slow" => 60.0,
-		"Fast" => 75.0
-	)
+    "moveSpeed" => Dict{String,Number}(
+        "Slow" => 60.0,
+        "Fast" => 75.0,
+    ),
 )
 Ahorn.minimumSize(entity::ConnectedMoveBlock) = 16, 16
 Ahorn.resizable(entity::ConnectedMoveBlock) = true, true
 
 Ahorn.selection(entity::ConnectedMoveBlock) = Ahorn.getEntityRectangle(entity)
 
-const arrows = Dict{String, String}(
+const arrows = Dict{String,String}(
     "up" => "objects/moveBlock/arrow02",
     "left" => "objects/moveBlock/arrow04",
     "right" => "objects/moveBlock/arrow00",
@@ -58,16 +63,16 @@ function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::ConnectedMoveBlock,
     direction = lowercase(get(entity.data, "direction", "up"))
     arrowSprite = Ahorn.getSprite(arrows[lowercase(direction)], "Gameplay")
 
-    block, innerCorners = "objects/moveBlock/base",  "objects/CommunalHelper/connectedMoveBlock/innerCorners"
+    block, innerCorners = "objects/moveBlock/base", "objects/CommunalHelper/connectedMoveBlock/innerCorners"
 
     rects = getExtensionRectangles(room)
     rect = Ahorn.Rectangle(x, y, width, height)
-	if !(rect in rects)
+    if !(rect in rects)
         push!(rects, rect)
     end
 
     for i in 1:tileWidth, j in 1:tileHeight
-		drawX, drawY = (i - 1) * 8, (j - 1) * 8
+        drawX, drawY = (i - 1) * 8, (j - 1) * 8
 
         closedLeft = !notAdjacent(entity, drawX - 8, drawY, rects)
         closedRight = !notAdjacent(entity, drawX + 8, drawY, rects)
@@ -76,7 +81,6 @@ function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::ConnectedMoveBlock,
         completelyClosed = closedLeft && closedRight && closedUp && closedDown
 
         if completelyClosed
-
             if notAdjacent(entity, drawX + 8, drawY - 8, rects)
                 # up right
                 Ahorn.drawImage(ctx, innerCorners, drawX, drawY, 8, 0, 8, 8)
@@ -96,7 +100,6 @@ function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::ConnectedMoveBlock,
             else
                 # entirely surrounded, fill tile
                 Ahorn.drawImage(ctx, block, drawX, drawY, 8, 8, 8, 8)
-
             end
         else
             if closedLeft && closedRight && !closedUp && closedDown

--- a/Ahorn/entities/connectedBlocks/ConnectedSolidExtension.jl
+++ b/Ahorn/entities/connectedBlocks/ConnectedSolidExtension.jl
@@ -1,17 +1,20 @@
-﻿module CommunalHelperConnectedSolidExtension
+module CommunalHelperConnectedSolidExtension
 
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
 
 @mapdef Entity "CommunalHelper/SolidExtension" SolidExtension(
-			x::Integer, y::Integer,
-			width::Integer=16, height::Integer=16)
+    x::Integer,
+    y::Integer,
+    width::Integer=16,
+    height::Integer=16,
+)
 
 const placements = Ahorn.PlacementDict(
     "Connected Solid Extension (Communal Helper)" => Ahorn.EntityPlacement(
         SolidExtension,
-		"rectangle"
-    )
+        "rectangle",
+    ),
 )
 
 Ahorn.minimumSize(entity::SolidExtension) = 16, 16
@@ -19,20 +22,20 @@ Ahorn.resizable(entity::SolidExtension) = true, true
 
 function Ahorn.selection(entity::SolidExtension)
     x, y = Ahorn.position(entity)
-	
+
     width = Int(get(entity.data, "width", 8))
     height = Int(get(entity.data, "height", 8))
-	
-	return Ahorn.Rectangle(x, y, width, height)
+
+    return Ahorn.Rectangle(x, y, width, height)
 end
 
 const block = "objects/CommunalHelper/connectedZipMover/extension_outline"
 
 const connectTo = [
-    "CommunalHelper/SolidExtension", 
+    "CommunalHelper/SolidExtension",
     "CommunalHelper/ConnectedZipMover",
     "CommunalHelper/ConnectedSwapBlock",
-    "CommunalHelper/ConnectedMoveBlock"
+    "CommunalHelper/ConnectedMoveBlock",
 ]
 
 # Gets rectangles from Solid Extensions & Connected Solids
@@ -41,14 +44,17 @@ function getSolidRectangles(room::Maple.Room)
     rects = []
 
     for e in entities
-        push!(rects, Ahorn.Rectangle(
-            Int(get(e.data, "x", 0)),
-            Int(get(e.data, "y", 0)),
-            Int(get(e.data, "width", 8)),
-            Int(get(e.data, "height", 8))
-        ))
+        push!(
+            rects,
+            Ahorn.Rectangle(
+                Int(get(e.data, "x", 0)),
+                Int(get(e.data, "y", 0)),
+                Int(get(e.data, "width", 8)),
+                Int(get(e.data, "height", 8)),
+            ),
+        )
     end
-        
+
     return rects
 end
 
@@ -64,7 +70,7 @@ function Ahorn.renderAbs(ctx::Ahorn.Cairo.CairoContext, entity::SolidExtension, 
     tileHeight = ceil(Int, height / 8)
 
     rect = Ahorn.Rectangle(x, y, width, height)
-	if !(rect in rects)
+    if !(rect in rects)
         push!(rects, rect)
     end
 
@@ -76,7 +82,7 @@ function Ahorn.renderAbs(ctx::Ahorn.Cairo.CairoContext, entity::SolidExtension, 
         closedUp = !notAdjacent(x, y, drawX, drawY - 8, rects)
         closedDown = !notAdjacent(x, y, drawX, drawY + 8, rects)
         completelyClosed = closedLeft && closedRight && closedUp && closedDown
-        
+
         if completelyClosed
             if notAdjacent(x, y, drawX + 8, drawY + 8, rects)
                 # down right
@@ -93,10 +99,8 @@ function Ahorn.renderAbs(ctx::Ahorn.Cairo.CairoContext, entity::SolidExtension, 
             elseif notAdjacent(x, y, drawX - 8, drawY - 8, rects)
                 # up left
                 Ahorn.drawImage(ctx, block, x + drawX - 7, y + drawY - 7, 16, 16, 8, 8)
-                
             end
-
-		else 
+        else
             if closedLeft && closedRight && !closedUp && closedDown
                 Ahorn.drawImage(ctx, block, x + drawX, y + drawY, 8, 0, 8, 8)
 
@@ -122,7 +126,6 @@ function Ahorn.renderAbs(ctx::Ahorn.Cairo.CairoContext, entity::SolidExtension, 
                 Ahorn.drawImage(ctx, block, x + drawX, y + drawY, 16, 16, 8, 8)
             end
         end
-
     end
 end
 

--- a/Ahorn/entities/connectedBlocks/ConnectedSwapBlock.jl
+++ b/Ahorn/entities/connectedBlocks/ConnectedSwapBlock.jl
@@ -5,33 +5,34 @@ using Ahorn.CommunalHelper
 
 function swapFinalizer(entity)
     x, y = Ahorn.position(entity)
-
     width = Int(get(entity.data, "width", 8))
-    height = Int(get(entity.data, "height", 8))
 
     entity.data["nodes"] = [(x + width, y)]
 end
 
 @mapdef Entity "CommunalHelper/ConnectedSwapBlock" ConnectedSwapBlock(
-                            x::Integer, y::Integer,
-                            width::Integer = Maple.defaultBlockWidth, 
-                            height::Integer = Maple.defaultBlockWidth,
-                            theme::String = "Normal",
-                            customGreenBlockTexture::String = "", customRedBlockTexture::String = "")
+    x::Integer,
+    y::Integer,
+    width::Integer=Maple.defaultBlockWidth,
+    height::Integer=Maple.defaultBlockWidth,
+    theme::String="Normal",
+    customGreenBlockTexture::String="",
+    customRedBlockTexture::String="",
+)
 
 const placements = Ahorn.PlacementDict(
     "Connected Swap Block ($theme) (Communal Helper)" => Ahorn.EntityPlacement(
         ConnectedSwapBlock,
         "rectangle",
-        Dict{String, Any}(
-            "theme" => theme
+        Dict{String,Any}(
+            "theme" => theme,
         ),
-        swapFinalizer
+        swapFinalizer,
     ) for theme in Maple.swap_block_themes
 )
 
-Ahorn.editingOptions(entity::ConnectedSwapBlock) = Dict{String, Any}(
-    "theme" => Maple.swap_block_themes
+Ahorn.editingOptions(entity::ConnectedSwapBlock) = Dict{String,Any}(
+    "theme" => Maple.swap_block_themes,
 )
 
 Ahorn.nodeLimits(entity::ConnectedSwapBlock) = 1, 1
@@ -46,23 +47,22 @@ function Ahorn.selection(entity::ConnectedSwapBlock)
     width = Int(get(entity.data, "width", 8))
     height = Int(get(entity.data, "height", 8))
 
-    return [Ahorn.Rectangle(x, y, width, height), Ahorn.Rectangle(stopX, stopY, width, height)]
+    return [
+        Ahorn.Rectangle(x, y, width, height),
+        Ahorn.Rectangle(stopX, stopY, width, height),
+    ]
 end
 
 function getTextures(entity::ConnectedSwapBlock)
     theme = lowercase(get(entity, "theme", "normal"))
+    themePath = (theme == "normal") ? "" : string(theme, "/")
 
-    if theme == "moon"
-        return "objects/swapblock/moon/blockRed", 
-               "objects/swapblock/moon/target", 
-               "objects/swapblock/moon/midBlockRed00",
-               "objects/CommunalHelper/connectedSwapBlock/moon/innerCornersRed"
-    end
-
-    return "objects/swapblock/blockRed", 
-           "objects/swapblock/target", 
-           "objects/swapblock/midBlockRed00",
-           "objects/CommunalHelper/connectedSwapBlock/innerCornersRed"
+    return (
+        "objects/swapblock/$(themePath)blockRed",
+        "objects/swapblock/$(themePath)target",
+        "objects/swapblock/$(themePath)midBlockRed00",
+        "objects/CommunalHelper/connectedSwapBlock/$(themePath)innerCornersRed",
+    )
 end
 
 function renderTrail(ctx, x::Number, y::Number, width::Number, height::Number, trail::String)
@@ -91,21 +91,21 @@ end
 
 function renderSwapBlock(ctx::Ahorn.Cairo.CairoContext, x::Number, y::Number, width::Number, height::Number, midResource::String, block::String, innerCorners::String, entity::ConnectedSwapBlock, room::Maple.Room)
     midSprite = Ahorn.getSprite(midResource, "Gameplay")
-    
+
     tileWidth = div(width, 8)
     tileHeight = div(height, 8)
-    
+
     rects = getExtensionRectangles(room)
     rx, ry = Ahorn.position(entity)
     rect = Ahorn.Rectangle(rx, ry, width, height)
-	
-	if !(rect in rects)
+
+    if !(rect in rects)
         push!(rects, rect)
     end
 
     for i in 1:tileWidth, j in 1:tileHeight
-		drawX, drawY = (i - 1) * 8, (j - 1) * 8
-		
+        drawX, drawY = (i - 1) * 8, (j - 1) * 8
+
         closedLeft = !notAdjacent(entity, drawX - 8, drawY, rects)
         closedRight = !notAdjacent(entity, drawX + 8, drawY, rects)
         closedUp = !notAdjacent(entity, drawX, drawY - 8, rects)
@@ -113,7 +113,6 @@ function renderSwapBlock(ctx::Ahorn.Cairo.CairoContext, x::Number, y::Number, wi
         completelyClosed = closedLeft && closedRight && closedUp && closedDown
 
         if completelyClosed
-            
             if notAdjacent(entity, drawX + 8, drawY - 8, rects)
                 # up right
                 Ahorn.drawImage(ctx, innerCorners, x + drawX, y + drawY, 8, 0, 8, 8)
@@ -133,9 +132,8 @@ function renderSwapBlock(ctx::Ahorn.Cairo.CairoContext, x::Number, y::Number, wi
             else
                 # entirely surrounded, fill tile
                 Ahorn.drawImage(ctx, block, x + drawX, y + drawY, 8, 8, 8, 8)
-
             end
-        else 
+        else
             if closedLeft && closedRight && !closedUp && closedDown
                 Ahorn.drawImage(ctx, block, x + drawX, y + drawY, 8, 0, 8, 8)
 
@@ -167,22 +165,19 @@ function renderSwapBlock(ctx::Ahorn.Cairo.CairoContext, x::Number, y::Number, wi
 end
 
 function Ahorn.renderSelectedAbs(ctx::Ahorn.Cairo.CairoContext, entity::ConnectedSwapBlock, room::Maple.Room)
-    sprite = get(entity.data, "sprite", "block")
     startX, startY = Int(entity.data["x"]), Int(entity.data["y"])
     stopX, stopY = Int.(entity.data["nodes"][1])
 
     width = Int(get(entity.data, "width", 32))
     height = Int(get(entity.data, "height", 32))
 
-    frame, trail, mid, innerCorners = getTextures(entity)
+    frame, _, mid, innerCorners = getTextures(entity)
 
     renderSwapBlock(ctx, stopX, stopY, width, height, mid, frame, innerCorners, entity, room)
     Ahorn.drawArrow(ctx, startX + width / 2, startY + height / 2, stopX + width / 2, stopY + height / 2, Ahorn.colors.selection_selected_fc, headLength=6)
 end
 
 function Ahorn.renderAbs(ctx::Ahorn.Cairo.CairoContext, entity::ConnectedSwapBlock, room::Maple.Room)
-    sprite = get(entity.data, "sprite", "block")
-
     startX, startY = Int(entity.data["x"]), Int(entity.data["y"])
     stopX, stopY = Int.(entity.data["nodes"][1])
 

--- a/Ahorn/entities/connectedBlocks/ConnectedZipMover.jl
+++ b/Ahorn/entities/connectedBlocks/ConnectedZipMover.jl
@@ -6,30 +6,36 @@ using Ahorn.CommunalHelper
 const theme_options = String["Normal", "Moon", "Cliffside"]
 
 @mapdef Entity "CommunalHelper/ConnectedZipMover" ConnectedZipMover(
-			x::Integer, y::Integer,
-			width::Integer=16, height::Integer=16,
-			theme::String="Normal",
-			permanent::Bool=false,
-			waiting::Bool=false,
-			ticking::Bool=false,
-			nodes::Array{Tuple{Integer, Integer}, 1}=Tuple{Integer, Integer}[],
-            customBlockTexture::String = "")
+    x::Integer,
+    y::Integer,
+    width::Integer=16,
+    height::Integer=16,
+    theme::String="Normal",
+    permanent::Bool=false,
+    waiting::Bool=false,
+    ticking::Bool=false,
+    nodes::Array{Tuple{Integer,Integer},1}=Tuple{Integer,Integer}[],
+    customBlockTexture::String="",
+)
 
 const placements = Ahorn.PlacementDict(
     "Connected Zip Mover ($(uppercasefirst(theme))) (Communal Helper)" => Ahorn.EntityPlacement(
         ConnectedZipMover,
-		"rectangle",
-		Dict{String, Any}(
-			"theme" => theme
+        "rectangle",
+        Dict{String,Any}(
+            "theme" => theme,
         ),
-		function(entity)
-            entity.data["nodes"] = [(Int(entity.data["x"]) + Int(entity.data["width"]) + 8, Int(entity.data["y"]))]
-        end
+        function (entity)
+            entity.data["nodes"] = [(
+                Int(entity.data["x"]) + Int(entity.data["width"]) + 8,
+                Int(entity.data["y"]),
+            )]
+        end,
     ) for theme in theme_options
 )
 
-Ahorn.editingOptions(entity::ConnectedZipMover) = Dict{String, Any}(
-    "theme" => theme_options
+Ahorn.editingOptions(entity::ConnectedZipMover) = Dict{String,Any}(
+    "theme" => theme_options,
 )
 
 Ahorn.nodeLimits(entity::ConnectedZipMover) = 1, -1
@@ -44,46 +50,36 @@ function Ahorn.selection(entity::ConnectedZipMover)
     height = Int(get(entity.data, "height", 8))
 
     res = [Ahorn.Rectangle(x, y, width, height)]
-	
-	for node in get(entity.data, "nodes", ())
+
+    for node in get(entity.data, "nodes", ())
         nx, ny = Int.(node)
-		
-		push!(res, Ahorn.Rectangle(nx + floor(Int, width / 2) - 5, ny + floor(Int, height / 2) - 5, 10, 10))
-	end
-	
-	return res
+
+        push!(res, Ahorn.Rectangle(nx + floor(Int, width / 2) - 5, ny + floor(Int, height / 2) - 5, 10, 10))
+    end
+
+    return res
 end
 
 function getTextures(entity::ConnectedZipMover)
     theme = lowercase(get(entity, "theme", "normal"))
-    
-    if theme == "moon"
-        return "objects/zipmover/moon/block", 
-               "objects/zipmover/moon/light01", 
-               "objects/zipmover/moon/cog",
-               "objects/CommunalHelper/connectedZipMover/moon/innerCorners"
-    end
-	
-	if theme == "cliffside"
-		return "objects/CommunalHelper/connectedZipMover/cliffside/block", 
-			   "objects/CommunalHelper/connectedZipMover/cliffside/light01", 
-               "objects/CommunalHelper/connectedZipMover/cliffside/cog",
-               "objects/CommunalHelper/connectedZipMover/cliffside/innerCorners"
-	end
+    folder = theme == "cliffside" ? "CommunalHelper/connectedZipMover" : "zipmover"
+    themePath = (theme == "normal") ? "" : string(theme, "/")
 
-    return "objects/zipmover/block", 
-           "objects/zipmover/light01",
-           "objects/zipmover/cog",
-           "objects/CommunalHelper/connectedZipMover/innerCorners"
+    return (
+        "objects/$(folder)/$(themePath)block",
+        "objects/$(folder)/$(themePath)light01",
+        "objects/$(folder)/$(themePath)cog",
+        "objects/$(folder)/$(themePath)innerCorners"
+    )
 end
 
 const ropeColor = (102, 57, 49) ./ 255
 
 function renderZipMover(ctx::Ahorn.Cairo.CairoContext, entity::ConnectedZipMover, room::Maple.Room)
-	rects = getExtensionRectangles(room)
-	
+    rects = getExtensionRectangles(room)
+
     x, y = Ahorn.position(entity)
-	px, py = x, y
+    px, py = x, y
 
     width = Int(get(entity.data, "width", 32))
     height = Int(get(entity.data, "height", 32))
@@ -93,53 +89,52 @@ function renderZipMover(ctx::Ahorn.Cairo.CairoContext, entity::ConnectedZipMover
 
     tileWidth = div(width, 8)
     tileHeight = div(height, 8)
-	
-	rect = Ahorn.Rectangle(x, y, width, height)
-	
-	if !(rect in rects)
+
+    rect = Ahorn.Rectangle(x, y, width, height)
+
+    if !(rect in rects)
         push!(rects, rect)
     end
-	
-	# Iteration through all the nodes
-	for node in get(entity.data, "nodes", ())
+
+    # Iteration through all the nodes
+    for node in get(entity.data, "nodes", ())
         nx, ny = Int.(node)
-		cx, cy = px + width / 2, py + height / 2
-		cnx, cny = nx + width / 2, ny + height / 2
+        cx, cy = px + width / 2, py + height / 2
+        cnx, cny = nx + width / 2, ny + height / 2
 
-		length = sqrt((px - nx)^2 + (py - ny)^2)
-		theta = atan(cny - cy, cnx - cx)
+        length = sqrt((px - nx)^2 + (py - ny)^2)
+        theta = atan(cny - cy, cnx - cx)
 
-		Ahorn.Cairo.save(ctx)
+        Ahorn.Cairo.save(ctx)
 
-		Ahorn.translate(ctx, cx, cy)
-		Ahorn.rotate(ctx, theta)
+        Ahorn.translate(ctx, cx, cy)
+        Ahorn.rotate(ctx, theta)
 
-		Ahorn.setSourceColor(ctx, ropeColor)
-		Ahorn.set_antialias(ctx, 1)
-		Ahorn.set_line_width(ctx, 1);
+        Ahorn.setSourceColor(ctx, ropeColor)
+        Ahorn.set_antialias(ctx, 1)
+        Ahorn.set_line_width(ctx, 1)
 
-		# Offset for rounding errors
-		Ahorn.move_to(ctx, 0, 4 + (theta <= 0))
-		Ahorn.line_to(ctx, length, 4 + (theta <= 0))
+        # Offset for rounding errors
+        Ahorn.move_to(ctx, 0, 4 + (theta <= 0))
+        Ahorn.line_to(ctx, length, 4 + (theta <= 0))
 
-		Ahorn.move_to(ctx, 0, -4 - (theta > 0))
-		Ahorn.line_to(ctx, length, -4 - (theta > 0))
+        Ahorn.move_to(ctx, 0, -4 - (theta > 0))
+        Ahorn.line_to(ctx, length, -4 - (theta > 0))
 
-		Ahorn.stroke(ctx)
+        Ahorn.stroke(ctx)
 
-		Ahorn.Cairo.restore(ctx)
-		
-		Ahorn.drawSprite(ctx, cog, cnx, cny)
-		
-		px, py = nx, ny
-	
-	end
-	
-	Ahorn.drawRectangle(ctx, x + 2, y + 2, width - 4, height - 4, (0.0, 0.0, 0.0, 1.0))
-	
-	for i in 1:tileWidth, j in 1:tileHeight
-		drawX, drawY = (i - 1) * 8, (j - 1) * 8
-		
+        Ahorn.Cairo.restore(ctx)
+
+        Ahorn.drawSprite(ctx, cog, cnx, cny)
+
+        px, py = nx, ny
+    end
+
+    Ahorn.drawRectangle(ctx, x + 2, y + 2, width - 4, height - 4, (0.0, 0.0, 0.0, 1.0))
+
+    for i in 1:tileWidth, j in 1:tileHeight
+        drawX, drawY = (i - 1) * 8, (j - 1) * 8
+
         closedLeft = !notAdjacent(entity, drawX - 8, drawY, rects)
         closedRight = !notAdjacent(entity, drawX + 8, drawY, rects)
         closedUp = !notAdjacent(entity, drawX, drawY - 8, rects)
@@ -164,7 +159,7 @@ function renderZipMover(ctx::Ahorn.Cairo.CairoContext, entity::ConnectedZipMover
                 # down left
                 Ahorn.drawImage(ctx, incorners, x + drawX, y + drawY, 0, 8, 8, 8)
             end
-        else 
+        else
             if closedLeft && closedRight && !closedUp && closedDown
                 Ahorn.drawRectangle(ctx, x + drawX, y + drawY, 8, 8, (0.0, 0.0, 0.0, 1.0))
                 Ahorn.drawImage(ctx, block, x + drawX, y + drawY, 8, 0, 8, 8)
@@ -195,11 +190,10 @@ function renderZipMover(ctx::Ahorn.Cairo.CairoContext, entity::ConnectedZipMover
             end
         end
     end
-    
+
     Ahorn.drawImage(ctx, lightSprite, x + floor(Int, (width - lightSprite.width) / 2), y)
 end
 
-Ahorn.renderAbs(ctx::Ahorn.Cairo.CairoContext, entity::ConnectedZipMover, room::Maple.Room) =
-    renderZipMover(ctx, entity, room)
+Ahorn.renderAbs(ctx::Ahorn.Cairo.CairoContext, entity::ConnectedZipMover, room::Maple.Room) = renderZipMover(ctx, entity, room)
 
 end

--- a/Ahorn/entities/dreamBlocks/ConnectedDreamBlock.jl
+++ b/Ahorn/entities/dreamBlocks/ConnectedDreamBlock.jl
@@ -3,37 +3,44 @@ module CommunalHelperConnectedDreamBlock
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
 
-@mapdef Entity "CommunalHelper/ConnectedDreamBlock" ConnectedDreamBlock(x::Integer, y::Integer,
-	width::Integer=Maple.defaultBlockWidth, height::Integer=Maple.defaultBlockHeight,
-	featherMode::Bool = false, oneUse::Bool = false, refillCount::Integer=-1, below::Bool=false)
+@mapdef Entity "CommunalHelper/ConnectedDreamBlock" ConnectedDreamBlock(
+    x::Integer,
+    y::Integer,
+    width::Integer=Maple.defaultBlockWidth,
+    height::Integer=Maple.defaultBlockHeight,
+    featherMode::Bool=false,
+    oneUse::Bool=false,
+    refillCount::Integer=-1,
+    below::Bool=false,
+)
 
 const placements = Ahorn.PlacementDict(
     "Connected Dream Block (Normal) (Communal Helper)" => Ahorn.EntityPlacement(
         ConnectedDreamBlock,
-		"rectangle"
+        "rectangle",
     ),
-	"Connected Dream Block (Feather Mode) (Communal Helper)" => Ahorn.EntityPlacement(
+    "Connected Dream Block (Feather Mode) (Communal Helper)" => Ahorn.EntityPlacement(
         ConnectedDreamBlock,
-		"rectangle",
-        Dict{String, Any}(
-            "featherMode" => true
-        )
-    ),
-	"Connected Dream Block (Normal, One Use) (Communal Helper)" => Ahorn.EntityPlacement(
-        ConnectedDreamBlock,
-		"rectangle",
-        Dict{String, Any}(
-            "oneUse" => true
-        )
-    ),
-	"Connected Dream Block (Feather Mode, One Use) (Communal Helper)" => Ahorn.EntityPlacement(
-        ConnectedDreamBlock,
-		"rectangle",
-        Dict{String, Any}(
+        "rectangle",
+        Dict{String,Any}(
             "featherMode" => true,
-			"oneUse" => true
-        )
-    )
+        ),
+    ),
+    "Connected Dream Block (Normal, One Use) (Communal Helper)" => Ahorn.EntityPlacement(
+        ConnectedDreamBlock,
+        "rectangle",
+        Dict{String,Any}(
+            "oneUse" => true,
+        ),
+    ),
+    "Connected Dream Block (Feather Mode, One Use) (Communal Helper)" => Ahorn.EntityPlacement(
+        ConnectedDreamBlock,
+        "rectangle",
+        Dict{String,Any}(
+            "featherMode" => true,
+            "oneUse" => true,
+        ),
+    ),
 )
 
 Ahorn.minimumSize(entity::ConnectedDreamBlock) = 8, 8

--- a/Ahorn/entities/dreamBlocks/DreamCrumbleWallOnRumble.jl
+++ b/Ahorn/entities/dreamBlocks/DreamCrumbleWallOnRumble.jl
@@ -3,16 +3,23 @@ module CommunalHelperDreamCrumbleWallOnRumble
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
 
-@mapdef Entity "CommunalHelper/DreamCrumbleWallOnRumble" DreamCrumbleWallOnRumble(x::Integer, y::Integer,
-	width::Integer=Maple.defaultBlockWidth, height::Integer=Maple.defaultBlockHeight,
-	featherMode::Bool = false, oneUse::Bool = false, refillCount::Integer=-1, below::Bool=false, persistent::Bool=false)
-
+@mapdef Entity "CommunalHelper/DreamCrumbleWallOnRumble" DreamCrumbleWallOnRumble(
+    x::Integer,
+    y::Integer,
+    width::Integer=Maple.defaultBlockWidth,
+    height::Integer=Maple.defaultBlockHeight,
+    featherMode::Bool=false,
+    oneUse::Bool=false,
+    refillCount::Integer=-1,
+    below::Bool=false,
+    persistent::Bool=false,
+)
 
 const placements = Ahorn.PlacementDict(
     "Dream Crumble Wall On Rumble (Communal Helper)" => Ahorn.EntityPlacement(
         DreamCrumbleWallOnRumble,
-		"rectangle"
-    )
+        "rectangle",
+    ),
 )
 
 Ahorn.minimumSize(entity::DreamCrumbleWallOnRumble) = 8, 8

--- a/Ahorn/entities/dreamBlocks/DreamFallingBlock.jl
+++ b/Ahorn/entities/dreamBlocks/DreamFallingBlock.jl
@@ -3,16 +3,23 @@ module CommunalHelperDreamFallingBlock
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
 
-@mapdef Entity "CommunalHelper/DreamFallingBlock" DreamFallingBlock(x::Integer, y::Integer,
-	width::Integer=Maple.defaultBlockWidth, height::Integer=Maple.defaultBlockHeight,
-	featherMode::Bool = false, oneUse::Bool = false, refillCount::Integer=-1, noCollide::Bool=false, below::Bool=false)
-
+@mapdef Entity "CommunalHelper/DreamFallingBlock" DreamFallingBlock(
+    x::Integer,
+    y::Integer,
+    width::Integer=Maple.defaultBlockWidth,
+    height::Integer=Maple.defaultBlockHeight,
+    featherMode::Bool=false,
+    oneUse::Bool=false,
+    refillCount::Integer=-1,
+    noCollide::Bool=false,
+    below::Bool=false,
+)
 
 const placements = Ahorn.PlacementDict(
     "Dream Falling Block (Communal Helper)" => Ahorn.EntityPlacement(
         DreamFallingBlock,
-		"rectangle"
-    )
+        "rectangle",
+    ),
 )
 
 Ahorn.minimumSize(entity::DreamFallingBlock) = 8, 8

--- a/Ahorn/entities/dreamBlocks/DreamFloatySpaceBlock.jl
+++ b/Ahorn/entities/dreamBlocks/DreamFloatySpaceBlock.jl
@@ -3,16 +3,22 @@ module CommunalHelperDreamFloatySpaceBlock
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
 
-@mapdef Entity "CommunalHelper/DreamFloatySpaceBlock" DreamFloatySpaceBlock(x::Integer, y::Integer,
-	width::Integer=Maple.defaultBlockWidth, height::Integer=Maple.defaultBlockHeight,
-	featherMode::Bool = false, oneUse::Bool = false, refillCount::Integer=-1, below::Bool=false)
-
+@mapdef Entity "CommunalHelper/DreamFloatySpaceBlock" DreamFloatySpaceBlock(
+    x::Integer,
+    y::Integer,
+    width::Integer=Maple.defaultBlockWidth,
+    height::Integer=Maple.defaultBlockHeight,
+    featherMode::Bool=false,
+    oneUse::Bool=false,
+    refillCount::Integer=-1,
+    below::Bool=false,
+)
 
 const placements = Ahorn.PlacementDict(
     "Dream Floaty Space Block (Communal Helper)" => Ahorn.EntityPlacement(
-        DreamFloatySpaceBlock,
-		"rectangle"
-    )
+        DreamFloatySpaceBlock, 
+        "rectangle"
+    ),
 )
 
 Ahorn.minimumSize(entity::DreamFloatySpaceBlock) = 8, 8

--- a/Ahorn/entities/dreamBlocks/DreamMoveBlock.jl
+++ b/Ahorn/entities/dreamBlocks/DreamMoveBlock.jl
@@ -3,34 +3,43 @@ module CommunalHelperDreamMoveBlock
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
 
-@mapdef Entity "CommunalHelper/DreamMoveBlock" DreamMoveBlock(x::Integer, y::Integer,
-	width::Integer=Maple.defaultBlockWidth, height::Integer=Maple.defaultBlockHeight,
-	direction::String="Right", moveSpeed::Number=60.0, noCollide::Bool=false,
-	featherMode::Bool=false, oneUse::Bool=false, refillCount::Integer=-1, below::Bool=false)
+@mapdef Entity "CommunalHelper/DreamMoveBlock" DreamMoveBlock(
+    x::Integer,
+    y::Integer,
+    width::Integer=Maple.defaultBlockWidth,
+    height::Integer=Maple.defaultBlockHeight,
+    direction::String="Right",
+    moveSpeed::Number=60.0,
+    noCollide::Bool=false,
+    featherMode::Bool=false,
+    oneUse::Bool=false,
+    refillCount::Integer=-1,
+    below::Bool=false,
+)
 
 const placements = Ahorn.PlacementDict(
     "Dream Move Block ($direction) (Communal Helper)" => Ahorn.EntityPlacement(
         DreamMoveBlock,
         "rectangle",
-        Dict{String, Any}(
-            "direction" => direction
-        )
+        Dict{String,Any}(
+            "direction" => direction,
+        ),
     ) for direction in Maple.move_block_directions
 )
 
-Ahorn.editingOptions(entity::DreamMoveBlock) = Dict{String, Any}(
+Ahorn.editingOptions(entity::DreamMoveBlock) = Dict{String,Any}(
     "direction" => Maple.move_block_directions,
-	"moveSpeed" => Dict{String, Number}(
-		"Slow" => 60.0,
-		"Fast" => 75.0
-	)
+    "moveSpeed" => Dict{String,Number}(
+        "Slow" => 60.0,
+        "Fast" => 75.0,
+    ),
 )
 Ahorn.minimumSize(entity::DreamMoveBlock) = 16, 16
 Ahorn.resizable(entity::DreamMoveBlock) = true, true
 
 Ahorn.selection(entity::DreamMoveBlock) = Ahorn.getEntityRectangle(entity)
 
-const arrows = Dict{String, String}(
+const arrows = Dict{String,String}(
     "up" => "objects/CommunalHelper/dreamMoveBlock/arrow02",
     "left" => "objects/CommunalHelper/dreamMoveBlock/arrow04",
     "right" => "objects/CommunalHelper/dreamMoveBlock/arrow00",

--- a/Ahorn/entities/dreamBlocks/DreamSwapBlock.jl
+++ b/Ahorn/entities/dreamBlocks/DreamSwapBlock.jl
@@ -3,17 +3,25 @@ module CommunalHelperDreamSwapBlock
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
 
-@mapdef Entity "CommunalHelper/DreamSwapBlock" DreamSwapBlock(x::Integer, y::Integer,
-	width::Integer=Maple.defaultBlockWidth, height::Integer=Maple.defaultBlockHeight,
-	noReturn::Bool=false, featherMode::Bool=false, oneUse::Bool=false, refillCount::Integer=-1, below::Bool=false)
+@mapdef Entity "CommunalHelper/DreamSwapBlock" DreamSwapBlock(
+    x::Integer,
+    y::Integer,
+    width::Integer=Maple.defaultBlockWidth,
+    height::Integer=Maple.defaultBlockHeight,
+    noReturn::Bool=false,
+    featherMode::Bool=false,
+    oneUse::Bool=false,
+    refillCount::Integer=-1,
+    below::Bool=false,
+)
 
 const placements = Ahorn.PlacementDict(
     "Dream Swap Block (Communal Helper)" => Ahorn.EntityPlacement(
         DreamSwapBlock,
         "rectangle",
-        Dict{String, Any}(),
-        Ahorn.SwapBlock.swapFinalizer
-    )
+        Dict{String,Any}(),
+        Ahorn.SwapBlock.swapFinalizer,
+    ),
 )
 
 Ahorn.nodeLimits(entity::DreamSwapBlock) = 1, 1
@@ -30,11 +38,13 @@ function Ahorn.selection(entity::DreamSwapBlock)
     width = Int(get(entity.data, "width", 8))
     height = Int(get(entity.data, "height", 8))
 
-    return [Ahorn.Rectangle(x, y, width, height), Ahorn.Rectangle(stopX, stopY, width, height)]
+    return [
+        Ahorn.Rectangle(x, y, width, height),
+        Ahorn.Rectangle(stopX, stopY, width, height),
+    ]
 end
 
 function Ahorn.renderSelectedAbs(ctx::Ahorn.Cairo.CairoContext, entity::DreamSwapBlock)
-    sprite = get(entity.data, "sprite", "block")
     startX, startY = Int(entity.data["x"]), Int(entity.data["y"])
     stopX, stopY = Int.(entity.data["nodes"][1])
 
@@ -47,7 +57,6 @@ function Ahorn.renderSelectedAbs(ctx::Ahorn.Cairo.CairoContext, entity::DreamSwa
 end
 
 function Ahorn.renderAbs(ctx::Ahorn.Cairo.CairoContext, entity::DreamSwapBlock)
-    sprite = get(entity.data, "sprite", "block")
 
     startX, startY = Int(entity.data["x"]), Int(entity.data["y"])
     stopX, stopY = Int.(entity.data["nodes"][1])

--- a/Ahorn/entities/dreamBlocks/DreamSwitchGate.jl
+++ b/Ahorn/entities/dreamBlocks/DreamSwitchGate.jl
@@ -3,20 +3,30 @@ module CommunalHelperDreamSwitchGate
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
 
-@mapdef Entity "CommunalHelper/DreamSwitchGate" DreamSwitchGate(x::Integer, y::Integer,
-	width::Integer=Maple.defaultBlockWidth, height::Integer=Maple.defaultBlockHeight,
-    featherMode::Bool = false, oneUse::Bool = false, refillCount::Integer=-1, below::Bool=false, permanent::Bool = false)
-
+@mapdef Entity "CommunalHelper/DreamSwitchGate" DreamSwitchGate(
+    x::Integer,
+    y::Integer,
+    width::Integer=Maple.defaultBlockWidth,
+    height::Integer=Maple.defaultBlockHeight,
+    featherMode::Bool=false,
+    oneUse::Bool=false,
+    refillCount::Integer=-1,
+    below::Bool=false,
+    permanent::Bool=false,
+)
 
 const placements = Ahorn.PlacementDict(
     "Dream Switch Gate (Communal Helper)" => Ahorn.EntityPlacement(
         DreamSwitchGate,
         "rectangle",
-        Dict{String, Any}(),
-		function(entity)
-            entity.data["nodes"] = [(Int(entity.data["x"]) + Int(entity.data["width"]), Int(entity.data["y"]))]
-        end
-    )
+        Dict{String,Any}(),
+        function (entity)
+            entity.data["nodes"] = [(
+                Int(entity.data["x"]) + Int(entity.data["width"]),
+                Int(entity.data["y"]),
+            )]
+        end,
+    ),
 )
 
 const iconSprite = Ahorn.getSprite("objects/switchgate/icon00", "Gameplay")
@@ -33,7 +43,10 @@ function Ahorn.selection(entity::DreamSwitchGate)
     width = Int(get(entity.data, "width", 8))
     height = Int(get(entity.data, "height", 8))
 
-    return [Ahorn.Rectangle(x, y, width, height), Ahorn.Rectangle(stopX, stopY, width, height)]
+    return [
+        Ahorn.Rectangle(x, y, width, height),
+        Ahorn.Rectangle(stopX, stopY, width, height),
+    ]
 end
 
 function Ahorn.renderSelectedAbs(ctx::Ahorn.Cairo.CairoContext, entity::DreamSwitchGate)

--- a/Ahorn/entities/dreamBlocks/DreamSwitchGate_MaxHelpingHand.jl
+++ b/Ahorn/entities/dreamBlocks/DreamSwitchGate_MaxHelpingHand.jl
@@ -3,13 +3,28 @@ module CommunalHelperDreamFlagSwitchGate
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
 
-@mapdef Entity "CommunalHelper/MaxHelpingHand/DreamFlagSwitchGate" DreamFlagSwitchGate(x::Integer, y::Integer,
-	width::Integer=Maple.defaultBlockWidth, height::Integer=Maple.defaultBlockHeight,
-    featherMode::Bool=false, oneUse::Bool=false, refillCount::Integer=-1, below::Bool=false, persistent::Bool=false,
-    flag::String="flag_touch_switch", icon::String="vanilla",
-    inactiveColor::String="5FCDE4", activeColor::String="FFFFFF", finishColor::String="F141DF",
-    shakeTime::Number=0.5, moveTime::Number=1.8, moveEased::Bool=true, allowReturn::Bool=false,
-    moveSound::String="event:/game/general/touchswitch_gate_open", finishedSound::String="event:/game/general/touchswitch_gate_finish")
+@mapdef Entity "CommunalHelper/MaxHelpingHand/DreamFlagSwitchGate" DreamFlagSwitchGate(
+    x::Integer,
+    y::Integer,
+    width::Integer=Maple.defaultBlockWidth,
+    height::Integer=Maple.defaultBlockHeight,
+    featherMode::Bool=false,
+    oneUse::Bool=false,
+    refillCount::Integer=-1,
+    below::Bool=false,
+    persistent::Bool=false,
+    flag::String="flag_touch_switch",
+    icon::String="vanilla",
+    inactiveColor::String="5FCDE4",
+    activeColor::String="FFFFFF",
+    finishColor::String="F141DF",
+    shakeTime::Number=0.5,
+    moveTime::Number=1.8,
+    moveEased::Bool=true,
+    allowReturn::Bool=false,
+    moveSound::String="event:/game/general/touchswitch_gate_open",
+    finishedSound::String="event:/game/general/touchswitch_gate_finish",
+)
 
 const placements = Ahorn.PlacementDict()
 
@@ -17,10 +32,13 @@ if isdefined(Ahorn, :MaxHelpingHand)
     placements["Dream Flag Switch Gate (Communal Helper, max480's Helping Hand)"] = Ahorn.EntityPlacement(
         DreamFlagSwitchGate,
         "rectangle",
-        Dict{String, Any}(),
+        Dict{String,Any}(),
         function (entity)
-            entity.data["nodes"] = [(Int(entity.data["x"]) + Int(entity.data["width"]), Int(entity.data["y"]))]
-        end
+            entity.data["nodes"] = [(
+                Int(entity.data["x"]) + Int(entity.data["width"]),
+                Int(entity.data["y"]),
+            )]
+        end,
     )
 else
     @warn "Max480's Helping Hand not detected: CommunalHelper+MaxHelpingHand plugins not loaded."
@@ -28,7 +46,7 @@ end
 
 function getIconSprite(entity::DreamFlagSwitchGate)
     icon = get(entity.data, "icon", "vanilla")
-    
+
     iconResource = "objects/switchgate/icon00"
     if icon != "vanilla"
         iconResource = "objects/MaxHelpingHand/flagSwitchGate/$(icon)/icon00"
@@ -42,11 +60,24 @@ Ahorn.nodeLimits(entity::DreamFlagSwitchGate) = 1, 1
 Ahorn.minimumSize(entity::DreamFlagSwitchGate) = 16, 16
 Ahorn.resizable(entity::DreamFlagSwitchGate) = true, true
 
-Ahorn.editingOrder(entity::DreamFlagSwitchGate) = String["x", "y", "width", "height", "flag", "inactiveColor", "activeColor", "finishColor", "hitSound", "moveSound", "finishedSound", "shakeTime", "moveTime"]
+Ahorn.editingOrder(entity::DreamFlagSwitchGate) = String[
+    "x",
+    "y",
+    "width",
+    "height",
+    "flag",
+    "inactiveColor",
+    "activeColor",
+    "finishColor",
+    "hitSound",
+    "moveSound",
+    "finishedSound",
+    "shakeTime",
+    "moveTime",
+]
 
-Ahorn.editingOptions(entity::DreamFlagSwitchGate) = Dict{String, Any}(
-    "icon" => Ahorn.MaxHelpingHandFlagSwitchGate.bundledIcons
-)
+Ahorn.editingOptions(entity::DreamFlagSwitchGate) =
+    Dict{String,Any}("icon" => Ahorn.MaxHelpingHandFlagSwitchGate.bundledIcons)
 
 function Ahorn.selection(entity::DreamFlagSwitchGate)
     x, y = Ahorn.position(entity)
@@ -55,7 +86,10 @@ function Ahorn.selection(entity::DreamFlagSwitchGate)
     width = Int(get(entity.data, "width", 8))
     height = Int(get(entity.data, "height", 8))
 
-    return [Ahorn.Rectangle(x, y, width, height), Ahorn.Rectangle(stopX, stopY, width, height)]
+    return [
+        Ahorn.Rectangle(x, y, width, height),
+        Ahorn.Rectangle(stopX, stopY, width, height),
+    ]
 end
 
 function Ahorn.renderSelectedAbs(ctx::Ahorn.Cairo.CairoContext, entity::DreamFlagSwitchGate)

--- a/Ahorn/entities/dreamBlocks/DreamZipMover.jl
+++ b/Ahorn/entities/dreamBlocks/DreamZipMover.jl
@@ -3,21 +3,35 @@ module CommunalHelperDreamZipMover
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
 
-@mapdef Entity "CommunalHelper/DreamZipMover" DreamZipMover(x::Integer, y::Integer,
-	width::Integer=Maple.defaultBlockWidth, height::Integer=Maple.defaultBlockHeight,
-    noReturn::Bool=false, dreamAesthetic::Bool=false, featherMode::Bool=false, oneUse::Bool=false, refillCount::Integer=-1, below::Bool=false,
-    nodes::Array{Tuple{Integer, Integer}, 1}=Tuple{Integer, Integer}[],
-    permanent::Bool=false, waiting::Bool=false, ticking::Bool=false)
+@mapdef Entity "CommunalHelper/DreamZipMover" DreamZipMover(
+    x::Integer,
+    y::Integer,
+    width::Integer=Maple.defaultBlockWidth,
+    height::Integer=Maple.defaultBlockHeight,
+    noReturn::Bool=false,
+    dreamAesthetic::Bool=false,
+    featherMode::Bool=false,
+    oneUse::Bool=false,
+    refillCount::Integer=-1,
+    below::Bool=false,
+    nodes::Array{Tuple{Integer,Integer},1}=Tuple{Integer,Integer}[],
+    permanent::Bool=false,
+    waiting::Bool=false,
+    ticking::Bool=false,
+)
 
 const placements = Ahorn.PlacementDict(
     "Dream Zip Mover (Communal Helper)" => Ahorn.EntityPlacement(
         DreamZipMover,
         "rectangle",
-        Dict{String, Any}(),
-        function(entity)
-            entity.data["nodes"] = [(Int(entity.data["x"]) + Int(entity.data["width"]) + 8, Int(entity.data["y"]))]
-        end
-    )
+        Dict{String,Any}(),
+        function (entity)
+            entity.data["nodes"] = [(
+                Int(entity.data["x"]) + Int(entity.data["width"]) + 8,
+                Int(entity.data["y"]),
+            )]
+        end,
+    ),
 )
 
 Ahorn.nodeLimits(entity::DreamZipMover) = 1, -1
@@ -32,19 +46,14 @@ function Ahorn.selection(entity::DreamZipMover)
     height = Int(get(entity.data, "height", 8))
 
     res = [Ahorn.Rectangle(x, y, width, height)]
-	
-	for node in get(entity.data, "nodes", ())
-        nx, ny = Int.(node)
-		
-		push!(res, Ahorn.Rectangle(nx + floor(Int, width / 2) - 5, ny + floor(Int, height / 2) - 5, 10, 10))
-	end
-	
-	return res
-end
 
-function getTextures(entity::DreamZipMover)
-    dreamAesthetic = Bool(get(entity.data, "dreamAesthetic", false))
-    return "objects/zipmover/block", "objects/zipmover/light01", (dreamAesthetic ? "objects/CommunalHelper/dreamZipMover/cog" : "objects/zipmover/cog")
+    for node in get(entity.data, "nodes", ())
+        nx, ny = Int.(node)
+
+        push!(res, Ahorn.Rectangle(nx + floor(Int, width / 2) - 5, ny + floor(Int, height / 2) - 5, 10, 10))
+    end
+
+    return res
 end
 
 const crossSprite = "objects/CommunalHelper/dreamMoveBlock/x"
@@ -58,45 +67,44 @@ function renderDreamZipMover(ctx::Ahorn.Cairo.CairoContext, entity::DreamZipMove
     height = Int(get(entity.data, "height", 32))
     dreamAesthetic = Bool(get(entity.data, "dreamAesthetic", false))
 
-    block, light, cog = getTextures(entity)
+    cog = dreamAesthetic ? "objects/CommunalHelper/dreamZipMover/cog" : "objects/zipmover/cog"
 
     # Dream block stuff
     renderDreamBlock(ctx, x, y, width, height, entity.data)
 
     # Iteration through all the nodes
-	for node in get(entity.data, "nodes", ())
+    for node in get(entity.data, "nodes", ())
         nx, ny = Int.(node)
-		cx, cy = px + width / 2, py + height / 2
-		cnx, cny = nx + width / 2, ny + height / 2
+        cx, cy = px + width / 2, py + height / 2
+        cnx, cny = nx + width / 2, ny + height / 2
 
-		length = sqrt((px - nx)^2 + (py - ny)^2)
-		theta = atan(cny - cy, cnx - cx)
+        length = sqrt((px - nx)^2 + (py - ny)^2)
+        theta = atan(cny - cy, cnx - cx)
 
-		Ahorn.Cairo.save(ctx)
+        Ahorn.Cairo.save(ctx)
 
-		Ahorn.translate(ctx, cx, cy)
-		Ahorn.rotate(ctx, theta)
+        Ahorn.translate(ctx, cx, cy)
+        Ahorn.rotate(ctx, theta)
 
-		Ahorn.setSourceColor(ctx, dreamAesthetic ? (0.9, 0.9, 0.9, 1.0) : ropeColor)
-		Ahorn.set_antialias(ctx, 1)
-		Ahorn.set_line_width(ctx, 1);
+        Ahorn.setSourceColor(ctx, dreamAesthetic ? (0.9, 0.9, 0.9, 1.0) : ropeColor)
+        Ahorn.set_antialias(ctx, 1)
+        Ahorn.set_line_width(ctx, 1)
 
-		# Offset for rounding errors
-		Ahorn.move_to(ctx, 0, 4 + (theta <= 0))
-		Ahorn.line_to(ctx, length, 4 + (theta <= 0))
+        # Offset for rounding errors
+        Ahorn.move_to(ctx, 0, 4 + (theta <= 0))
+        Ahorn.line_to(ctx, length, 4 + (theta <= 0))
 
-		Ahorn.move_to(ctx, 0, -4 - (theta > 0))
-		Ahorn.line_to(ctx, length, -4 - (theta > 0))
+        Ahorn.move_to(ctx, 0, -4 - (theta > 0))
+        Ahorn.line_to(ctx, length, -4 - (theta > 0))
 
-		Ahorn.stroke(ctx)
+        Ahorn.stroke(ctx)
 
-		Ahorn.Cairo.restore(ctx)
-		
-		Ahorn.drawSprite(ctx, cog, cnx, cny)
-		
-		px, py = nx, ny
-	
-	end
+        Ahorn.Cairo.restore(ctx)
+
+        Ahorn.drawSprite(ctx, cog, cnx, cny)
+
+        px, py = nx, ny
+    end
 
     if Bool(get(entity.data, "noReturn", false))
         noReturnSprite = Ahorn.getSprite(crossSprite, "Gameplay")

--- a/Ahorn/entities/panels/DreamTunnelEntry.jl
+++ b/Ahorn/entities/panels/DreamTunnelEntry.jl
@@ -3,62 +3,64 @@ module CommunalHelperDreamTunnelEntry
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
 
-@mapdef Entity "CommunalHelper/DreamTunnelEntry" DreamTunnelEntry(x::Integer, y::Integer, 
-	overrideAllowStaticMovers=false, depth::Integer=-13000)
-
-const placements = Ahorn.PlacementDict(
-	"Dream Tunnel Entry ($dir) (Communal Helper)" => Ahorn.EntityPlacement(
-		DreamTunnelEntry,
-		"rectangle",
-		Dict{String, Any}(
-			"orientation" => dir
-		),
-	) for dir in Maple.spike_directions
+@mapdef Entity "CommunalHelper/DreamTunnelEntry" DreamTunnelEntry(
+    x::Integer,
+    y::Integer,
+    overrideAllowStaticMovers=false,
+    depth::Integer=-13000,
 )
 
-Ahorn.editingOptions(entity::DreamTunnelEntry) = Dict{String, Any}(
+const placements = Ahorn.PlacementDict(
+    "Dream Tunnel Entry ($dir) (Communal Helper)" => Ahorn.EntityPlacement(
+        DreamTunnelEntry,
+        "rectangle",
+        Dict{String,Any}(
+            "orientation" => dir,
+        ),
+    ) for dir in Maple.spike_directions
+)
+
+Ahorn.editingOptions(entity::DreamTunnelEntry) = Dict{String,Any}(
     "orientation" => Maple.spike_directions,
-	"depth" => CommunalHelper.depths
+    "depth" => CommunalHelper.depths,
 )
 
 Ahorn.minimumSize(entity::DreamTunnelEntry) = 8, 8
 
-const resizeDirections = Dict{String, Tuple{Bool, Bool}}(
-	"Up" => (true, false),
-	"Down" => (true, false),
-	"Left" => (false, true),
-	"Right" => (false, true),
+const resizeDirections = Dict{String,Tuple{Bool,Bool}}(
+    "Up" => (true, false),
+    "Down" => (true, false),
+    "Left" => (false, true),
+    "Right" => (false, true),
 )
 
 function Ahorn.resizable(entity::DreamTunnelEntry)
-	orientation = get(entity.data, "orientation", "Up")
-	return resizeDirections[orientation]
+    orientation = get(entity.data, "orientation", "Up")
+    return resizeDirections[orientation]
 end
 
 function Ahorn.selection(entity::DreamTunnelEntry)
-	x, y = Ahorn.position(entity)
+    x, y = Ahorn.position(entity)
 
-	width = Int(get(entity.data, "width", 8))
-	height = Int(get(entity.data, "height", 8))
+    width = Int(get(entity.data, "width", 8))
+    height = Int(get(entity.data, "height", 8))
 
-	orientation = get(entity.data, "orientation", "Up")
-
-	return Ahorn.Rectangle(x, y, width, height)
+    return Ahorn.Rectangle(x, y, width, height)
 end
 
 function Ahorn.renderAbs(ctx::Ahorn.Cairo.CairoContext, entity::DreamTunnelEntry)
-	orientation = get(entity.data, "orientation", "Up")
+    orientation = get(entity.data, "orientation", "Up")
 
-	width = Int(get(entity.data, "width", 8))
-	height = Int(get(entity.data, "height", 8))
-	
-	x, y = Ahorn.position(entity)
-	ox, oy = x + width * (orientation == "Right"), y + height * (orientation == "Down")
-	cx, cy = x + width * in(orientation, ("Up", "Down", "Right")), y + height * in(orientation, ("Down", "Left", "Right"))
+    width = Int(get(entity.data, "width", 8))
+    height = Int(get(entity.data, "height", 8))
 
-	Ahorn.drawRectangle(ctx, x, y, width, height, (0.0, 0.0, 0.0, 0.4))
-	Ahorn.drawLines(ctx, ((ox, oy), (cx, cy)), (1.0, 1.0, 1.0, 1.0), thickness=1)
+    x, y = Ahorn.position(entity)
+    ox, oy = x + width * (orientation == "Right"), y + height * (orientation == "Down")
+    cx, cy = x + width * in(orientation, ("Up", "Down", "Right")),
+    y + height * in(orientation, ("Down", "Left", "Right"))
 
+    Ahorn.drawRectangle(ctx, x, y, width, height, (0.0, 0.0, 0.0, 0.4))
+    Ahorn.drawLines(ctx, ((ox, oy), (cx, cy)), (1.0, 1.0, 1.0, 1.0), thickness=1)
 end
 
-end 
+end

--- a/Ahorn/entities/panels/SurfaceSoundPanel.jl
+++ b/Ahorn/entities/panels/SurfaceSoundPanel.jl
@@ -3,63 +3,64 @@ module CommunalHelperSurfaceSoundPanel
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
 
-const surfaceSoundPanelDirections = String["Up", "Left", "Right"]
+const directions = String["Up", "Left", "Right"]
 
-@mapdef Entity "CommunalHelper/SurfaceSoundPanel" Panel(x::Integer, y::Integer, 
-   soundIndex::Integer=11)
-
-const placements = Ahorn.PlacementDict(
-   "Sound Surface Panel ($dir) (Communal Helper)" => Ahorn.EntityPlacement(
-      Panel,
-      "rectangle",
-      Dict{String, Any}(
-         "orientation" => dir
-      ),
-   ) for dir in surfaceSoundPanelDirections
+@mapdef Entity "CommunalHelper/SurfaceSoundPanel" Panel(
+    x::Integer,
+    y::Integer,
+    soundIndex::Integer=11,
 )
 
-Ahorn.editingOptions(entity::Panel) = Dict{String, Any}(
-   "orientation" => Maple.spike_directions,
-   "soundIndex" => CommunalHelper.surfaceSounds
+const placements = Ahorn.PlacementDict(
+    "Sound Surface Panel ($dir) (Communal Helper)" => Ahorn.EntityPlacement(
+        Panel,
+        "rectangle",
+        Dict{String,Any}(
+            "orientation" => dir,
+        ),
+    ) for dir in directions
+)
+
+Ahorn.editingOptions(entity::Panel) = Dict{String,Any}(
+    "orientation" => Maple.spike_directions,
+    "soundIndex" => CommunalHelper.surfaceSounds,
 )
 
 Ahorn.minimumSize(entity::Panel) = 8, 8
 
-const resizeDirections = Dict{String, Tuple{Bool, Bool}}(
-   "Up" => (true, false),
-   "Left" => (false, true),
-   "Right" => (false, true),
+const resizeDirections = Dict{String,Tuple{Bool,Bool}}(
+    "Up" => (true, false),
+    "Left" => (false, true),
+    "Right" => (false, true),
 )
 
 function Ahorn.resizable(entity::Panel)
-   orientation = get(entity.data, "orientation", "Up")
-   return resizeDirections[orientation]
+    orientation = get(entity.data, "orientation", "Up")
+    return resizeDirections[orientation]
 end
 
 function Ahorn.selection(entity::Panel)
-   x, y = Ahorn.position(entity)
+    x, y = Ahorn.position(entity)
 
-   width = Int(get(entity.data, "width", 8))
-   height = Int(get(entity.data, "height", 8))
+    width = Int(get(entity.data, "width", 8))
+    height = Int(get(entity.data, "height", 8))
 
-   orientation = get(entity.data, "orientation", "Up")
-
-   return Ahorn.Rectangle(x, y, width, height)
+    return Ahorn.Rectangle(x, y, width, height)
 end
 
 function Ahorn.renderAbs(ctx::Ahorn.Cairo.CairoContext, entity::Panel)
-   orientation = get(entity.data, "orientation", "Up")
+    orientation = get(entity.data, "orientation", "Up")
 
-   width = Int(get(entity.data, "width", 8))
-   height = Int(get(entity.data, "height", 8))
-   
-   x, y = Ahorn.position(entity)
-   ox, oy = x + width * (orientation == "Right"), y + height * (orientation == "Down")
-   cx, cy = x + width * in(orientation, ("Up", "Down", "Right")), y + height * in(orientation, ("Down", "Left", "Right"))
+    width = Int(get(entity.data, "width", 8))
+    height = Int(get(entity.data, "height", 8))
 
-   Ahorn.drawRectangle(ctx, x, y, width, height, (1.0, 0.5, 0.0, 0.4))
-   Ahorn.drawLines(ctx, ((ox, oy), (cx, cy)), (1.0, 1.0, 1.0, 1.0), thickness=1)
+    x, y = Ahorn.position(entity)
+    ox, oy = x + width * (orientation == "Right"), y + height * (orientation == "Down")
+    cx, cy = x + width * in(orientation, ("Up", "Down", "Right")),
+    y + height * in(orientation, ("Down", "Left", "Right"))
 
+    Ahorn.drawRectangle(ctx, x, y, width, height, (1.0, 0.5, 0.0, 0.4))
+    Ahorn.drawLines(ctx, ((ox, oy), (cx, cy)), (1.0, 1.0, 1.0, 1.0), thickness=1)
 end
 
-end 
+end

--- a/Ahorn/entities/trackSwitchBox.jl
+++ b/Ahorn/entities/trackSwitchBox.jl
@@ -1,20 +1,25 @@
 module CommunalHelperTrackSwitchBox
+
 using ..Ahorn, Maple
 
-@mapdef Entity "CommunalHelper/TrackSwitchBox" TrackSwitchBox(x::Integer, y::Integer, globalSwitch::Bool = false)
+@mapdef Entity "CommunalHelper/TrackSwitchBox" TrackSwitchBox(
+    x::Integer,
+    y::Integer,
+    globalSwitch::Bool=false,
+)
 
 const placements = Ahorn.PlacementDict(
     "Track Switch Box (Communal Helper)" => Ahorn.EntityPlacement(
         TrackSwitchBox,
-        "point"
+        "point",
     ),
     "Track Switch Box (Session Switch) (Communal Helper)" => Ahorn.EntityPlacement(
         TrackSwitchBox,
         "point",
-        Dict{String, Any}(
+        Dict{String,Any}(
             "globalSwitch" => true,
-        )
-    )
+        ),
+    ),
 )
 
 const sprite = "objects/CommunalHelper/trackSwitchBox/idle00"

--- a/Ahorn/libraries/CommunalHelper.jl
+++ b/Ahorn/libraries/CommunalHelper.jl
@@ -13,238 +13,266 @@ export renderCassetteBlock, cassetteColorNames, getCassetteColor
 export getExtensionRectangles, notAdjacent
 # Depths
 export depths
+# mapdef hacks
+export @mapdefdata, appendkwargs
 
 "Celeste.Depths"
-const depths = Dict{String, Integer}(
-        "BGTerrain (10000)" => 10000,
-        "BGDecals (9000)" => 9000,
-        "BGParticles (8000)" => 8000,
-        "Below (2000)" => 2000,
-        "NPCs (1000)" => 1000,
-        "Player (0)" => 0,
-        "Dust (-50)" => -50,
-        "Pickups (-100)" => -100,
-        "Particles (-8000)" => -8000,
-        "Above Particles (-8500)" => -8500,
-        "Solids (-9000)" => -9000,
-        "FGTerrain (-10000)" => -10000,
-        "FGDecals (-10500)" => -10500,
-        "DreamBlocks (-11000)" => -11000,
-        "CrystalSpinners (-11500)" => -11500,
-        "Chaser (-12500)" => -12500,
-        "Fake Walls (-13000)" => -13000,
-        "FGParticles (-50000)" => -50000
+const depths = Dict{String,Integer}(
+    "BGTerrain (10000)" => 10000,
+    "BGDecals (9000)" => 9000,
+    "BGParticles (8000)" => 8000,
+    "Below (2000)" => 2000,
+    "NPCs (1000)" => 1000,
+    "Player (0)" => 0,
+    "Dust (-50)" => -50,
+    "Pickups (-100)" => -100,
+    "Particles (-8000)" => -8000,
+    "Above Particles (-8500)" => -8500,
+    "Solids (-9000)" => -9000,
+    "FGTerrain (-10000)" => -10000,
+    "FGDecals (-10500)" => -10500,
+    "DreamBlocks (-11000)" => -11000,
+    "CrystalSpinners (-11500)" => -11500,
+    "Chaser (-12500)" => -12500,
+    "Fake Walls (-13000)" => -13000,
+    "FGParticles (-50000)" => -50000,
 )
 
 "Celeste.SurfaceSound"
-const surfaceSounds = Dict{String, Integer}(
-   "Asphalt" => 1,
-   "Car" => 2,
-   "Dirt" => 3,
-   "Snow" => 4,
-   "Wood" => 5,
-   "StoneBridge" => 6,
-   "Girder" => 7,
-   "Brick" => 8,
-   "ZipMover" => 9,
-   "DreamBlockInactive" => 11,
-   "DreamBlockActive" => 12,
-   "ResortWood" => 13,
-   "ResortRoof" => 14,
-   "ResortSinkingPlatforms" => 15,
-   "ResortBasementTile" => 16,
-   "ResortLinens" => 17,
-   "ResortBoxes" => 18,
-   "ResortBooks" => 19,
-   "ClutterDoor" => 20,
-   "ClutterSwitch" => 21,
-   "ResortMagicButton" => 21,
-   "ResortElevator" => 22,
-   "CliffsideSnow" => 23,
-   "CliffsideGrass" => 25,
-   "CliffsideWhiteBlock" => 27,
-   "Gondola" => 28,
-   "AuroraGlass" => 32,
-   "Grass" => 33,
-   "CassetteBlock" => 35,
-   "CoreIce" => 36,
-   "CoreMoltenRock" => 37,
-   "Glitch" => 40,
-   "MoonCafe" => 42,
-   "DreamClouds" => 43,
-   "Moon" => 44,
+const surfaceSounds = Dict{String,Integer}(
+    "Asphalt" => 1,
+    "Car" => 2,
+    "Dirt" => 3,
+    "Snow" => 4,
+    "Wood" => 5,
+    "StoneBridge" => 6,
+    "Girder" => 7,
+    "Brick" => 8,
+    "ZipMover" => 9,
+    "DreamBlockInactive" => 11,
+    "DreamBlockActive" => 12,
+    "ResortWood" => 13,
+    "ResortRoof" => 14,
+    "ResortSinkingPlatforms" => 15,
+    "ResortBasementTile" => 16,
+    "ResortLinens" => 17,
+    "ResortBoxes" => 18,
+    "ResortBooks" => 19,
+    "ClutterDoor" => 20,
+    "ClutterSwitch" => 21,
+    "ResortMagicButton" => 21,
+    "ResortElevator" => 22,
+    "CliffsideSnow" => 23,
+    "CliffsideGrass" => 25,
+    "CliffsideWhiteBlock" => 27,
+    "Gondola" => 28,
+    "AuroraGlass" => 32,
+    "Grass" => 33,
+    "CassetteBlock" => 35,
+    "CoreIce" => 36,
+    "CoreMoltenRock" => 37,
+    "Glitch" => 40,
+    "MoonCafe" => 42,
+    "DreamClouds" => 43,
+    "Moon" => 44,
 )
 
 """
-	 hexToRGBA(hex)
+    hexToRGBA(hex)
 
 Convert a hex color code to an RGBA tuple with value from 0.0-1.0
 
 # Examples:
     hexToRGBA("ff00ff")
 """
-hexToRGBA(hex) = tuple(Ahorn.argb32ToRGBATuple(parse(Int, hex; base=16))[1:3] ./ 255..., 1.0)
+hexToRGBA(hex) =
+    tuple(Ahorn.argb32ToRGBATuple(parse(Int, hex; base=16))[1:3] ./ 255..., 1.0)
 
 """
-	 renderDreamBlock(ctx, x, y, width, height, data)
-	
+    renderDreamBlock(ctx, x, y, width, height, data)
+
 Draw a custom dreamblock based on the attributes present in `data`.
 
 # Supported Attributes:
-	`featherMode`::Bool
-	`oneUse`::Bool
-	`noCollide`::Bool
-	`doubleRefill`::Bool OR `refillCount`::Int
+    `featherMode`::Bool
+    `oneUse`::Bool
+    `noCollide`::Bool
+    `doubleRefill`::Bool OR `refillCount`::Int
 """
 function renderDreamBlock(ctx::CairoContext, x::Number, y::Number, width::Number, height::Number, data::Dict{String, Any})
-	save(ctx)
+    save(ctx)
 
-	set_antialias(ctx, 1)
-	set_line_width(ctx, 1)
+    set_antialias(ctx, 1)
+    set_line_width(ctx, 1)
 
-	fillColor = get(data, "featherMode", false) ? (0.31, 0.69, 1.0, 0.4) : (0.0, 0.0, 0.0, 0.4)
-	#get(data, "noCollide", false)
+    fillColor =
+        get(data, "featherMode", false) ? (0.31, 0.69, 1.0, 0.4) : (0.0, 0.0, 0.0, 0.4)
+    #get(data, "noCollide", false)
 
-	lineColor = (1.0, 1.0, 1.0, 1.0)
-	if get(data, "doubleRefill", false)
-		lineColor = (1.0, 0.43, 0.94, 1.0)
-	else
-		refillCount = Int(get(data, "refillCount", -1))
-		if refillCount != -1
-			lineColor = get(hairColors, refillCount + 1, (1.0, 0.43, 0.94, 1.0))
-		end
-	end
+    lineColor = (1.0, 1.0, 1.0, 1.0)
+    if get(data, "doubleRefill", false)
+        lineColor = (1.0, 0.43, 0.94, 1.0)
+    else
+        refillCount = Int(get(data, "refillCount", -1))
+        if refillCount != -1
+            lineColor = get(hairColors, refillCount + 1, (1.0, 0.43, 0.94, 1.0))
+        end
+    end
 
-	if (get(data, "oneUse", false))
-		set_dash(ctx, [0.6, 0.2])
-	end
+    if (get(data, "oneUse", false))
+        set_dash(ctx, [0.6, 0.2])
+    end
 
-	Ahorn.drawRectangle(ctx, x, y, width, height, fillColor, lineColor)
+    Ahorn.drawRectangle(ctx, x, y, width, height, fillColor, lineColor)
 
-	restore(ctx)
+    restore(ctx)
 end
 
 # Translated from Celeste.UserIO.GetSavePath
 function getSavesDir()
-	if Sys.islinux() || Sys.isfreebsd() || Sys.isopenbsd() || Sys.isnetbsd()
-		envVar = get(ENV, "XDG_DATA_HOME", nothing)
-		if !isnothing(envVar) && !isempty(envVar)
-			return joinpath(envVar, "Celeste", "Saves")
-		end
-		envVar = get(ENV, "HOME", nothing)
-		if !isnothing(envVar) && !isempty(envVar)
-			return joinpath(envVar, ".local", "share", "Celeste", "Saves")
-		end
-	elseif Sys.isapple()
-		envVar = get(ENV, "HOME", nothing)
-		if !isnothing(envVar) && !isempty(envVar)
-			return joinpath(envVar, "Library", "Application Support", "Celeste", "Saves")
-		end
-	elseif Sys.iswindows()
-		return joinpath(Ahorn.config["celeste_dir"], "Saves")
-	end
-	throw(ErrorException("Unsupported operating system. (how did you even get celeste working?)"))
+    if Sys.islinux() || Sys.isfreebsd() || Sys.isopenbsd() || Sys.isnetbsd()
+        envVar = get(ENV, "XDG_DATA_HOME", nothing)
+        if !isnothing(envVar) && !isempty(envVar)
+            return joinpath(envVar, "Celeste", "Saves")
+        end
+        envVar = get(ENV, "HOME", nothing)
+        if !isnothing(envVar) && !isempty(envVar)
+            return joinpath(envVar, ".local", "share", "Celeste", "Saves")
+        end
+    elseif Sys.isapple()
+        envVar = get(ENV, "HOME", nothing)
+        if !isnothing(envVar) && !isempty(envVar)
+            return joinpath(envVar, "Library", "Application Support", "Celeste", "Saves")
+        end
+    elseif Sys.iswindows()
+        return joinpath(Ahorn.config["celeste_dir"], "Saves")
+    end
+    throw(
+        ErrorException(
+            "Unsupported operating system. (how did you even get celeste working?)",
+        ),
+    )
 end
 
 function getPlayerHairColors()
-	colors = [
-		(0.27, 0.7, 1.0, 1.0),
-		(0.67, 0.2, 0.2, 1.0),
-		(1.0, 0.43, 0.94, 1.0)
-	]
-	try
-		path = joinpath(getSavesDir(), "modsettings-MoreDasheline.celeste")
-		if isfile(path)
-			# can't hecking use YAML.jl because it can't read the hex values properly
-			moreDasheline = Dict{String, String}(
-				strip(key) => strip(value) for (key, value) in split.(readlines(path), ":")
-			) 
+    colors = [(0.27, 0.7, 1.0, 1.0), (0.67, 0.2, 0.2, 1.0), (1.0, 0.43, 0.94, 1.0)]
+    try
+        path = joinpath(getSavesDir(), "modsettings-MoreDasheline.celeste")
+        if isfile(path)
+            # can't hecking use YAML.jl because it can't read the hex values properly
+            moreDasheline = Dict{String,String}(
+                strip(key) => strip(value) for (key, value) in split.(readlines(path), ":")
+            )
 
-			colors = append!(colors, [
-				hexToRGBA(moreDasheline["ThreeDashColor"]),
-				hexToRGBA(moreDasheline["FourDashColor"]),
-				hexToRGBA(moreDasheline["FiveDashColor"])
-			])
-			println("Using MoreDasheline hair colors for CommunalHelper DreamBlocks.")
-			return colors
-		end
-	catch err
-		@warn "Error loading MoreDasheline hair colors:\n$err"
-	end
-	
-	println("MoreDasheline hair colors not loaded, using default hair colors for CommunalHelper DreamBlocks.")
+            colors = append!(colors, [
+                    hexToRGBA(moreDasheline["ThreeDashColor"]),
+                    hexToRGBA(moreDasheline["FourDashColor"]),
+                    hexToRGBA(moreDasheline["FiveDashColor"]),
+                ],
+            )
+            println("Using MoreDasheline hair colors for CommunalHelper DreamBlocks.")
+            return colors
+        end
+    catch err
+        @warn "Error loading MoreDasheline hair colors:\n$err"
+    end
 
-	return colors
+    println(
+        "MoreDasheline hair colors not loaded, using default hair colors for CommunalHelper DreamBlocks.",
+    )
+
+    return colors
 end
 
 const hairColors = getPlayerHairColors()
 
-
 const cassetteBlock = "objects/cassetteblock/solid"
-const cassetteColors = Dict{Int, Ahorn.colorTupleType}(
-   1 => (240, 73, 190, 255) ./ 255,
-	2 => (252, 220, 58, 255) ./ 255,
-	3 => (56, 224, 78, 255) ./ 255
+const cassetteColors = Dict{Int,Ahorn.colorTupleType}(
+    1 => (240, 73, 190, 255) ./ 255,
+    2 => (252, 220, 58, 255) ./ 255,
+    3 => (56, 224, 78, 255) ./ 255,
 )
 const defaultCassetteColor = (73, 170, 240, 255) ./ 255
 
-const cassetteColorNames = Dict{String, Int}(
-    "Blue" => 0,
-    "Rose" => 1,
-    "Bright Sun" => 2,
-    "Malachite" => 3
-)
+const cassetteColorNames =
+    Dict{String,Int}("Blue" => 0, "Rose" => 1, "Bright Sun" => 2, "Malachite" => 3)
 
 getCassetteColor(index::Int) = get(cassetteColors, index, defaultCassetteColor)
 
 function renderCassetteBlock(ctx::CairoContext, x, y, width, height, index, customColor=nothing)
-   tileWidth = ceil(Int, width / 8)
-   tileHeight = ceil(Int, height / 8)
+    tileWidth = ceil(Int, width / 8)
+    tileHeight = ceil(Int, height / 8)
 
-   color = isnothing(customColor) ? get(cassetteColors, index, defaultCassetteColor) : customColor
+    color = isnothing(customColor) ? get(cassetteColors, index, defaultCassetteColor) : customColor
 
-   for i in 1:tileWidth, j in 1:tileHeight
-		tx = (i == 1) ? 0 : ((i == tileWidth) ? 16 : 8)
-      ty = (j == 1) ? 0 : ((j == tileHeight) ? 16 : 8)
+    for i in 1:tileWidth, j in 1:tileHeight
+        tx = (i == 1) ? 0 : ((i == tileWidth) ? 16 : 8)
+        ty = (j == 1) ? 0 : ((j == tileHeight) ? 16 : 8)
 
-      Ahorn.drawImage(ctx, cassetteBlock, x + (i - 1) * 8, y + (j - 1) * 8, tx, ty, 8, 8, tint=color)
+        Ahorn.drawImage(ctx, cassetteBlock, x + (i - 1) * 8, y + (j - 1) * 8, tx, ty, 8, 8, tint=color)
     end
 end
 
 # Get Rectangles from SolidExtensions present in the room.
 function getExtensionRectangles(room::Room)
-	entities = filter(e -> e.name == "CommunalHelper/SolidExtension", room.entities)
-	rects = []
+    entities = filter(e -> e.name == "CommunalHelper/SolidExtension", room.entities)
+    rects = []
 
-	for e in entities
-		 push!(rects, Ahorn.Rectangle(
-			  Int(get(e.data, "x", 0)),
-			  Int(get(e.data, "y", 0)),
-			  Int(get(e.data, "width", 8)),
-			  Int(get(e.data, "height", 8))
-		 ))
-	end
-		 
-	return rects
+    for e in entities
+        push!(
+            rects,
+            Ahorn.Rectangle(
+                Int(get(e.data, "x", 0)),
+                Int(get(e.data, "y", 0)),
+                Int(get(e.data, "width", 8)),
+                Int(get(e.data, "height", 8)),
+            ),
+        )
+    end
+
+    return rects
 end
 
 "Check for collision with an array of rectangles at specified tile position"
 function notAdjacent(x, y, ox, oy, rects)
-	rect = Ahorn.Rectangle(x + ox + 4, y + oy + 4, 1, 1)
+    rect = Ahorn.Rectangle(x + ox + 4, y + oy + 4, 1, 1)
 
-	for r in rects
-		 if Ahorn.checkCollision(r, rect)
-			  return false
-		 end
-	end
+    for r in rects
+        if Ahorn.checkCollision(r, rect)
+            return false
+        end
+    end
 
-	return true
+    return true
 end
 notAdjacent(entity::Entity, ox, oy, rects) = notAdjacent(Ahorn.position(entity)..., ox, oy, rects)
 
 function detectMod(mod)
-	any(s -> occursin(mod, lowercase(s)), Ahorn.getCelesteModZips()) ||
-		any(s -> occursin(mod, lowercase(s)), Ahorn.getCelesteModDirs())
+    any(s -> occursin(mod, lowercase(s)), Ahorn.getCelesteModZips()) ||
+        any(s -> occursin(mod, lowercase(s)), Ahorn.getCelesteModDirs())
+end
+
+# Don't worry about it
+macro mapdefdata(entity::Symbol, id::String, type::Symbol, data::Symbol)
+    expr = Base.eval(__module__, data)
+    expr.args[1] = type
+    return :(@mapdef $entity $id $expr) |> esc
+end
+
+function appendkwargs(func::Expr, kwargs::Expr...)
+    return _appendkwargs(deepcopy(func), deepcopy(kwargs)...)
+end
+
+function _appendkwargs(func::Expr, kwargs::Expr...)
+    for e in kwargs
+        if e.head == :tuple
+            func = appendkwargs(func, e.args...)
+        else
+            e.head = :kw
+            push!(func.args, e)
+        end
+    end
+    return func
 end
 
 end

--- a/Ahorn/libraries/CommunalHelper.jl
+++ b/Ahorn/libraries/CommunalHelper.jl
@@ -260,13 +260,13 @@ macro mapdefdata(entity::Symbol, id::String, type::Symbol, data::Symbol)
 end
 
 function appendkwargs(func::Expr, kwargs::Expr...)
-    return _appendkwargs(deepcopy(func), deepcopy(kwargs)...)
+    return _appendkwargs!(deepcopy(func), deepcopy(kwargs)...)
 end
 
-function _appendkwargs(func::Expr, kwargs::Expr...)
+function _appendkwargs!(func::Expr, kwargs::Expr...)
     for e in kwargs
         if e.head == :tuple
-            func = appendkwargs(func, e.args...)
+            _appendkwargs!(func, e.args...)
         else
             e.head = :kw
             push!(func.args, e)

--- a/Ahorn/triggers/TrackSwitchTrigger.jl
+++ b/Ahorn/triggers/TrackSwitchTrigger.jl
@@ -5,21 +5,25 @@ using ..Ahorn, Maple
 modes = ["Alternate", "On", "Off"]
 
 @mapdef Trigger "CommunalHelper/TrackSwitchTrigger" TrackSwitchTrigger(
-					x::Integer, y::Integer, 
-					width::Integer = Maple.defaultTriggerWidth, 
-					height::Integer = Maple.defaultTriggerHeight,
-					oneUse::Bool = true, flash::Bool = false, globalSwitch::Bool = false, mode::String = "Alternate")
-					
-
-const placements = Ahorn.PlacementDict(
-	"Track Switch Trigger (Communal Helper)" => Ahorn.EntityPlacement(
-		TrackSwitchTrigger,
-		"rectangle"
-	)
+    x::Integer,
+    y::Integer,
+    width::Integer=Maple.defaultTriggerWidth,
+    height::Integer=Maple.defaultTriggerHeight,
+    oneUse::Bool=true,
+    flash::Bool=false,
+    globalSwitch::Bool=false,
+    mode::String="Alternate",
 )
 
-Ahorn.editingOptions(trigger::TrackSwitchTrigger) = Dict{String, Any}(
-    "mode" => modes
+const placements = Ahorn.PlacementDict(
+    "Track Switch Trigger (Communal Helper)" => Ahorn.EntityPlacement(
+        TrackSwitchTrigger, 
+        "rectangle"
+    ),
+)
+
+Ahorn.editingOptions(trigger::TrackSwitchTrigger) = Dict{String,Any}(
+    "mode" => modes,
 )
 
 end


### PR DESCRIPTION
Used [JuliaFormatter.jl](https://github.com/domluna/JuliaFormatter.jl) to auto-format files according to the included `.JuliaFormatter.toml` file.

Since some results from the auto-format were undesirable (usually due to inconsistencies throughout similar code) the code was hand-tweaked to be consistent.

Some optimizations were made to code, as well as rewriting the `@mapdef`s in `TimedTriggerSpikes.jl` to use a new macro, `@mapdefdata`, which allows for reusing attributes between entity types (should this break at any point, it should be reverted immediately).

