### PR TITLE
Improve optional dependency handling

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -37,7 +37,7 @@ jobs:
         path: src/bin/Debug/net452
 
     - name: Create mod zip
-      run: zip -qq -r CommunalHelper.zip Ahorn/* Audio Graphics src/bin/Debug/net452 everest.yaml
+      run: zip -qq -r CommunalHelper.zip Ahorn/* Audio Dialog Graphics src/bin/Debug/net452 everest.yaml
 
     - name: Upload release asset
       id: upload

--- a/Dialog/English.txt
+++ b/Dialog/English.txt
@@ -1,0 +1,2 @@
+communalhelper_failedloadingdeps=Failed loading optional dependencies.
+Send your log.txt to a CommunalHelper maintainer.

--- a/everest.yaml
+++ b/everest.yaml
@@ -3,9 +3,4 @@
   DLL: src/bin/Debug/net452/CommunalHelper.dll
   Dependencies:
     - Name: Everest
-      Version: 1.3164.0
-  OptionalDependencies:
-    - Name: MaxHelpingHand
-      Version: 1.0.0
-    - Name: MoreDasheline
-      Version: 1.0.0
+      Version: 1.3233.0

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -88,6 +88,20 @@ namespace Celeste.Mod.CommunalHelper {
             return list;
         }
 
+        public static MethodInfo GetMethod(this Type type, string name, BindingFlags bindingAttr, bool throwOnNull = false) {
+            var method = type.GetMethod(name, bindingAttr);
+            if (throwOnNull && method is null)
+                throw new NullReferenceException($"Could not find method {name} in type {type.FullName}");
+            return method;
+        }
+
+        public static MethodInfo GetMethod(this Type type, string name, Type[] types, bool throwOnNull = false) {
+            var method = type.GetMethod(name, types);
+            if (throwOnNull && method is null)
+                throw new NullReferenceException($"Could not find method {name}({string.Join<Type>(",", types)}) in type {type.FullName}.");
+            return method;
+        }
+
         // Dream Tunnel Dash related extension methods located in DreamTunnelDash.cs
 
         internal static bool CelesteTASLoaded;

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -134,15 +134,13 @@ namespace Celeste.Mod.CommunalHelper {
             return CollabUtilsLoaded ? (Entity) m_FindFirst_MiniHeart.Invoke(list, new object[] { }) : null;
         }
 
+        public static bool SatisfiesDependency(EverestModuleMetadata meta, EverestModuleMetadata dependency) =>
+            meta.Name == dependency.Name && Everest.Loader.VersionSatisfiesDependency(meta.Version, dependency.Version);
+
         // Modified version of Everest.Loader.DependencyLoaded
         public static bool TryGetModule(EverestModuleMetadata meta, out EverestModule module) {
             foreach (EverestModule other in Everest.Modules) {
-                EverestModuleMetadata otherData = other.Metadata;
-                if (otherData.Name != meta.Name)
-                    continue;
-
-                Version version = otherData.Version;
-                if (Everest.Loader.VersionSatisfiesDependency(meta.Version, version)) {
+                if (SatisfiesDependency(meta, other.Metadata)) {
                     module = other;
                     return true;
                 }


### PR DESCRIPTION
- fixes #92  
(not thoroughly tested)

Uses the `OnRegisterModule` event to check for optional dependencies even after the game (or mod, now that the main check is done on mod `Load`) has finished loading.

Optional dependencies now also fail safely if reflected members are not found, with logging and a message in the ModOptions menu.

Also sets default `LogLevel` for CommunalHelper to `Debug` (not logged by default).