### PR TITLE
Fix CassetteZipMover liftboost when deactivating

### DIFF
--- a/src/Entities/CassetteStuff/CassetteMoveBlock.cs
+++ b/src/Entities/CassetteStuff/CassetteMoveBlock.cs
@@ -210,7 +210,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                 MoveStaticMovers(newPosition - Position);
                 Position = newPosition;
                 Visible = false;
-                UpdatePresent(false);
+                Present = false;
                 yield return 2.2f;
 
                 foreach (MoveBlockDebris d in debris)
@@ -218,7 +218,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                 while (CollideCheck<Actor>() || CollideCheck<Solid>())
                     yield return null;
 
-                UpdatePresent(true);
+                Present = true;
                 EventInstance sound = Audio.Play(SFX.game_04_arrowblock_reform_begin, debris[0].Position);
                 Coroutine component;
                 Coroutine routine = component = new Coroutine(SoundFollowsDebrisCenter(sound, debris));

--- a/src/Entities/CassetteStuff/CassetteZipMover.cs
+++ b/src/Entities/CassetteStuff/CassetteZipMover.cs
@@ -21,12 +21,6 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             private MTexture cogWhite;
             private Vector2 from;
             private Vector2 to;
-            private Vector2 sparkAdd;
-
-            private float sparkDirFromA;
-            private float sparkDirFromB;
-            private float sparkDirToA;
-            private float sparkDirToB;
 
             private ParticleType sparkParticle;
             private ParticleType sparkParticlePressed;
