### PR TITLE
Fix Scrape Particle Interval

### DIFF
--- a/src/Entities/ConnectedStuff/ConnectedMoveBlock.cs
+++ b/src/Entities/ConnectedStuff/ConnectedMoveBlock.cs
@@ -263,7 +263,8 @@ namespace Celeste.Mod.CommunalHelper {
                         }
                     }
                     Vector2 move = Position - start;
-                    SpawnScrapeParticles(Math.Abs(move.X) != 0, Math.Abs(move.Y) != 0);
+                    if (Scene.OnInterval(0.03f))
+                        SpawnScrapeParticles(Math.Abs(move.X) != 0, Math.Abs(move.Y) != 0);
 
                     curMoveCheck = flag2;
 

--- a/src/Entities/ConnectedStuff/ConnectedSolid.cs
+++ b/src/Entities/ConnectedStuff/ConnectedSolid.cs
@@ -165,9 +165,9 @@ namespace Celeste.Mod.CommunalHelper {
                         Vector2 vecTop = Position + hitbox.Position + new Vector2(t, -1);
                         Vector2 vecBottom = Position + hitbox.Position + new Vector2(t, hitbox.Height + 1);
                         if (Scene.CollideCheck<Solid>(vecTop))
-                            level.ParticlesFG.Emit(ZipMover.P_Scrape, vecTop, 0);
+                            level.ParticlesFG.Emit(ZipMover.P_Scrape, vecTop);
                         if (Scene.CollideCheck<Solid>(vecBottom))
-                            level.ParticlesFG.Emit(ZipMover.P_Scrape, vecBottom, 0);
+                            level.ParticlesFG.Emit(ZipMover.P_Scrape, vecBottom);
                     }
                 }
 
@@ -176,9 +176,9 @@ namespace Celeste.Mod.CommunalHelper {
                         Vector2 vecLeft = Position + hitbox.Position + new Vector2(-1, t);
                         Vector2 vecRight = Position + hitbox.Position + new Vector2(hitbox.Width + 1, t);
                         if (Scene.CollideCheck<Solid>(vecLeft))
-                            level.ParticlesFG.Emit(ZipMover.P_Scrape, vecLeft, 0);
+                            level.ParticlesFG.Emit(ZipMover.P_Scrape, vecLeft);
                         if (Scene.CollideCheck<Solid>(vecRight))
-                            level.ParticlesFG.Emit(ZipMover.P_Scrape, vecRight, 0);
+                            level.ParticlesFG.Emit(ZipMover.P_Scrape, vecRight);
                     }
                 }
             }

--- a/src/Entities/ConnectedStuff/EquationMoveBlock.cs
+++ b/src/Entities/ConnectedStuff/EquationMoveBlock.cs
@@ -120,7 +120,8 @@ namespace Celeste.Mod.CommunalHelper.Entities.ConnectedStuff {
                     moveTime += Engine.DeltaTime;
 
                     Vector2 move = Position - start;
-                    SpawnScrapeParticles(Math.Abs(move.X) != 0, Math.Abs(move.Y) != 0);
+                    if (Scene.OnInterval(0.03f))
+                        SpawnScrapeParticles(Math.Abs(move.X) != 0, Math.Abs(move.Y) != 0);
 
                     curMoveCheck = moveCheck;
 


### PR DESCRIPTION
There were a couple Connected Solid types that didn't have the scrape particle interval set so they would spam particles.

Zip mover particle quantity is definitely higher than it should be + the direction isn't correct with the default, that can be looked at later though :) probably shouldn't share the same logic