### PR TITLE
Connected Cracked Block + Crystal Bomb compat

### DIFF
--- a/src/CommunalHelperModule.cs
+++ b/src/CommunalHelperModule.cs
@@ -96,6 +96,7 @@ namespace Celeste.Mod.CommunalHelper {
 
             #region Imports
 
+            typeof(Imports.CavernHelper).ModInterop();
             typeof(Imports.GravityHelper).ModInterop();
 
             #endregion

--- a/src/Entities/ConnectedStuff/ConnectedTempleCrackedBlock.cs
+++ b/src/Entities/ConnectedStuff/ConnectedTempleCrackedBlock.cs
@@ -140,8 +140,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             }
             Add(new LightOcclude(0.5f));
 
-            Action<Vector2> onExplode = (pos) => Break(pos);
-            Component explosionCollider = CavernHelper.GetCrystalBombExplosionCollider?.Invoke(onExplode, null);
+            Component explosionCollider = CavernHelper.GetCrystalBombExplosionCollider?.Invoke(Break, null);
             if (explosionCollider != null) {
                 Add(explosionCollider);
             }

--- a/src/Entities/ConnectedStuff/ConnectedTempleCrackedBlock.cs
+++ b/src/Entities/ConnectedStuff/ConnectedTempleCrackedBlock.cs
@@ -1,4 +1,5 @@
-﻿using Celeste.Mod.Entities;
+﻿using Celeste.Mod.CommunalHelper.Imports;
+using Celeste.Mod.Entities;
 using Microsoft.Xna.Framework;
 using Mono.Cecil.Cil;
 using Monocle;
@@ -138,6 +139,12 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                 }
             }
             Add(new LightOcclude(0.5f));
+
+            Action<Vector2> onExplode = (pos) => Break(pos);
+            Component explosionCollider = CavernHelper.GetCrystalBombExplosionCollider?.Invoke(onExplode, null);
+            if (explosionCollider != null) {
+                Add(explosionCollider);
+            }
         }
 
         public override void Added(Scene scene) {

--- a/src/Imports/CavernHelper.cs
+++ b/src/Imports/CavernHelper.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Xna.Framework;
+using Monocle;
+using MonoMod.ModInterop;
+using System;
+
+namespace Celeste.Mod.CommunalHelper.Imports {
+    /// <summary>
+    /// Import methods defined here: <see href="https://github.com/CommunalHelper/CavernHelper/blob/dev/Code/CavernInterop.cs">CavernInterop</see>.
+    /// </summary>
+    [ModImportName("CavernHelper")]
+    public static class CavernHelper {
+        public static Func<Action<Vector2>, Collider, Component> GetCrystalBombExplosionCollider;
+    }
+}


### PR DESCRIPTION
Adds Cavern Helper imports from v1.3.5 to make connected cracked blocks break when in range of a crystal bomb explosion.

I'm not sure if an optional dependency should be added or not. It looks like you guys decided not to for Gravity Helper, maybe there was a reason for that I'm not aware of? Personally I think it'd be nice, since otherwise it's up to the mapper to know they need to set the appropriate dependency versions for both mods.