@@ -34,15 +28,6 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             public PathRenderer(CassetteZipMover zipMover) {
                 Depth = Depths.BGDecals;
                 this.zipMover = zipMover;
-
-                from = this.zipMover.start + new Vector2(this.zipMover.Width / 2f, this.zipMover.Height / 2f);
-                to = this.zipMover.targets[0] + new Vector2(this.zipMover.Width / 2f, this.zipMover.Height / 2f);
-                sparkAdd = (from - to).SafeNormalize(5f).Perpendicular();
-                float angle = (from - to).Angle();
-                sparkDirFromA = angle + (float) Math.PI / 8f;
-                sparkDirFromB = angle - (float) Math.PI / 8f;
-                sparkDirToA = angle + (float) Math.PI - (float) Math.PI / 8f;
-                sparkDirToB = angle + (float) Math.PI + (float) Math.PI / 8f;
 
                 cog = GFX.Game["objects/CommunalHelper/cassetteZipMover/cog"];
                 cogPressed = GFX.Game["objects/CommunalHelper/cassetteZipMover/cogPressed"];
@@ -59,20 +44,51 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             }
 
             public void CreateSparks() {
-                from = GetNodeFrom(zipMover.start);
-                for (int i = 0; i < zipMover.targets.Length; i++) {
-                    to = GetNodeFrom(zipMover.targets[i]);
-                    ParticleType particle = zipMover.Collidable ? sparkParticle : sparkParticlePressed;
-                    SceneAs<Level>().ParticlesBG.Emit(particle, from + sparkAdd + Calc.Random.Range(-Vector2.One, Vector2.One), sparkDirFromA);
-                    SceneAs<Level>().ParticlesBG.Emit(particle, from - sparkAdd + Calc.Random.Range(-Vector2.One, Vector2.One), sparkDirFromB);
-                    SceneAs<Level>().ParticlesBG.Emit(particle, to + sparkAdd + Calc.Random.Range(-Vector2.One, Vector2.One), sparkDirToA);
-                    SceneAs<Level>().ParticlesBG.Emit(particle, to - sparkAdd + Calc.Random.Range(-Vector2.One, Vector2.One), sparkDirToB);
-                    from = GetNodeFrom(zipMover.targets[i]);
+                ParticleType particle = zipMover.Collidable ? sparkParticle : sparkParticlePressed;
+                ParticleSystem particlesBG = SceneAs<Level>().ParticlesBG;
+
+                // First Node
+                Vector2 node = GetNodeFrom(zipMover.start, true);
+                Vector2 next = GetNodeFrom(zipMover.nodes[1], true);
+
+                float angle = Calc.Angle(node, next);
+                float sparkDir = angle + Calc.QuarterCircle;
+                Vector2 sparkAdd = Calc.AngleToVector(sparkDir, 5f);
+
+                particlesBG.Emit(particle, node + sparkAdd + Calc.Random.Range(-Vector2.One, Vector2.One), sparkDir + Calc.EighthCircle);
+                particlesBG.Emit(particle, node - sparkAdd + Calc.Random.Range(-Vector2.One, Vector2.One), sparkDir + Calc.HalfCircle - Calc.EighthCircle);
+
+                // Mid Nodes
+                for (int i = 2; i < zipMover.nodes.Length; i++) {
+                    node = next;
+                    next = GetNodeFrom(zipMover.nodes[i], true);
+
+                    // Half-way angle between previous and next nodes
+                    float lastAngle = angle;
+                    angle = Calc.Angle(node, next);
+                    sparkDir = Calc.AngleLerp(lastAngle, angle, 0.5f) - Calc.QuarterCircle;
+                    sparkAdd = Calc.AngleToVector(sparkDir, 5f);
+
+                    particlesBG.Emit(particle, node + sparkAdd + Calc.Random.Range(-Vector2.One, Vector2.One), sparkDir);
+                    particlesBG.Emit(particle, node - sparkAdd + Calc.Random.Range(-Vector2.One, Vector2.One), sparkDir + Calc.HalfCircle);
                 }
+
+                // Last Node
+                node = next;
+
+                sparkDir = angle - Calc.QuarterCircle;
+                sparkAdd = Calc.AngleToVector(sparkDir, 5f);
+
+                particlesBG.Emit(particle, node + sparkAdd + Calc.Random.Range(-Vector2.One, Vector2.One), sparkDir + Calc.EighthCircle);
+                particlesBG.Emit(particle, node - sparkAdd + Calc.Random.Range(-Vector2.One, Vector2.One), sparkDir + Calc.HalfCircle - Calc.EighthCircle);
             }
 
-            private Vector2 GetNodeFrom(Vector2 node) {
-                return node + new Vector2(zipMover.Width / 2f, zipMover.Height / 2f);
+            private Vector2 GetNodeFrom(Vector2 node, bool offsetBlockHeight = false) {
+                Vector2 ret = node + new Vector2(zipMover.Width / 2f, zipMover.Height / 2f);
+                if (offsetBlockHeight) {
+                    ret += zipMover.blockOffset;
+                }
+                return ret;
             }
 
             public override void Update() {
@@ -81,21 +97,25 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             }
 
             public override void Render() {
-                from = GetNodeFrom(zipMover.start);
-                for (int j = 0; j < zipMover.targets.Length; j++) {
-                    for (int i = 1; i <= zipMover.blockHeight; ++i) {
-                        to = GetNodeFrom(zipMover.targets[j]);
-                        DrawCogs(zipMover.blockOffset + Vector2.UnitY * i, undersideColor);
-                        from = GetNodeFrom(zipMover.targets[j]);
+                int blockHeight = zipMover.blockHeight;
+                // Draw the "drop shadow" when active
+                if (blockHeight != 0) {
+                    from = GetNodeFrom(zipMover.start);
+                    for (int j = 1; j < zipMover.nodes.Length; j++) {
+                        for (int i = 1; i <= blockHeight; ++i) {
+                            to = GetNodeFrom(zipMover.nodes[j]);
+                            DrawCogs(Vector2.UnitY * i, undersideColor);
+                            from = to;
+                        }
                     }
                 }
-                from = GetNodeFrom(zipMover.start);
-                for (int j = 0; j < zipMover.targets.Length; j++) {
-                    to = GetNodeFrom(zipMover.targets[j]);
-                    DrawCogs(zipMover.blockOffset);
-                    from = GetNodeFrom(zipMover.targets[j]);
-                }
 
+                from = GetNodeFrom(zipMover.start);
+                for (int j = 1; j < zipMover.nodes.Length; j++) {
+                    to = GetNodeFrom(zipMover.nodes[j]);
+                    DrawCogs(zipMover.blockOffset);
+                    from = to;
+                }
             }
 
             private void DrawCogs(Vector2 offset, Color? colorOverride = null) {
@@ -130,13 +150,17 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         private SoundSource sfx = new SoundSource();
         private SoundSource altSfx = new SoundSource();
 
-        private Vector2[] targets, points, originalNodes;
+        /// <summary>
+        /// Entity nodes with start Position as the first element
+        /// </summary>
+        protected Vector2[] nodes;
+
         private bool permanent;
         private bool waits;
         private bool ticking;
         private bool noReturn;
 
-        public CassetteZipMover(Vector2 position, EntityID id, int width, int height, Vector2[] targets, int index, float tempo, bool noReturn, bool perm, bool waits, bool ticking, Color? overrideColor)
+        public CassetteZipMover(Vector2 position, EntityID id, int width, int height, Vector2[] nodes, int index, float tempo, bool noReturn, bool perm, bool waits, bool ticking, Color? overrideColor)
             : base(position, id, width, height, index, tempo, false, overrideColor) {
             start = Position;
             this.noReturn = noReturn;
@@ -144,10 +168,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             this.waits = waits;
             this.ticking = ticking;
 
-            this.targets = new Vector2[targets.Length];
-            points = new Vector2[targets.Length + 1];
-            points[0] = Position;
-            originalNodes = targets;
+            this.nodes = nodes;
 
             Add(new Coroutine(Sequence()));
 
@@ -158,7 +179,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         }
 
         public CassetteZipMover(EntityData data, Vector2 offset, EntityID id)
-            : this(data.Position + offset, id, data.Width, data.Height, data.Nodes, data.Int("index"), data.Float("tempo", 1f),
+            : this(data.Position + offset, id, data.Width, data.Height, data.NodesWithPosition(offset), data.Int("index"), data.Float("tempo", 1f),
                   data.Bool("noReturn", false),
                   data.Bool("permanent"),
                   data.Bool("waiting"),
@@ -178,15 +199,6 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         public override void Added(Scene scene) {
             base.Added(scene);
-
-            // Offset the points to their position, relative to the room's position.
-            Rectangle bounds = SceneAs<Level>().Bounds;
-            Vector2 levelOffset = new Vector2(bounds.Left, bounds.Top);
-            for (int i = 0; i < originalNodes.Length; i++) {
-                targets[i] = originalNodes[i] + levelOffset;
-                points[i + 1] = targets[i];
-            }
-
             scene.Add(pathRenderer = new PathRenderer(this));
         }
 
@@ -246,7 +258,6 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         private IEnumerator Sequence() {
             // Infinite.
-            Vector2 start = Position;
             while (true) {
                 if (!HasPlayerRider()) {
                     yield return null;
@@ -260,8 +271,9 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                 // Player is riding.
                 bool shouldCancel = false;
                 int i;
-                for (i = 0; i < targets.Length; i++) {
-                    to = targets[i];
+                // Zeroth node is the origin
+                for (i = 1; i < nodes.Length; i++) {
+                    to = nodes[i];
 
                     // Start shaking.
                     sfx.Play(CustomSFX.game_connectedZipMover_normal_zip_mover_start);
@@ -278,6 +290,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                         at2 = Calc.Approach(at2, 1f, 2f * Engine.DeltaTime);
                         percent = Ease.SineIn(at2);
                         Vector2 vector = Vector2.Lerp(from, to, percent);
+                        vector = FixCassetteY(vector);
                         ScrapeParticlesCheck(to);
                         if (Scene.OnInterval(0.1f)) {
                             pathRenderer.CreateSparks();
@@ -285,7 +298,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                         MoveTo(vector);
                     }
 
-                    bool last = (i == targets.Length - 1);
+                    bool last = (i == nodes.Length - 1);
 
                     // Arrived, will wait for 0.5 secs.
                     StartShaking(0.2f);
@@ -295,7 +308,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                     StopPlayerRunIntoAnimation = true;
                     yield return 0.5f;
 
-                    from = targets[i];
+                    from = nodes[i];
 
                     if (ticking && !last) {
                         float tickTime = 0.0f;
@@ -329,10 +342,11 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                 if (!permanent) {
                     if (noReturn) {
                         ReverseNodes(out Vector2 newStart);
-                        start = this.start = newStart;
+                        start = newStart;
                     } else {
-                        for (i -= 2 - (shouldCancel ? 1 : 0); i > -2; i--) {
-                            to = (i == -1) ? start : targets[i];
+                        for (i -= 2 - (shouldCancel ? 1 : 0); i > -1; i--) {
+                            
+                            to = (i == 0) ? start : nodes[i];
 
                             // Goes back to start with a speed that is four times slower.
                             StopPlayerRunIntoAnimation = false;
@@ -344,10 +358,11 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                                 at2 = Calc.Approach(at2, 1f, 0.5f * Engine.DeltaTime);
                                 percent = 1f - Ease.SineIn(at2);
                                 Vector2 position = Vector2.Lerp(from, to, Ease.SineIn(at2));
+                                position = FixCassetteY(position);
                                 MoveTo(position);
                             }
-                            if (i != -1) {
-                                from = targets[i];
+                            if (i != 0) {
+                                from = nodes[i];
                             }
 
                             StartShaking(0.2f);
@@ -374,12 +389,13 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             }
         }
 
+        private Vector2 FixCassetteY(Vector2 vec) {
+            return vec + blockOffset;
+        }
+
         private void ReverseNodes(out Vector2 newStart) {
-            Array.Reverse(points);
-            for (int i = 0; i < points.Length - 1; i++) {
-                targets[i] = points[i + 1];
-            }
-            newStart = points[0];
+            Array.Reverse(nodes);
+            newStart = nodes[0];
         }
     }
 }

--- a/src/Entities/CassetteStuff/CustomCassetteBlock.cs
+++ b/src/Entities/CassetteStuff/CustomCassetteBlock.cs
@@ -15,7 +15,8 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         public static List<string> CustomCassetteBlockNames = new List<string>();
 
         public static void Initialize() {
-            // Overengineered attempt to handle CustomCassetteBlock types
+            // Overengineered attempt to handle adding a CassetteBlockController when CustomCassetteBlock types are present
+            // Actual loading handled in the OnLoadEntity handler
             IEnumerable<Type> customCassetteBlockTypes =
                 from module in Everest.Modules
                 from type in module.GetType().Assembly.GetTypesSafe()
@@ -42,13 +43,32 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         protected Color color;
         protected Color pressedColor;
 
-        public int blockHeight = 2;
-        protected Vector2 blockOffset = Vector2.Zero;
+        protected int blockHeight {
+            get => blockData.Get<int>("blockHeight");
+            set => blockData.Set("blockHeight", value);
+        }
+        /// <summary>
+        /// Block offset based on <c>(2 - <see cref="blockHeight"/>)</c>
+        /// </summary>
+        protected Vector2 blockOffset => Vector2.UnitY * (2 - blockHeight);
+        // dynamic hitbox currently disabled
         private bool dynamicHitbox;
         private Hitbox[] hitboxes;
 
-        public bool Present = true;
-        public bool virtualCollidable = true;
+        private bool present = true;
+        /// <summary>
+        /// Whether the block is actually collidable, not just according to cassette state.
+        /// </summary>
+        public bool Present {
+            get => present;
+            set {
+                present = value;
+                // Update collision immediately without waiting for Update
+                Collidable = value && virtualCollidable;
+            }
+        }
+        // Whether the block is collidable according to cassette state
+        private bool virtualCollidable = true;
 
         protected DynData<CassetteBlock> blockData;
 
@@ -78,8 +98,11 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             if (!Present) {
                 Collidable = virtualCollidable;
             }
+
             base.Update();
+            // Update what the cassette state dictates collision should be
             virtualCollidable = Collidable;
+
             if (!Present) {
                 Collidable = false;
                 DisableStaticMovers();
@@ -93,15 +116,15 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             Vector2 origin = blockData.Get<Vector2>("groupOrigin") - Position;
             Vector2 size = new Vector2(Width, Height);
 
-            Vector2 value = (size - new Vector2(solid.Width, solid.Height)) * 0.5f;
-            solid.Origin = origin - value;
+            Vector2 half = (size - new Vector2(solid.Width, solid.Height)) * 0.5f;
+            solid.Origin = origin - half;
             solid.Position = origin;
             solid.Color = color;
             Add(solid);
             all.Add(solid);
 
-            value = (size - new Vector2(pressed.Width, pressed.Height)) * 0.5f;
-            pressed.Origin = origin - value;
+            half = (size - new Vector2(pressed.Width, pressed.Height)) * 0.5f;
+            pressed.Origin = origin - half;
             pressed.Position = origin;
             pressed.Color = color;
             Add(pressed);
@@ -110,7 +133,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         public void HandleShiftSize(int amount) {
             blockHeight -= amount;
-            blockOffset = (2 - blockHeight) * Vector2.UnitY;
+            //blockOffset = (2 - blockHeight) * Vector2.UnitY;
             if (dynamicHitbox) {
                 Collider = hitboxes[blockHeight];
             }
@@ -123,17 +146,12 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             }
         }
 
-        protected void UpdatePresent(bool present) {
-            Present = present;
-            Collidable = present && virtualCollidable;
-        }
-
         #region Hooks
 
         private static bool createdCassetteManager = false;
 
         internal static void Hook() {
-            On.Celeste.CassetteBlock.ShiftSize += CassetteBlock_ShiftSize;
+            //On.Celeste.CassetteBlock.ShiftSize += CassetteBlock_ShiftSize;
             On.Celeste.CassetteBlock.UpdateVisualState += CassetteBlock_UpdateVisualState;
             IL.Celeste.CassetteBlock.Update += CassetteBlock_Update;
             On.Celeste.Level.LoadLevel += Level_LoadLevel;
@@ -141,7 +159,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         }
 
         internal static void Unhook() {
-            On.Celeste.CassetteBlock.ShiftSize -= CassetteBlock_ShiftSize;
+            //On.Celeste.CassetteBlock.ShiftSize -= CassetteBlock_ShiftSize;
             On.Celeste.CassetteBlock.UpdateVisualState -= CassetteBlock_UpdateVisualState;
             IL.Celeste.CassetteBlock.Update -= CassetteBlock_Update;
             On.Celeste.Level.LoadLevel -= Level_LoadLevel;

--- a/src/Entities/CassetteStuff/CustomCassetteBlock.cs
+++ b/src/Entities/CassetteStuff/CustomCassetteBlock.cs
@@ -51,7 +51,6 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         /// Block offset based on <c>(2 - <see cref="blockHeight"/>)</c>
         /// </summary>
         protected Vector2 blockOffset => Vector2.UnitY * (2 - blockHeight);
-        // dynamic hitbox currently disabled
         private bool dynamicHitbox;
         private Hitbox[] hitboxes;
 
@@ -132,10 +131,8 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         }
 
         public void HandleShiftSize(int amount) {
-            blockHeight -= amount;
-            //blockOffset = (2 - blockHeight) * Vector2.UnitY;
             if (dynamicHitbox) {
-                Collider = hitboxes[blockHeight];
+                Collider = hitboxes[blockHeight - amount];
             }
         }
 
@@ -151,7 +148,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         private static bool createdCassetteManager = false;
 
         internal static void Hook() {
-            //On.Celeste.CassetteBlock.ShiftSize += CassetteBlock_ShiftSize;
+            On.Celeste.CassetteBlock.ShiftSize += CassetteBlock_ShiftSize;
             On.Celeste.CassetteBlock.UpdateVisualState += CassetteBlock_UpdateVisualState;
             IL.Celeste.CassetteBlock.Update += CassetteBlock_Update;
             On.Celeste.Level.LoadLevel += Level_LoadLevel;
@@ -159,7 +156,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         }
 
         internal static void Unhook() {
-            //On.Celeste.CassetteBlock.ShiftSize -= CassetteBlock_ShiftSize;
+            On.Celeste.CassetteBlock.ShiftSize -= CassetteBlock_ShiftSize;
             On.Celeste.CassetteBlock.UpdateVisualState -= CassetteBlock_UpdateVisualState;
             IL.Celeste.CassetteBlock.Update -= CassetteBlock_Update;
             On.Celeste.Level.LoadLevel -= Level_LoadLevel;
@@ -179,9 +176,9 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                     cassetteBlock.HandleShiftSize(amount);
                 }
             }
-            if (shift) {
+
+            if (shift)
                 orig(block, amount);
-            }
         }
 
         private static void CassetteBlock_UpdateVisualState(On.Celeste.CassetteBlock.orig_UpdateVisualState orig, CassetteBlock block) {


### PR DESCRIPTION
Also cleans up CassetteZipMover code (three different fields for tracking the nodes?) and improves the "spark" particles for nodes

Should keep full functionality (including `dynamicHitbox`) for other CassetteBlocks