### PR TITLE
Improve Attached Wall Booster core mode handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -358,3 +358,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# JetBrains Rider
+.idea

--- a/Ahorn/entities/AttachedWallBooster.jl
+++ b/Ahorn/entities/AttachedWallBooster.jl
@@ -8,8 +8,8 @@ using ..Ahorn, Maple
     width::Integer=8,
     height::Integer=8,
     left::Bool=false,
-    notCoreMode::Bool=false,
     legacyBoost::Bool=true,
+    coreModeBehavior::String="ToggleDefaultHot"
 )
 
 const placements = Ahorn.PlacementDict(
@@ -31,6 +31,10 @@ const placements = Ahorn.PlacementDict(
 
 Ahorn.minimumSize(entity::AttachedWallBooster) = 8, 8
 Ahorn.resizable(entity::AttachedWallBooster) = false, true
+
+Ahorn.editingOptions(entity::AttachedWallBooster) = Dict{String, Any}(
+    "coreModeBehavior" => String["ToggleDefaultHot", "ToggleDefaultCold", "AlwaysHot", "AlwaysCold"]
+)
 
 function Ahorn.selection(entity::AttachedWallBooster)
     x, y = Ahorn.position(entity)

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -8,8 +8,10 @@
 
 # -- Attached Wall Booster --
 placements.entities.CommunalHelper/AttachedWallBooster.tooltips.left=Whether the Attached Wall Booster should attach to the left sides of solids.
-placements.entities.CommunalHelper/AttachedWallBooster.tooltips.notCoreMode=Whether the Attached Wall Booster should ignore the current Core Mode and be in Ice Mode.
+placements.entities.CommunalHelper/AttachedWallBooster.names.notCoreMode=Force Ice on Room Entry
+placements.entities.CommunalHelper/AttachedWallBooster.tooltips.notCoreMode=Whether the Attached Wall Booster should ignore the current Core Mode and be in Ice Mode when entering the room.\nThis is a legacy option that may not work as expected with different settings for Core Mode Behavior.
 placements.entities.CommunalHelper/AttachedWallBooster.tooltips.legacyBoost=Makes this Attached Wall Booster apply the expected speed boost to the player.\nIf disabled, the vertical boost is applied twice if the player isn't moving horizontally, due to a bug that was accidentally introduced in 1.11.2.\nAlso, if disabled, this entity is reskinned with a variant of the wall booster textures.
+placements.entities.CommunalHelper/AttachedWallBooster.tooltips.coreModeBehavior=How the Attached Wall Booster should interact with the Core Mode.\nIf set to Toggle, it will respect the current Core Mode and use the default value if the Core Mode is None.\nIf set to Always Hot/Cold, it will completely ignore the Core Mode and always stay in one mode.
 
 
 # -- Custom Cassette Block --
@@ -283,7 +285,7 @@ placements.entities.CommunalHelper/SyncedZipMoverActivationController.tooltips.z
 placements.entities.CommunalHelper/SyncedZipMoverActivationController.tooltips.colorCode=Target color code.
 
 
-# -- Melvin -- 
+# -- Melvin --
 placements.entities.CommunalHelper/Melvin.tooltips.weakTop=Whether this Melvin can be dashed into from above.
 placements.entities.CommunalHelper/Melvin.tooltips.weakBottom=Whether this Melvin can be dashed into from below.
 placements.entities.CommunalHelper/Melvin.tooltips.weakLeft=Whether this Melvin can be dashed into from the left.
@@ -385,7 +387,7 @@ placements.entities.CommunalHelper/CoreModeMusicController.tooltips.params=A lis
 placements.entities.CommunalHelper/CoreModeMusicController.tooltips.hot=The values to which the parameters will be set when the core mode is "Hot".
 placements.entities.CommunalHelper/CoreModeMusicController.tooltips.cold=The values to which the parameters will be set when the core mode is "Cold".
 placements.entities.CommunalHelper/CoreModeMusicController.tooltips.none=The values to which the parameters will be set when the core mode is "None".
-placements.entities.CommunalHelper/CoreModeMusicController.tooltips.disable=If this is ticked on, this controller will look for every controller with the same parameter list (in order), and disable it (remove it). It also removes itself afterwards. 
+placements.entities.CommunalHelper/CoreModeMusicController.tooltips.disable=If this is ticked on, this controller will look for every controller with the same parameter list (in order), and disable it (remove it). It also removes itself afterwards.
 
 # -- No Overlay Watch Tower --
 placements.entities.CommunalHelper/NoOverlayLookout.tooltips.summit=Whether the watch tower should zoom on the final node or not. Requires nodes to function, otherwise game will crash.
@@ -400,7 +402,7 @@ placements.entities.CommunalHelper/DreamStrawberry.tooltips.order=Manually deter
 
 # -- Dash State Trigger --
 placements.triggers.CommunalHelper/DashStateTrigger.tooltips.dashState=The dash state to set.
-placements.triggers.CommunalHelper/DashStateTrigger.tooltips.mode=The changing mode.\n'Trigger' changes the dash state when the player enters the trigger.\n'OneUse' makes this trigger remove itself when used.\n'Field' makes it change the dash state constantly while the player is inside. 
+placements.triggers.CommunalHelper/DashStateTrigger.tooltips.mode=The changing mode.\n'Trigger' changes the dash state when the player enters the trigger.\n'OneUse' makes this trigger remove itself when used.\n'Field' makes it change the dash state constantly while the player is inside.
 
 # -- Music Param Trigger --
 placements.triggers.CommunalHelper/MusicParamTrigger.tooltips.enterValue=The value to which the parameter(s) are set when the player is touching the trigger.

--- a/Loenn/entities/attached_wall_booster.lua
+++ b/Loenn/entities/attached_wall_booster.lua
@@ -14,8 +14,8 @@ attachedWallBooster.placements = {
         data = {
             height = 8,
             left = true,
-            notCoreMode = false,
-            legacyBoost = true
+            legacyBoost = true,
+            coreModeBehavior = "ToggleDefaultHot"
         }
     },
     {
@@ -24,15 +24,49 @@ attachedWallBooster.placements = {
         data = {
             height = 8,
             left = false,
-            notCoreMode = false,
-            legacyBoost = true
+            legacyBoost = true,
+            coreModeBehavior = "ToggleDefaultHot"
         }
     }
 }
 
-local topTexture = "objects/wallBooster/fireTop00"
-local middleTexture = "objects/wallBooster/fireMid00"
-local bottomTexture = "objects/wallBooster/fireBottom00"
+local names = {
+    ToggleDefaultHot = "Toggle (Default to Hot)",
+    ToggleDefaultCold = "Toggle (Default to Cold)",
+    AlwaysHot = "Always Hot",
+    AlwaysCold = "Always Cold"
+}
+
+attachedWallBooster.fieldInformation = {
+    coreModeBehavior = {
+        options = {
+            "ToggleDefaultHot",
+            "ToggleDefaultCold",
+            "AlwaysHot",
+            "AlwaysCold"
+        },
+        displayTransformer = function(s) return names[s] end,
+        editable = false
+    }
+}
+
+local fireTopTexture = "objects/wallBooster/fireTop00"
+local fireMiddleTexture = "objects/wallBooster/fireMid00"
+local fireBottomTexture = "objects/wallBooster/fireBottom00"
+
+local iceTopTexture = "objects/wallBooster/iceTop00"
+local iceMiddleTexture = "objects/wallBooster/iceMid00"
+local iceBottomTexture = "objects/wallBooster/iceBottom00"
+
+local function getWallTextures(renderCold)
+    if renderCold then
+        return iceTopTexture, iceMiddleTexture, iceBottomTexture
+
+    else
+        return fireTopTexture, fireMiddleTexture, fireBottomTexture
+    end
+end
+
 local topTextureAlt = "objects/CommunalHelper/attachedWallBooster/fireTop00"
 local bottomTextureAlt = "objects/CommunalHelper/attachedWallBooster/fireBottom00"
 
@@ -45,6 +79,9 @@ function attachedWallBooster.sprite(room, entity)
     local offsetX = left and 0 or 8
     local scaleX = left and 1 or -1
 
+    local renderCold = entity.notCoreMode or entity.coreModeBehavior == "ToggleDefaultCold" or entity.coreModeBehavior == "AlwaysCold"
+    local topTexture, middleTexture, bottomTexture = getWallTextures(renderCold)
+
     for i = 2, tileHeight - 1 do
         local middleSprite = drawableSprite.fromTexture(middleTexture, entity)
 
@@ -56,8 +93,8 @@ function attachedWallBooster.sprite(room, entity)
     end
 
     local legacyBoost = entity.legacyBoost
-    local topSprite = drawableSprite.fromTexture(legacyBoost and topTexture or topTextureAlt, entity)
-    local bottomSprite = drawableSprite.fromTexture(legacyBoost and bottomTexture or bottomTextureAlt, entity)
+    local topSprite = drawableSprite.fromTexture((legacyBoost or renderCold) and topTexture or topTextureAlt, entity)
+    local bottomSprite = drawableSprite.fromTexture((legacyBoost or renderCold) and bottomTexture or bottomTextureAlt, entity)
 
     topSprite:addPosition(offsetX, 0)
     topSprite:setScale(scaleX, 1)

--- a/Loenn/entities/attached_wall_booster.lua
+++ b/Loenn/entities/attached_wall_booster.lua
@@ -30,22 +30,14 @@ attachedWallBooster.placements = {
     }
 }
 
-local names = {
-    ToggleDefaultHot = "Toggle (Default to Hot)",
-    ToggleDefaultCold = "Toggle (Default to Cold)",
-    AlwaysHot = "Always Hot",
-    AlwaysCold = "Always Cold"
-}
-
 attachedWallBooster.fieldInformation = {
     coreModeBehavior = {
         options = {
-            "ToggleDefaultHot",
-            "ToggleDefaultCold",
-            "AlwaysHot",
-            "AlwaysCold"
+            {"Toggle (Default to Hot)", "ToggleDefaultHot"},
+            {"Toggle (Default to Cold)", "ToggleDefaultCold"},
+            {"Always Hot", "AlwaysHot"},
+            {"Always Cold", "AlwaysCold"}
         },
-        displayTransformer = function(s) return names[s] end,
         editable = false
     }
 }

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -41,7 +41,9 @@ entities.CommunalHelper/CustomSummitGem.attributes.description.index=Determines 
 entities.CommunalHelper/AttachedWallBooster.placements.name.right=Attached Wall Booster (Right)
 entities.CommunalHelper/AttachedWallBooster.placements.name.left=Attached Wall Booster (Left)
 entities.CommunalHelper/AttachedWallBooster.attributes.description.left=Whether the Attached Wall Booster should attach to the left sides of solids.
-entities.CommunalHelper/AttachedWallBooster.attributes.description.notCoreMode=Whether the Attached Wall Booster should ignore the current Core Mode and be in Ice Mode.
+entities.CommunalHelper/AttachedWallBooster.attributes.name.notCoreMode=Force Ice on Room Entry
+entities.CommunalHelper/AttachedWallBooster.attributes.description.notCoreMode=Whether the Attached Wall Booster should ignore the current Core Mode and be in Ice Mode when entering the room.\nThis is a legacy option that may not work as expected with different settings for Core Mode Behavior.
+entities.CommunalHelper/AttachedWallBooster.attributes.description.coreModeBehavior=How the Attached Wall Booster should interact with the Core Mode.\nIf set to Toggle, it will respect the current Core Mode and use the default value if the Core Mode is None.\nIf set to Always Hot/Cold, it will completely ignore the Core Mode and always stay in one mode.
 entities.CommunalHelper/AttachedWallBooster.attributes.description.legacyBoost=Makes this Attached Wall Booster apply the expected speed boost to the player.\nIf disabled, the vertical boost is applied twice if the player isn't moving horizontally, due to a bug that was accidentally introduced in 1.11.2.\nAlso, if disabled, this entity is reskinned with a variant of the wall booster textures.
 
 # Station Block
@@ -433,7 +435,7 @@ entities.CommunalHelper/CoreModeMusicController.attributes.description.params=A 
 entities.CommunalHelper/CoreModeMusicController.attributes.description.hot=The values to which the parameters will be set when the core mode is "Hot".
 entities.CommunalHelper/CoreModeMusicController.attributes.description.cold=The values to which the parameters will be set when the core mode is "Cold".
 entities.CommunalHelper/CoreModeMusicController.attributes.description.none=The values to which the parameters will be set when the core mode is "None".
-entities.CommunalHelper/CoreModeMusicController.attributes.description.disable=If this is ticked on, this controller will look for every controller with the same parameter list (in order), and disable it (remove it). It also removes itself afterwards. 
+entities.CommunalHelper/CoreModeMusicController.attributes.description.disable=If this is ticked on, this controller will look for every controller with the same parameter list (in order), and disable it (remove it). It also removes itself afterwards.
 
 # Heart Gem Shards
 entities.CommunalHelper/CrystalHeart.placements.name.heart_gem_shards=Crystal Heart (Shards)
@@ -521,7 +523,7 @@ entities.CommunalHelper/CustomSummitGemManager.attributes.description.heartOffse
 # Redless Berry
 entities.CommunalHelper/RedlessBerry.placements.name.redless_berry=Redless Berry
 entities.CommunalHelper/RedlessBerry.attributes.description.persistent=Whether this Redless Berry stays with the player, even throughout deaths.
-entities.CommunalHelper/RedlessBerry.attributes.description.winged=Makes this Redless Berry winged, meaning that it won't appear if the player was tired at some point in the session. 
+entities.CommunalHelper/RedlessBerry.attributes.description.winged=Makes this Redless Berry winged, meaning that it won't appear if the player was tired at some point in the session.
 
 # Dream Strawberry
 entities.CommunalHelper/DreamStrawberry.placements.name.dream_dash_berry=Dream Strawberry
@@ -548,7 +550,7 @@ entities.CommunalHelper/PlayerSeekerBarrier.attributes.description.spiky=[DEPREC
 # Dash State Trigger
 triggers.CommunalHelper/DashStateTrigger.placements.name.trigger=Dash State
 triggers.CommunalHelper/DashStateTrigger.attributes.description.dashState=The dash state to set.
-triggers.CommunalHelper/DashStateTrigger.attributes.description.mode=The changing mode. 'Trigger' changes the dash state when the player enters the trigger. 'OneUse' makes this trigger remove itself when used. 'Field' makes it change the dash state constantly while the player is inside. 
+triggers.CommunalHelper/DashStateTrigger.attributes.description.mode=The changing mode. 'Trigger' changes the dash state when the player enters the trigger. 'OneUse' makes this trigger remove itself when used. 'Field' makes it change the dash state constantly while the player is inside.
 
 # Music Param Trigger
 triggers.CommunalHelper/MusicParamTrigger.placements.name.trigger=Music Parameter
@@ -622,4 +624,4 @@ style.effects.CommunalHelper/Cloudscape.description.innerDensity=A number betwee
 style.effects.CommunalHelper/Cloudscape.description.outerDensity=A number between 0 and 2 that determines how cloudy the effect is at the edge. 0 is no clouds at all, 1 is enough to fill most gaps, 2 is twice as much clouds.
 style.effects.CommunalHelper/Cloudscape.description.innerRotation=The rotational speed at the middle.
 style.effects.CommunalHelper/Cloudscape.description.outerRotation=The rotational speed at the edge.
-style.effects.CommunalHelper/Cloudscape.description.rotationExponent=A number between 0 and 2 that describes the interpolation of the rotational speed between the inner and outer rings. 1 is linear, 0 makes the value approach the outer target value faster, 2 makes the value approach the outer target value sooner.\nThis is hard to describe. 
+style.effects.CommunalHelper/Cloudscape.description.rotationExponent=A number between 0 and 2 that describes the interpolation of the rotational speed between the inner and outer rings. 1 is linear, 0 makes the value approach the outer target value faster, 2 makes the value approach the outer target value sooner.\nThis is hard to describe.


### PR DESCRIPTION
The `notCoreMode` option inherited from vanilla has very idiosyncratic behavior (it forces the wall booster to be in ice mode when entering the room, but doesn't prevent it from toggling with the core mode). This PR retires that option (retaining backwards compatibility) and replaces it with a dropdown that offers the options of always using the hot/cold variant or toggling based on core mode, and also allows specifying in that case which mode to use if the core mode is None.