### PR TITLE
Add ModInterop exports

### DIFF
--- a/src/CommunalHelperModule.cs
+++ b/src/CommunalHelperModule.cs
@@ -91,12 +91,14 @@ namespace Celeste.Mod.CommunalHelper {
 
             PlayerSeekerBarrier.Hook();
             PlayerSeekerBarrierRenderer.Hook();
-            
+
             #region Imports
 
             typeof(Imports.GravityHelper).ModInterop();
 
             #endregion
+
+            ModExports.Initialize();
         }
 
         public override void Unload() {

--- a/src/ModInterop.cs
+++ b/src/ModInterop.cs
@@ -16,7 +16,7 @@ namespace Celeste.Mod.CommunalHelper {
 
             #region DreamTunnel
 
-            public static int StDreamTunnelDash() => DreamTunnelDash.StDreamTunnelDash;
+            public static int GetDreamTunnelDashState() => DreamTunnelDash.StDreamTunnelDash;
             public static bool HasDreamTunnelDash() => DreamTunnelDash.HasDreamTunnelDash;
 
             public static Component DreamTunnelInteraction(Action<Player> onPlayerEnter, Action<Player> onPlayerExit)
@@ -27,7 +27,7 @@ namespace Celeste.Mod.CommunalHelper {
             #region Seeker
 
             public static bool HasSeekerDash() => SeekerDash.HasSeekerDash;
-            public static bool SeekerAttacking() => SeekerDash.SeekerAttacking;
+            public static bool IsSeekerDashAttacking() => SeekerDash.SeekerAttacking;
 
             #endregion
 

--- a/src/ModInterop.cs
+++ b/src/ModInterop.cs
@@ -7,6 +7,10 @@ namespace Celeste.Mod.CommunalHelper {
 
     public static class ModExports {
 
+        internal static void Initialize() {
+            typeof(DashStates).ModInterop();
+        }
+
         [ModExportName("CommunalHelper.DashStates")]
         public static class DashStates {
 

--- a/src/ModInterop.cs
+++ b/src/ModInterop.cs
@@ -16,8 +16,8 @@ namespace Celeste.Mod.CommunalHelper {
 
             #region DreamTunnel
 
-            public static int StDreamTunnelDash => DreamTunnelDash.StDreamTunnelDash;
-            public static bool HasDreamTunnelDash => DreamTunnelDash.HasDreamTunnelDash;
+            public static int StDreamTunnelDash() => DreamTunnelDash.StDreamTunnelDash;
+            public static bool HasDreamTunnelDash() => DreamTunnelDash.HasDreamTunnelDash;
 
             public static Component DreamTunnelInteraction(Action<Player> onPlayerEnter, Action<Player> onPlayerExit)
                 => new DreamTunnelInteraction(onPlayerEnter, onPlayerExit);
@@ -26,8 +26,8 @@ namespace Celeste.Mod.CommunalHelper {
 
             #region Seeker
 
-            public static bool HasSeekerDash => SeekerDash.HasSeekerDash;
-            public static bool SeekerAttacking => SeekerDash.SeekerAttacking;
+            public static bool HasSeekerDash() => SeekerDash.HasSeekerDash;
+            public static bool SeekerAttacking() => SeekerDash.SeekerAttacking;
 
             #endregion
 

--- a/src/ModInterop.cs
+++ b/src/ModInterop.cs
@@ -1,0 +1,33 @@
+using Celeste.Mod.CommunalHelper.DashStates;
+using Monocle;
+using MonoMod.ModInterop;
+using System;
+
+namespace Celeste.Mod.CommunalHelper {
+
+    public static class ModExports {
+
+        [ModExportName("CommunalHelper.DashStates")]
+        public static class DashStates {
+
+            #region DreamTunnel
+
+            public static int StDreamTunnelDash => DreamTunnelDash.StDreamTunnelDash;
+            public static bool HasDreamTunnelDash => DreamTunnelDash.HasDreamTunnelDash;
+
+            public static Component DreamTunnelInteraction(Action<Player> onPlayerEnter, Action<Player> onPlayerExit)
+                => new DreamTunnelInteraction(onPlayerEnter, onPlayerExit);
+
+            #endregion
+
+            #region Seeker
+
+            public static bool HasSeekerDash => SeekerDash.HasSeekerDash;
+            public static bool SeekerAttacking => SeekerDash.SeekerAttacking;
+
+            #endregion
+
+        }
+
+    }
+}


### PR DESCRIPTION
Makes it easier for other mods to integrate with communalhelper stuff without having to explicitly reference CommunalHelper
