### PR TITLE
Refactor out shared Ahorn entity data using @mapdefdata

### DIFF
--- a/Ahorn/.vscode/extensions.json
+++ b/Ahorn/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+    "recommendations": ["julialang.language-julia"]
+}

--- a/Ahorn/.vscode/settings.json
+++ b/Ahorn/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "julia.environmentPath": "${env:LocalAppData}\\Ahorn\\env"
+}

--- a/Ahorn/entities/cassetteBlocks/CassetteFallingBlock.jl
+++ b/Ahorn/entities/cassetteBlocks/CassetteFallingBlock.jl
@@ -2,16 +2,9 @@ module CommunalHelperCassetteFallingBlock
 
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
+using Ahorn.CommunalHelperEntityPresets: CustomCassetteBlockData
 
-@mapdef Entity "CommunalHelper/CassetteFallingBlock" CassetteFallingBlock(
-    x::Integer,
-    y::Integer,
-    width::Integer=Maple.defaultBlockWidth,
-    height::Integer=Maple.defaultBlockHeight,
-    index::Integer=0,
-    tempo::Number=1.0,
-    customColor="",
-)
+@mapdefdata Entity "CommunalHelper/CassetteFallingBlock" CassetteFallingBlock CustomCassetteBlockData
 
 const placements = Ahorn.PlacementDict(
     "Cassette Falling Block ($index - $color) (Communal Helper)" => Ahorn.EntityPlacement(

--- a/Ahorn/entities/cassetteBlocks/CassetteMoveBlock.jl
+++ b/Ahorn/entities/cassetteBlocks/CassetteMoveBlock.jl
@@ -2,18 +2,13 @@ module CommunalHelperCassetteMoveBlock
 
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
+using Ahorn.CommunalHelperEntityPresets: CustomCassetteBlockData
 
-@mapdef Entity "CommunalHelper/CassetteMoveBlock" CassetteMoveBlock(
-    x::Integer,
-    y::Integer,
-    width::Integer=Maple.defaultBlockWidth,
-    height::Integer=Maple.defaultBlockHeight,
+const entityData = appendkwargs(CustomCassetteBlockData, :(
     direction::String="Right",
     moveSpeed::Number=60.0,
-    index::Integer=0,
-    tempo::Number=1.0,
-    customColor="",
-)
+))
+@mapdefdata Entity "CommunalHelper/CassetteMoveBlock" CassetteMoveBlock entityData
 
 const placements = Ahorn.PlacementDict(
     "Cassette Move Block ($index - $color) (Communal Helper)" => Ahorn.EntityPlacement(

--- a/Ahorn/entities/cassetteBlocks/CassetteSwapBlock.jl
+++ b/Ahorn/entities/cassetteBlocks/CassetteSwapBlock.jl
@@ -2,6 +2,7 @@ module CommunalHelperCassetteSwapBlock
 
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
+using Ahorn.CommunalHelperEntityPresets: CustomCassetteBlockData
 
 function swapFinalizer(entity)
     x, y = Ahorn.position(entity)
@@ -10,16 +11,10 @@ function swapFinalizer(entity)
     entity.data["nodes"] = [(x + width, y)]
 end
 
-@mapdef Entity "CommunalHelper/CassetteSwapBlock" CassetteSwapBlock(
-    x::Integer,
-    y::Integer,
-    width::Integer=Maple.defaultBlockWidth,
-    height::Integer=Maple.defaultBlockHeight,
-    index::Integer=0,
-    tempo::Number=1.0,
+const entityData = appendkwargs(CustomCassetteBlockData, :(
     noReturn::Bool=false,
-    customColor="",
-)
+))
+@mapdefdata Entity "CommunalHelper/CassetteSwapBlock" CassetteSwapBlock entityData
 
 const ropeColors = Dict{Int,Ahorn.colorTupleType}(
     1 => (194, 116, 171, 255) ./ 255,

--- a/Ahorn/entities/cassetteBlocks/CassetteZipMover.jl
+++ b/Ahorn/entities/cassetteBlocks/CassetteZipMover.jl
@@ -2,20 +2,15 @@ module CommunalHelperCassetteZipMover
 
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
+using Ahorn.CommunalHelperEntityPresets: CustomCassetteBlockData
 
-@mapdef Entity "CommunalHelper/CassetteZipMover" CassetteZipMover(
-    x::Integer,
-    y::Integer,
-    width::Integer=Maple.defaultBlockWidth,
-    height::Integer=Maple.defaultBlockHeight,
-    index::Integer=0,
-    tempo::Number=1.0,
+const entityData = appendkwargs(CustomCassetteBlockData, :(
     permanent::Bool=false,
     waiting::Bool=false,
     ticking::Bool=false,
     noReturn::Bool=false,
-    customColor="",
-)
+))
+@mapdefdata Entity "CommunalHelper/CassetteZipMover" CassetteZipMover entityData
 
 const ropeColors = Dict{Int,Ahorn.colorTupleType}(
     1 => (194, 116, 171, 255) ./ 255,

--- a/Ahorn/entities/cassetteBlocks/CustomCassetteBlock.jl
+++ b/Ahorn/entities/cassetteBlocks/CustomCassetteBlock.jl
@@ -2,16 +2,9 @@ module CommunalHelperCustomCassetteBlock
 
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
+using Ahorn.CommunalHelperEntityPresets: CustomCassetteBlockData
 
-@mapdef Entity "CommunalHelper/CustomCassetteBlock" CustomCassetteBlock(
-    x::Integer,
-    y::Integer,
-    width::Integer=Maple.defaultBlockWidth,
-    height::Integer=Maple.defaultBlockHeight,
-    index::Integer=0,
-    tempo::Number=1.0,
-    customColor="",
-)
+@mapdefdata Entity "CommunalHelper/CustomCassetteBlock" CustomCassetteBlock CustomCassetteBlockData
 
 const placements = Ahorn.PlacementDict(
     "Custom Cassette Block ($index - $color) (Communal Helper)" => Ahorn.EntityPlacement(

--- a/Ahorn/entities/dreamBlocks/ConnectedDreamBlock.jl
+++ b/Ahorn/entities/dreamBlocks/ConnectedDreamBlock.jl
@@ -2,17 +2,9 @@ module CommunalHelperConnectedDreamBlock
 
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
+using Ahorn.CommunalHelperEntityPresets: CustomDreamBlockData
 
-@mapdef Entity "CommunalHelper/ConnectedDreamBlock" ConnectedDreamBlock(
-    x::Integer,
-    y::Integer,
-    width::Integer=Maple.defaultBlockWidth,
-    height::Integer=Maple.defaultBlockHeight,
-    featherMode::Bool=false,
-    oneUse::Bool=false,
-    refillCount::Integer=-1,
-    below::Bool=false,
-)
+@mapdefdata Entity "CommunalHelper/ConnectedDreamBlock" ConnectedDreamBlock CustomDreamBlockData
 
 const placements = Ahorn.PlacementDict(
     "Connected Dream Block (Normal) (Communal Helper)" => Ahorn.EntityPlacement(

--- a/Ahorn/entities/dreamBlocks/DreamCrumbleWallOnRumble.jl
+++ b/Ahorn/entities/dreamBlocks/DreamCrumbleWallOnRumble.jl
@@ -2,18 +2,12 @@ module CommunalHelperDreamCrumbleWallOnRumble
 
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
+using Ahorn.CommunalHelperEntityPresets: CustomDreamBlockData
 
-@mapdef Entity "CommunalHelper/DreamCrumbleWallOnRumble" DreamCrumbleWallOnRumble(
-    x::Integer,
-    y::Integer,
-    width::Integer=Maple.defaultBlockWidth,
-    height::Integer=Maple.defaultBlockHeight,
-    featherMode::Bool=false,
-    oneUse::Bool=false,
-    refillCount::Integer=-1,
-    below::Bool=false,
-    persistent::Bool=false,
-)
+const entityData = appendkwargs(CustomDreamBlockData, :(
+    permanent::Bool=false,
+))
+@mapdefdata Entity "CommunalHelper/DreamCrumbleWallOnRumble" DreamCrumbleWallOnRumble entityData
 
 const placements = Ahorn.PlacementDict(
     "Dream Crumble Wall On Rumble (Communal Helper)" => Ahorn.EntityPlacement(

--- a/Ahorn/entities/dreamBlocks/DreamFallingBlock.jl
+++ b/Ahorn/entities/dreamBlocks/DreamFallingBlock.jl
@@ -3,24 +3,18 @@ module CommunalHelperDreamFallingBlock
 using ..Ahorn, Maple
 using Ahorn.Cairo
 using Ahorn.CommunalHelper
+using Ahorn.CommunalHelperEntityPresets: CustomDreamBlockData
 
-@mapdef Entity "CommunalHelper/DreamFallingBlock" DreamFallingBlock(
-    x::Integer,
-    y::Integer,
-    width::Integer=Maple.defaultBlockWidth,
-    height::Integer=Maple.defaultBlockHeight,
-    featherMode::Bool=false,
-    oneUse::Bool=false,
-    refillCount::Integer=-1,
+const entityData = appendkwargs(CustomDreamBlockData, :(
     noCollide::Bool=false,
-    below::Bool=false,
     fallDistance::Integer=64,
     centeredChain::Bool=false,
     chainOutline::Bool=true,
     indicator::Bool=false,
     indicatorAtStart::Bool=false,
     chained::Bool=false,
-)
+))
+@mapdefdata Entity "CommunalHelper/DreamFallingBlock" DreamFallingBlock entityData
 
 const placements = Ahorn.PlacementDict(
     "Dream Falling Block (Communal Helper)" => Ahorn.EntityPlacement(

--- a/Ahorn/entities/dreamBlocks/DreamFloatySpaceBlock.jl
+++ b/Ahorn/entities/dreamBlocks/DreamFloatySpaceBlock.jl
@@ -2,17 +2,9 @@ module CommunalHelperDreamFloatySpaceBlock
 
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
+using Ahorn.CommunalHelperEntityPresets: CustomDreamBlockData
 
-@mapdef Entity "CommunalHelper/DreamFloatySpaceBlock" DreamFloatySpaceBlock(
-    x::Integer,
-    y::Integer,
-    width::Integer=Maple.defaultBlockWidth,
-    height::Integer=Maple.defaultBlockHeight,
-    featherMode::Bool=false,
-    oneUse::Bool=false,
-    refillCount::Integer=-1,
-    below::Bool=false,
-)
+@mapdefdata Entity "CommunalHelper/DreamFloatySpaceBlock" DreamFloatySpaceBlock CustomDreamBlockData
 
 const placements = Ahorn.PlacementDict(
     "Dream Floaty Space Block (Communal Helper)" => Ahorn.EntityPlacement(

--- a/Ahorn/entities/dreamBlocks/DreamMoveBlock.jl
+++ b/Ahorn/entities/dreamBlocks/DreamMoveBlock.jl
@@ -2,20 +2,14 @@ module CommunalHelperDreamMoveBlock
 
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
+using Ahorn.CommunalHelperEntityPresets: CustomDreamBlockData
 
-@mapdef Entity "CommunalHelper/DreamMoveBlock" DreamMoveBlock(
-    x::Integer,
-    y::Integer,
-    width::Integer=Maple.defaultBlockWidth,
-    height::Integer=Maple.defaultBlockHeight,
+const entityData = appendkwargs(CustomDreamBlockData, :(
     direction::String="Right",
     moveSpeed::Number=60.0,
     noCollide::Bool=false,
-    featherMode::Bool=false,
-    oneUse::Bool=false,
-    refillCount::Integer=-1,
-    below::Bool=false,
-)
+))
+@mapdefdata Entity "CommunalHelper/DreamMoveBlock" DreamMoveBlock entityData
 
 const placements = Ahorn.PlacementDict(
     "Dream Move Block ($direction) (Communal Helper)" => Ahorn.EntityPlacement(

--- a/Ahorn/entities/dreamBlocks/DreamSwapBlock.jl
+++ b/Ahorn/entities/dreamBlocks/DreamSwapBlock.jl
@@ -2,18 +2,12 @@ module CommunalHelperDreamSwapBlock
 
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
+using Ahorn.CommunalHelperEntityPresets: CustomDreamBlockData
 
-@mapdef Entity "CommunalHelper/DreamSwapBlock" DreamSwapBlock(
-    x::Integer,
-    y::Integer,
-    width::Integer=Maple.defaultBlockWidth,
-    height::Integer=Maple.defaultBlockHeight,
+const entityData = appendkwargs(CustomDreamBlockData, :(
     noReturn::Bool=false,
-    featherMode::Bool=false,
-    oneUse::Bool=false,
-    refillCount::Integer=-1,
-    below::Bool=false,
-)
+))
+@mapdefdata Entity "CommunalHelper/DreamSwapBlock" DreamSwapBlock entityData
 
 const placements = Ahorn.PlacementDict(
     "Dream Swap Block (Communal Helper)" => Ahorn.EntityPlacement(

--- a/Ahorn/entities/dreamBlocks/DreamSwitchGate.jl
+++ b/Ahorn/entities/dreamBlocks/DreamSwitchGate.jl
@@ -2,18 +2,12 @@ module CommunalHelperDreamSwitchGate
 
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
+using Ahorn.CommunalHelperEntityPresets: CustomDreamBlockData
 
-@mapdef Entity "CommunalHelper/DreamSwitchGate" DreamSwitchGate(
-    x::Integer,
-    y::Integer,
-    width::Integer=Maple.defaultBlockWidth,
-    height::Integer=Maple.defaultBlockHeight,
-    featherMode::Bool=false,
-    oneUse::Bool=false,
-    refillCount::Integer=-1,
-    below::Bool=false,
+const entityData = appendkwargs(CustomDreamBlockData, :(
     permanent::Bool=false,
-)
+))
+@mapdefdata Entity "CommunalHelper/DreamSwitchGate" DreamSwitchGate entityData
 
 const placements = Ahorn.PlacementDict(
     "Dream Switch Gate (Communal Helper)" => Ahorn.EntityPlacement(

--- a/Ahorn/entities/dreamBlocks/DreamSwitchGate_MaxHelpingHand.jl
+++ b/Ahorn/entities/dreamBlocks/DreamSwitchGate_MaxHelpingHand.jl
@@ -2,16 +2,9 @@ module CommunalHelperDreamFlagSwitchGate
 
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
+using Ahorn.CommunalHelperEntityPresets: CustomDreamBlockData
 
-@mapdef Entity "CommunalHelper/MaxHelpingHand/DreamFlagSwitchGate" DreamFlagSwitchGate(
-    x::Integer,
-    y::Integer,
-    width::Integer=Maple.defaultBlockWidth,
-    height::Integer=Maple.defaultBlockHeight,
-    featherMode::Bool=false,
-    oneUse::Bool=false,
-    refillCount::Integer=-1,
-    below::Bool=false,
+const entityData = appendkwargs(CustomDreamBlockData, :(
     persistent::Bool=false,
     flag::String="flag_touch_switch",
     icon::String="vanilla",
@@ -24,7 +17,8 @@ using Ahorn.CommunalHelper
     allowReturn::Bool=false,
     moveSound::String="event:/game/general/touchswitch_gate_open",
     finishedSound::String="event:/game/general/touchswitch_gate_finish",
-)
+))
+@mapdefdata Entity "CommunalHelper/MaxHelpingHand/DreamFlagSwitchGate" DreamFlagSwitchGate entityData
 
 const placements = Ahorn.PlacementDict()
 

--- a/Ahorn/entities/dreamBlocks/DreamZipMover.jl
+++ b/Ahorn/entities/dreamBlocks/DreamZipMover.jl
@@ -2,23 +2,17 @@ module CommunalHelperDreamZipMover
 
 using ..Ahorn, Maple
 using Ahorn.CommunalHelper
+using Ahorn.CommunalHelperEntityPresets: CustomDreamBlockData
 
-@mapdef Entity "CommunalHelper/DreamZipMover" DreamZipMover(
-    x::Integer,
-    y::Integer,
-    width::Integer=Maple.defaultBlockWidth,
-    height::Integer=Maple.defaultBlockHeight,
-    noReturn::Bool=false,
+const entityData = appendkwargs(CustomDreamBlockData, :(
     dreamAesthetic::Bool=false,
-    featherMode::Bool=false,
-    oneUse::Bool=false,
-    refillCount::Integer=-1,
-    below::Bool=false,
     nodes::Array{Tuple{Integer,Integer},1}=Tuple{Integer,Integer}[],
     permanent::Bool=false,
     waiting::Bool=false,
     ticking::Bool=false,
-)
+    noReturn::Bool=false,
+))
+@mapdefdata Entity "CommunalHelper/DreamZipMover" DreamZipMover entityData
 
 const placements = Ahorn.PlacementDict(
     "Dream Zip Mover (Communal Helper)" => Ahorn.EntityPlacement(

--- a/Ahorn/libraries/EntityPresets.jl
+++ b/Ahorn/libraries/EntityPresets.jl
@@ -11,4 +11,14 @@ const CustomDreamBlockData = :(dreamblock(
     below::Bool=false,
 ))
 
+const CustomCassetteBlockData = :(cassetteblock(
+    x::Integer,
+    y::Integer,
+    width::Integer=Maple.defaultBlockWidth,
+    height::Integer=Maple.defaultBlockHeight,
+    index::Integer=0,
+    tempo::Number=1.0,
+    customColor="",
+))
+
 end

--- a/Ahorn/libraries/EntityPresets.jl
+++ b/Ahorn/libraries/EntityPresets.jl
@@ -1,0 +1,14 @@
+module CommunalHelperEntityPresets
+
+const CustomDreamBlockData = :(dreamblock(
+    x::Integer,
+    y::Integer,
+    width::Integer=Maple.defaultBlockWidth,
+    height::Integer=Maple.defaultBlockHeight,
+    featherMode::Bool=false,
+    oneUse::Bool=false,
+    refillCount::Integer=-1,
+    below::Bool=false,
+))
+
+end


### PR DESCRIPTION
Makes use of the `@mapdefdata` macro to provide shared data for all dreamblock and cassetteblock plugins.

Also adds vscode config files for the Ahorn folder.