### PR TITLE
fix rubble spawning in connected temple cracked blocks

### DIFF
--- a/src/Entities/ConnectedStuff/ConnectedTempleCrackedBlock.cs
+++ b/src/Entities/ConnectedStuff/ConnectedTempleCrackedBlock.cs
@@ -187,9 +187,11 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             }
             broken = true;
             Collidable = false;
-            for (int i = 0; (float) i < base.Width / 8f; i++) {
-                for (int j = 0; (float) j < base.Height / 8f; j++) {
-                    Scene.Add(Engine.Pooler.Create<Debris>().Init(Position + new Vector2(i * 8 + 4, j * 8 + 4), '1', playSound: true).BlastFrom(from));
+            for (int i = 0; i < tiles.GetLength(0); i++) {
+                for (int j = 0; j < tiles.GetLength(1); j++) {
+                    if (tiles[i, j] != null) {
+                        Scene.Add(Engine.Pooler.Create<Debris>().Init(GroupBoundsMin + new Vector2(i * 8 + 4, j * 8 + 4), '1', playSound: true).BlastFrom(from));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Previously, rubble from breaking a connected temple cracked block resulted in a massive rectangle of rubble that didn't even necessarily align with the connected block's extensions.

With this fix, rubble spawns at each tile that was occupied by the source block or a collidable extension.

Video credit to bigkahuna:

https://user-images.githubusercontent.com/109830893/193165101-53cdd2e6-a257-45f0-a86c-0e18a32e1cfe.mp4

