### PR TITLE
Fix CassetteMoveBlock's static movers visual issues

### DIFF
--- a/src/Entities/CassetteStuff/CassetteMoveBlock.cs
+++ b/src/Entities/CassetteStuff/CassetteMoveBlock.cs
@@ -208,6 +208,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                 }
                 Vector2 newPosition = startPosition + blockOffset;
                 SetDisabledStaticMoversVisibility(false);
+                SetStaticMoversVisible(false);
                 MoveStaticMovers(newPosition - Position);
                 Position = newPosition;
                 Visible = false;
@@ -237,10 +238,16 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                     d.RemoveSelf();
                 Audio.Play("event:/game/04_cliffside/arrowblock_reappear", Position);
                 Visible = true;
-                if (Collidable) {
-                    EnableStaticMovers();
-                }
                 SetDisabledStaticMoversVisibility(true);
+                SetStaticMoversVisible(true);
+                
+                if (Collidable)
+                    EnableStaticMovers();
+                else {
+                    // would inexplicably appear turned on
+                    DisableStaticMovers();
+                }
+
                 speed = targetSpeed = 0f;
                 angle = targetAngle = homeAngle;
                 noSquish = null;

--- a/src/Entities/CassetteStuff/CassetteMoveBlock.cs
+++ b/src/Entities/CassetteStuff/CassetteMoveBlock.cs
@@ -207,6 +207,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                     }
                 }
                 Vector2 newPosition = startPosition + blockOffset;
+                SetDisabledStaticMoversVisibility(false);
                 MoveStaticMovers(newPosition - Position);
                 Position = newPosition;
                 Visible = false;
@@ -239,6 +240,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                 if (Collidable) {
                     EnableStaticMovers();
                 }
+                SetDisabledStaticMoversVisibility(true);
                 speed = targetSpeed = 0f;
                 angle = targetAngle = homeAngle;
                 noSquish = null;

--- a/src/Entities/CassetteStuff/CustomCassetteBlock.cs
+++ b/src/Entities/CassetteStuff/CustomCassetteBlock.cs
@@ -157,6 +157,12 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             }
         }
 
+        protected void SetStaticMoversVisible(bool visible) {
+            foreach (StaticMover staticMover in staticMovers) {
+                staticMover.Entity.Visible = visible;
+            }
+        }
+
         #region Hooks
 
         private static bool createdCassetteManager = false;
@@ -167,6 +173,9 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             IL.Celeste.CassetteBlock.Update += CassetteBlock_Update;
             On.Celeste.Level.LoadLevel += Level_LoadLevel;
             Everest.Events.Level.OnLoadEntity += Level_OnLoadEntity;
+
+            // Fix static movers getting enabled by Platform.EnableStaticMovers when CustomCassetteBlock is not visible.
+            On.Celeste.Platform.EnableStaticMovers += Platform_EnableStaticMovers;
         }
 
         internal static void Unhook() {
@@ -175,6 +184,14 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             IL.Celeste.CassetteBlock.Update -= CassetteBlock_Update;
             On.Celeste.Level.LoadLevel -= Level_LoadLevel;
             Everest.Events.Level.OnLoadEntity -= Level_OnLoadEntity;
+
+            On.Celeste.Platform.EnableStaticMovers -= Platform_EnableStaticMovers;
+        }
+
+        private static void Platform_EnableStaticMovers(On.Celeste.Platform.orig_EnableStaticMovers orig, Platform self) {
+            if (self is CustomCassetteBlock && !self.Visible)
+                return; // do nothing
+            orig(self);
         }
 
         private static void CassetteBlock_ShiftSize(On.Celeste.CassetteBlock.orig_ShiftSize orig, CassetteBlock block, int amount) {

--- a/src/Entities/CassetteStuff/CustomCassetteBlock.cs
+++ b/src/Entities/CassetteStuff/CustomCassetteBlock.cs
@@ -143,6 +143,20 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             }
         }
 
+        /// <summary>
+        /// Makes static movers (Spikes and Springs) appear or disappear when they are disabled.
+        /// </summary>
+        /// <param name="visible">Whether disabled static movers should be visible.</param>
+        protected void SetDisabledStaticMoversVisibility(bool visible) {
+            foreach (StaticMover staticMover in staticMovers) {
+                if (staticMover.Entity is Spikes spikes)
+                    spikes.VisibleWhenDisabled = visible;
+
+                if (staticMover.Entity is Spring spring)
+                    spring.VisibleWhenDisabled = visible;
+            }
+        }
+
         #region Hooks
 
         private static bool createdCassetteManager = false;


### PR DESCRIPTION
Basically done by setting `Spikes` and `Spring`'s `VisibleWhenDisabled` field to false during the respawning sequence, and by preventing `Platform.EnableStaticMovers` from setting static movers visible regardless of the state of the block.