### PR TITLE
Removed some sources of log spam

### DIFF
--- a/Graphics/CommunalHelper/Sprites.xml
+++ b/Graphics/CommunalHelper/Sprites.xml
@@ -471,13 +471,6 @@
         <Loop id="noFlash" path="CommunalHelper/recolorableBerry/leaves" delay=".1" frames="0-6" />
         <Loop id="flap" path="CommunalHelper/recolorableBerry/leaves_wings" delay=".08" frames="0-8,0-8,0-7,9" />
         <Anim id="collect" path="CommunalHelper/recolorableBerry/leaves" delay=".07" frames="7-11"/>
-        <Anim id="fade0" path="normal" delay=".08" frames="12-14,14*10,15-19"/>
-        <Anim id="fade1" path="normal" delay=".07" frames="20-22,22*10,23-26"/>
-        <Anim id="fade2" path="normal" delay=".07" frames="28-30,30*10,31-34"/>
-        <Anim id="fade3" path="normal" delay=".07" frames="36-38,38*10,39-42"/>
-        <Anim id="fade4" path="normal" delay=".07" frames="44-46,46*10,47-50"/>
-        <Anim id="fade5" path="normal" delay=".07" frames="52,53,54,53,54,53,54,53,54,53,54,53,54-59"/>
-        <Anim id="fade_wow" path="wow/normal" delay=".1" frames="52-66"/>
     </recolorableStrawberryOverlay>
 
 </Sprites>

--- a/src/Entities/ConnectedStuff/ConnectedMoveBlock.cs
+++ b/src/Entities/ConnectedStuff/ConnectedMoveBlock.cs
@@ -122,7 +122,7 @@ namespace Celeste.Mod.CommunalHelper {
             customTexture = !string.IsNullOrWhiteSpace(customPath);
             if (customTexture) {
                 string temp;
-                if (GFX.Game["objects/" + customPath] == null) {
+                if (!GFX.Game.Has("objects/" + customPath)) {
                     if (GFX.Game["objects/" + customPath + "/tileset"] == null) {
                         throw new Exception($"No valid tileset found, searched @ objects/{customPath}.png & objects/{customPath}/tileset.png\nFor custom arrow textures, use 'objects/{customPath}/arrow', 'objects/{customPath}/tileset' for tiles, and 'objects/{customPath}/x.png' for the breaking X sprite.");
                     }

--- a/src/Entities/Panels/AbstractPanel.cs
+++ b/src/Entities/Panels/AbstractPanel.cs
@@ -158,7 +158,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         private static void LogHooked(string fullname) {
             if (!hooked.Contains(fullname)) {
-                Logger.Log(LogLevel.Verbose, "CommunalHelper", $"Hooking {fullname} to override when AbstractPanel present.");
+                Logger.Log(LogLevel.Debug, "CommunalHelper", $"Hooking {fullname} to override when AbstractPanel present.");
                 hooked.Add(fullname);
             }
         }

--- a/src/Entities/Panels/AbstractPanel.cs
+++ b/src/Entities/Panels/AbstractPanel.cs
@@ -158,7 +158,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
 
         private static void LogHooked(string fullname) {
             if (!hooked.Contains(fullname)) {
-                Logger.Log(LogLevel.Info, "CommunalHelper", $"Hooking {fullname} to override when AbstractPanel present.");
+                Logger.Log(LogLevel.Verbose, "CommunalHelper", $"Hooking {fullname} to override when AbstractPanel present.");
                 hooked.Add(fullname);
             }
         }


### PR DESCRIPTION
1. Unnecessary animations with missing images for Redless Berry
2. A texture access with fallback vs. just testing for key existence in ConnectedMoveBlock (fallback usage could be further cleaned up, but this removes the log spam)
3. Hook logging which should probably be lower priority in AbstractPanel