### PR TITLE
Seeker Dash Improvements

### DIFF
--- a/Loenn/entities/player_seeker_barrier.lua
+++ b/Loenn/entities/player_seeker_barrier.lua
@@ -4,13 +4,29 @@ playerSeekerBarrier.name = "CommunalHelper/PlayerSeekerBarrier"
 playerSeekerBarrier.depth = 0
 
 playerSeekerBarrier.placements = {
-    name = "player_seeker_barrier",
-    data = {
-        width = 8,
-        height = 8
+    {
+        name = "normal",
+        data = {
+            width = 8,
+            height = 8,
+            spiky = false,
+        }
+    },
+    {
+        name = "spiky",
+        data = {
+            width = 8,
+            height = 8,
+            spiky = true,
+        }
     }
 }
 
-playerSeekerBarrier.color = {0.36, 0.36, 0.36, 0.8}
+local normalColor = {0.36, 0.36, 0.36, 0.8}
+local spikyColor = {0.36, 0.36, 0.36, 0.8}
+
+function playerSeekerBarrier.color(room, entity)
+    return entity.spiky and spikyColor or normalColor
+end
 
 return playerSeekerBarrier

--- a/Loenn/entities/player_seeker_barrier.lua
+++ b/Loenn/entities/player_seeker_barrier.lua
@@ -23,7 +23,7 @@ playerSeekerBarrier.placements = {
 }
 
 local normalColor = {0.36, 0.36, 0.36, 0.8}
-local spikyColor = {0.36, 0.36, 0.36, 0.8}
+local spikyColor = {0.36, 0.13, 0.13, 0.8}
 
 function playerSeekerBarrier.color(room, entity)
     return entity.spiky and spikyColor or normalColor

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -533,7 +533,9 @@ entities.CommunalHelper/SeekerDashRefill.placements.name.seeker_dash_refill=Seek
 entities.CommunalHelper/SeekerDashRefill.attributes.description.oneUse=Whether the crystal should permanently disappear after being collected.
 
 # Player Seeker Barrier
-entities.CommunalHelper/PlayerSeekerBarrier.placements.name.player_seeker_barrier=Player Seeker Barrier
+entities.CommunalHelper/PlayerSeekerBarrier.placements.name.normal=Player Seeker Barrier
+entities.CommunalHelper/PlayerSeekerBarrier.placements.name.spiky=Player Seeker Barrier (Spiky)
+entities.CommunalHelper/PlayerSeekerBarrier.attributes.description.spiky=Whether the edges of this barrier act like spikes.
 
 # Dash State Trigger
 triggers.CommunalHelper/DashStateTrigger.placements.name.trigger=Dash State

--- a/src/DashStates/SeekerDash/SeekerDash.cs
+++ b/src/DashStates/SeekerDash/SeekerDash.cs
@@ -317,6 +317,12 @@ namespace Celeste.Mod.CommunalHelper.DashStates {
                     self.SceneAs<Level>().Particles.Emit(Seeker.P_HitWall, 12, origin, new Vector2(dir.Y, dir.X) * 4f, (-dir).Angle());
                     self.OnReflectSeeker();
                     Audio.Play(SFX.game_05_seeker_impact_lightwall, self.Position);
+
+                    // Rare case where the player hits the seeker barrier before colliding with the spikes.
+                    // When this happens, the player is sent back and doesn't collide with the spikes, and doesn't die.
+                    if (self is PlayerSeekerBarrier playerSeekerBarrier && playerSeekerBarrier.Spiky)
+                        return DashCollisionResults.NormalOverride;
+
                     return DashCollisionResults.Bounce;
                 }
                 return DashCollisionResults.NormalOverride;

--- a/src/Entities/ConnectedStuff/ConnectedTempleCrackedBlock.cs
+++ b/src/Entities/ConnectedStuff/ConnectedTempleCrackedBlock.cs
@@ -194,6 +194,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         }
 
         public void Break(Vector2 from) {
+            DestroyStaticMovers();
             Audio.Play("event:/game/05_mirror_temple/crackedwall_vanish", base.Center);
             if (persistent) {
                 SceneAs<Level>().Session.DoNotLoad.Add(eid);

--- a/src/Entities/ConnectedStuff/ConnectedTempleCrackedBlock.cs
+++ b/src/Entities/ConnectedStuff/ConnectedTempleCrackedBlock.cs
@@ -1,4 +1,5 @@
-﻿using Celeste.Mod.CommunalHelper.Imports;
+﻿using Celeste.Mod.CommunalHelper.DashStates;
+using Celeste.Mod.CommunalHelper.Imports;
 using Celeste.Mod.Entities;
 using Microsoft.Xna.Framework;
 using Mono.Cecil.Cil;
@@ -111,12 +112,10 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         private int frames;
 
         public ConnectedTempleCrackedBlock(EntityData data, Vector2 offset)
-            : this(new EntityID(data.Level.Name, data.ID), data, offset) {
-        }
+            : this(new EntityID(data.Level.Name, data.ID), data, offset) { }
 
         public ConnectedTempleCrackedBlock(EntityID eid, EntityData data, Vector2 offset)
-            : this(eid, data.Position + offset, data.Width, data.Height, data.Bool("persistent")) {
-        }
+            : this(eid, data.Position + offset, data.Width, data.Height, data.Bool("persistent")) { }
 
         public ConnectedTempleCrackedBlock(EntityID eid, Vector2 position, int width, int height, bool persistent)
             : base(position, width, height, safe: true) {
@@ -144,6 +143,14 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             if (explosionCollider != null) {
                 Add(explosionCollider);
             }
+
+            OnDashCollide = (player, dir) => {
+                if (SeekerDash.SeekerAttacking) {
+                    Break(player.Center);
+                    return DashCollisionResults.Rebound;
+                }
+                return DashCollisionResults.NormalCollision;
+            };
         }
 
         public override void Added(Scene scene) {

--- a/src/Entities/Misc/PlayerSeekerBarrier.cs
+++ b/src/Entities/Misc/PlayerSeekerBarrier.cs
@@ -26,9 +26,12 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         private PlayerSeekerBarrier master;
         private List<PlayerSeekerBarrier> group;
 
+        public bool Spiky { get; }
+
         public PlayerSeekerBarrier(EntityData data, Vector2 offset)
             : base(data, offset) {
             SurfaceSoundIndex = SurfaceIndex.AuroraGlass;
+            Spiky = data.Bool("spiky", false);
         }
 
         public override void Update() {

--- a/src/Entities/Misc/PlayerSeekerBarrierRenderer.cs
+++ b/src/Entities/Misc/PlayerSeekerBarrierRenderer.cs
@@ -26,6 +26,8 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             public float[] Wave;
             public float Length;
 
+            public readonly bool spiky;
+
             public Edge(PlayerSeekerBarrier parent, Vector2 a, Vector2 b) {
                 Parent = parent;
                 Visible = true;
@@ -43,7 +45,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                     Wave = new float[(int) Length + 2];
 
                 for (int i = 0; i <= Length; i++)
-                    Wave[i] = GetWaveAt(time, i, Length);
+                    Wave[i] = (spiky ? GetSpikyWaveAt(time, i, Length) : GetWaveAt(time, i, Length));
             }
 
             private float GetWaveAt(float offset, float along, float length) {
@@ -56,6 +58,18 @@ namespace Celeste.Mod.CommunalHelper.Entities {
                 float num = offset + along * 0.25f;
                 float num2 = (float) (Math.Sin(num) * 2.0 + Math.Sin(num * 0.25f));
                 return (1f + num2 * Ease.SineInOut(Calc.YoYo(along / length))) * (1f - Parent.Solidify);
+            }
+
+            private float GetSpikyWaveAt(float offset, float along, float length) {
+                if (along <= 1f || along >= length - 1f)
+                    return 0f;
+
+                if (Parent.Solidify >= 1f)
+                    return 0f;
+
+                float intensity = (1f - Parent.Solidify);
+                float at = offset + along * 0.5f;
+                return Util.MappedTriangleWave(at / 2, 0, 8) * Util.PowerBounce(along / length, 2.5f) * intensity;
             }
 
             public bool InView(ref Rectangle view)

--- a/src/Utils/Util.cs
+++ b/src/Utils/Util.cs
@@ -75,5 +75,23 @@ namespace Celeste.Mod.CommunalHelper {
             Vector2 size = Max(a, b) - min;
             return new((int) min.X, (int) min.Y, (int) size.X, (int) size.Y);
         }
+
+        /// <summary>
+        /// Triangle wave function.
+        /// </summary>
+        public static float TriangleWave(float x)
+            => 2 * Math.Abs(Mod(x, 2) - 1) - 1;
+
+        /// <summary>
+        /// Triangle wave between mapped between two values.
+        /// </summary>
+        /// <param name="x">The input value.</param>
+        /// <param name="from">The ouput when <c>x</c> is an even integer.</param>
+        /// <param name="to">The output when <c>x</c> is an odd integer.</param>
+        public static float MappedTriangleWave(float x, float from, float to)
+            => (from - to) * Math.Abs(Mod(x, 2) - 1) + to;
+
+        public static float PowerBounce(float x, float p)
+            => -(float)Math.Pow(Math.Abs(2 * (Mod(x, 1) - .5f)), p) + 1;
     }
 }


### PR DESCRIPTION
* Added "spiky" variants of Player Seeker Barriers, which spawn invisible spikes on their bounds, and have spiky edges.
* Connected Temple Cracked Blocks destroy their static movers when broken. Decided not to make vanilla Temple Cracked Blocks behave the same, as you can just use CH's blocks as a replacement.

The look of spiky edges can easily be changed in code, this is what they currently look like:
![image](https://user-images.githubusercontent.com/59423464/197365093-618c2180-e914-4f91-a8bd-e96ef2f7e36a.png)
The goal is of course to find pick something both readable and that looks like deadly spikes.
