### PR TITLE
Fix inconsistent shaking behaviour for dream falling block types

### DIFF
--- a/src/Entities/ChainStuff/ChainedDreamFallingBlock.cs
+++ b/src/Entities/ChainStuff/ChainedDreamFallingBlock.cs
@@ -69,12 +69,12 @@ namespace Celeste.Mod.CommunalHelper.Entities.ChainStuff {
         public override void Update() {
             base.Update();
 
-            if (Triggered && indicator && !indicatorAtStart)
+            if (HasStartedFalling && indicator && !indicatorAtStart)
                 pathLerp = Calc.Approach(pathLerp, 1f, Engine.DeltaTime * 2f);
         }
 
         public override void Render() {
-            if ((Triggered || indicatorAtStart) && indicator && !heldByChain) {
+            if ((HasStartedFalling || indicatorAtStart) && indicator && !heldByChain) {
                 float toY = startY + (chainStopY + Height - startY) * Ease.ExpoOut(pathLerp);
                 Draw.Rect(X, Y, Width, toY - Y, Color.Black * 0.75f);
             }

--- a/src/Entities/ChainStuff/ChainedFallingBlock.cs
+++ b/src/Entities/ChainStuff/ChainedFallingBlock.cs
@@ -10,7 +10,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         private char tileType;
         private TileGrid tiles;
 
-        private bool triggered;
+        private bool hasStartedFalling;
         private bool climbFall;
         private bool held;
 
@@ -61,7 +61,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         }
 
         public override void OnStaticMoverTrigger(StaticMover sm) {
-            triggered = true;
+            hasStartedFalling = true;
         }
 
         private bool PlayerFallCheck() {
@@ -84,10 +84,10 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         }
 
         private IEnumerator Sequence() {
-            while (!triggered && !PlayerFallCheck()) {
+            while (!hasStartedFalling && !PlayerFallCheck()) {
                 yield return null;
             }
-            triggered = true;
+            hasStartedFalling = true;
 
             Vector2 rattleSoundPos = new Vector2(Center.X, startY);
             while (true) {
@@ -196,12 +196,12 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         public override void Update() {
             base.Update();
 
-            if (triggered && indicator && !indicatorAtStart)
+            if (hasStartedFalling && indicator && !indicatorAtStart)
                 pathLerp = Calc.Approach(pathLerp, 1f, Engine.DeltaTime * 2f);
         }
 
         public override void Render() {
-            if ((triggered || indicatorAtStart) && indicator && !held) {
+            if ((hasStartedFalling || indicatorAtStart) && indicator && !held) {
                 float toY = startY + (chainStopY + Height - startY) * Ease.ExpoOut(pathLerp);
                 Draw.Rect(X, Y, Width, toY - Y, Color.Black * 0.75f);
             }

--- a/src/Entities/ChainStuff/ChainedFallingBlock.cs
+++ b/src/Entities/ChainStuff/ChainedFallingBlock.cs
@@ -72,9 +72,6 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         }
 
         private bool PlayerWaitCheck() {
-            if (triggered)
-                return true;
-
             if (PlayerFallCheck())
                 return true;
 

--- a/src/Entities/DreamStuff/DreamFallingBlock.cs
+++ b/src/Entities/DreamStuff/DreamFallingBlock.cs
@@ -42,7 +42,6 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             while (!Triggered && !HasPlayerRider()) {
                 yield return null;
             }
-            Triggered = true;
 
             while (FallDelay > 0f) {
                 FallDelay -= Engine.DeltaTime;


### PR DESCRIPTION
Fixes and closes #81.
The addition of Chained Falling Block entities caused the `DreamFallingBlock.Triggered` field to be assigned differently.

Now, `DreamFallingBlock.HasStartedFalling` is used to know when to display the chained variant indicator, and `ChainedFallingBlock.triggered` has been renamed to `hasStartedFalling`, and isn't involved in the behavior. 