### PR TITLE
Add extra options to Track Switch Box to allow disabling the floating behavior.

### DIFF
--- a/Ahorn/entities/TrackSwitchBox.jl
+++ b/Ahorn/entities/TrackSwitchBox.jl
@@ -6,7 +6,7 @@ using ..Ahorn, Maple
     x::Integer,
     y::Integer,
     globalSwitch::Bool=false,
-    float::Bool=true,
+    floaty::Bool=true,
     bounce::Bool=true,
 )
 

--- a/Ahorn/entities/TrackSwitchBox.jl
+++ b/Ahorn/entities/TrackSwitchBox.jl
@@ -6,6 +6,8 @@ using ..Ahorn, Maple
     x::Integer,
     y::Integer,
     globalSwitch::Bool=false,
+    float::Bool=true,
+    bounce::Bool=true,
 )
 
 const placements = Ahorn.PlacementDict(

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -232,7 +232,7 @@ placements.entities.CommunalHelper/StationBlockTrack.tooltips.moveMode=This opti
 
 # -- Track Switch Box --
 placements.entities.CommunalHelper/TrackSwitchBox.tooltips.globalSwitch=Whether the level should keep the state of the ON/OFF tracks, even after reloading or dying. If unticked, the state will be reset at every reload.
-placements.entities.CommunalHelper/TrackSwitchBox.tooltips.float=Whether the box should float up and down; this also causes the box to sink down if the player stands on it. If unticked, the box will stay its place.
+placements.entities.CommunalHelper/TrackSwitchBox.tooltips.floaty=Whether the box should float up and down; this also causes the box to sink down if the player stands on it. If unticked, the box will stay in its place.
 placements.entities.CommunalHelper/TrackSwitchBox.tooltips.bounce=Whether the box should bounce away from the player when dashed into.
 
 

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -232,6 +232,8 @@ placements.entities.CommunalHelper/StationBlockTrack.tooltips.moveMode=This opti
 
 # -- Track Switch Box --
 placements.entities.CommunalHelper/TrackSwitchBox.tooltips.globalSwitch=Whether the level should keep the state of the ON/OFF tracks, even after reloading or dying. If unticked, the state will be reset at every reload.
+placements.entities.CommunalHelper/TrackSwitchBox.tooltips.float=Whether the box should float up and down; this also causes the box to sink down if the player stands on it. If unticked, the box will stay its place.
+placements.entities.CommunalHelper/TrackSwitchBox.tooltips.bounce=Whether the box should bounce away from the player when dashed into.
 
 
 # -- Summit Gem --

--- a/src/Entities/StationBlock/TrackSwitchBox.cs
+++ b/src/Entities/StationBlock/TrackSwitchBox.cs
@@ -20,6 +20,8 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         private float sink;
         private bool canSwitch = true;
+        private bool canFloat = true;
+        private bool canBounce = true;
 
         private float shakeCounter;
         private bool smashParticles = false;
@@ -42,12 +44,14 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         private bool spikesLeft, spikesRight, spikesUp, spikesDown;
 
-        public TrackSwitchBox(Vector2 position, bool global)
+        public TrackSwitchBox(Vector2 position, bool global, bool canFloat, bool canBounce)
             : base(position, 32f, 32f, safe: true) {
 
             colorLerp = (LocalTrackSwitchState = CommunalHelperModule.Session.TrackInitialState) == TrackSwitchState.On ? 0f : 1f;
 
             this.global = global;
+            this.canFloat = canFloat;
+            this.canBounce = canBounce;
 
             SurfaceSoundIndex = SurfaceIndex.ZipMover;
             start = Position;
@@ -72,7 +76,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         }
 
         public TrackSwitchBox(EntityData e, Vector2 levelOffset)
-            : this(e.Position + levelOffset, e.Bool("globalSwitch")) { }
+            : this(e.Position + levelOffset, e.Bool("globalSwitch"), e.Bool("float"), e.Bool("bounce")) { }
 
         public override void Awake(Scene scene) {
             base.Awake(scene);
@@ -181,8 +185,12 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                 sink = Calc.Approach(sink, flag ? 1 : 0, 2f * Engine.DeltaTime);
                 sine.Rate = MathHelper.Lerp(1f, 0.5f, sink);
                 Vector2 vector = start;
-                vector.Y += sink * 6f + sine.Value * MathHelper.Lerp(4f, 2f, sink);
-                vector += bounce.Value * bounceDir * 12f;
+                if (canFloat) {
+                    vector.Y += sink * 6f + sine.Value * MathHelper.Lerp(4f, 2f, sink);
+                }
+                if (canBounce) {
+                    vector += bounce.Value * bounceDir * 12f;
+                }
                 MoveToX(vector.X);
                 MoveToY(vector.Y);
                 if (smashParticles) {

--- a/src/Entities/StationBlock/TrackSwitchBox.cs
+++ b/src/Entities/StationBlock/TrackSwitchBox.cs
@@ -76,7 +76,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         }
 
         public TrackSwitchBox(EntityData e, Vector2 levelOffset)
-            : this(e.Position + levelOffset, e.Bool("globalSwitch"), e.Bool("float"), e.Bool("bounce")) { }
+            : this(e.Position + levelOffset, e.Bool("globalSwitch"), e.Bool("floaty"), e.Bool("bounce")) { }
 
         public override void Awake(Scene scene) {
             base.Awake(scene);


### PR DESCRIPTION
This should close #83 by adding a `canFloat`/`float` and `canBounce`/`bounce` option to Track Switch Boxes to disable the **floating** behavior and the **bouncing away from the player when dashed into** behavior respectively.