### PR TITLE
Use DynamicData instead of DynData

### DIFF
--- a/src/DashStates/DashStateRefill.cs
+++ b/src/DashStates/DashStateRefill.cs
@@ -16,12 +16,12 @@ public abstract class DashStateRefill : Refill
 
     private readonly float respawnTime;
 
-    protected DynData<Refill> baseData;
+    protected DynamicData baseData;
 
     protected DashStateRefill(EntityData data, Vector2 offset)
         : base(data, offset)
     {
-        baseData = new DynData<Refill>(this);
+        baseData = DynamicData.For(this);
 
         respawnTime = data.Float("respawnTime", 2.5f); // default is 2.5 sec.
 
@@ -31,13 +31,13 @@ public abstract class DashStateRefill : Refill
         {
             Remove(baseData.Get<Sprite>("sprite"));
             Add(sprite);
-            baseData["sprite"] = sprite;
+            baseData.Set("sprite", sprite);
         }
 
         if (TryCreateCustomOutline(out Image outline))
         {
             Remove(baseData.Get<Image>("outline"));
-            baseData["outline"] = outline;
+            baseData.Set("outline", outline);
             Add(outline);
         }
 
@@ -45,7 +45,7 @@ public abstract class DashStateRefill : Refill
         {
             Remove(baseData.Get<Sprite>("flash"));
             Add(flash);
-            baseData["flash"] = flash;
+            baseData.Set("flash", flash);
         }
     }
 
@@ -60,7 +60,7 @@ public abstract class DashStateRefill : Refill
             Input.Rumble(RumbleStrength.Medium, RumbleLength.Medium);
             Collidable = false;
             Add(new Coroutine((IEnumerator) m_Refill_RefillRoutine.Invoke(this, new object[] { player })));
-            baseData["respawnTimer"] = respawnTime;
+            baseData.Set("respawnTimer", respawnTime);
         }
     }
 

--- a/src/DashStates/DashStateRefill.cs
+++ b/src/DashStates/DashStateRefill.cs
@@ -21,7 +21,7 @@ public abstract class DashStateRefill : Refill
     protected DashStateRefill(EntityData data, Vector2 offset)
         : base(data, offset)
     {
-        baseData = DynamicData.For(this);
+        baseData = new(typeof(Refill), this);
 
         respawnTime = data.Float("respawnTime", 2.5f); // default is 2.5 sec.
 

--- a/src/DashStates/DreamTunnelDash/DreamTunnelEntry.cs
+++ b/src/DashStates/DreamTunnelDash/DreamTunnelEntry.cs
@@ -530,7 +530,7 @@ public class DreamTunnelEntry : AbstractPanel
         cursor.Emit(OpCodes.Ldarg_0);
         cursor.EmitDelegate<Func<Platform, Player, Platform>>((platform, player) =>
         {
-            foreach (StaticMover sm in new DynData<Platform>(platform).Get<List<StaticMover>>("staticMovers"))
+            foreach (StaticMover sm in DynamicData.For(platform).Get<List<StaticMover>>("staticMovers"))
             {
                 Vector2 origin = player.Position + new Vector2((float) player.Facing * 3, -4f);
                 if (sm.Entity is DreamTunnelEntry entry
@@ -552,7 +552,7 @@ public class DreamTunnelEntry : AbstractPanel
         cursor.Emit(OpCodes.Ldarg_0);
         cursor.EmitDelegate<Func<Platform, Player, Platform>>((platform, player) =>
         {
-            foreach (StaticMover sm in new DynData<Platform>(platform).Get<List<StaticMover>>("staticMovers"))
+            foreach (StaticMover sm in DynamicData.For(platform).Get<List<StaticMover>>("staticMovers"))
             {
                 if (sm.Entity is DreamTunnelEntry entry && entry.Orientation == Spikes.Directions.Up
                     && player.CollideCheck(entry, player.Position + Vector2.UnitY))
@@ -573,7 +573,7 @@ public class DreamTunnelEntry : AbstractPanel
         cursor.Emit(OpCodes.Ldarg_1);
         cursor.EmitDelegate<Func<Platform, Player, int, Platform>>((platform, player, dir) =>
         {
-            foreach (StaticMover sm in new DynData<Platform>(platform).Get<List<StaticMover>>("staticMovers"))
+            foreach (StaticMover sm in DynamicData.For(platform).Get<List<StaticMover>>("staticMovers"))
             {
                 if (sm.Entity is DreamTunnelEntry entry
                     && (entry.Orientation is Spikes.Directions.Left or Spikes.Directions.Right)

--- a/src/DashStates/SeekerDash/SeekerDash.cs
+++ b/src/DashStates/SeekerDash/SeekerDash.cs
@@ -219,7 +219,7 @@ public static class SeekerDash
 
         self.Scene.Tracker.GetEntities<SeekerBarrier>().ForEach(e => e.Collidable = false);
 
-        DynData<Player> playerData = self.GetData();
+        DynamicData playerData = self.GetData();
 
         // launchPossible is a bad hack to fix wavedashing
         bool resetLaunchPossible = false;
@@ -394,7 +394,7 @@ public static class SeekerDash
     // Bop the seeker if SeekerAttacking, kill the seeker if player was launched from seekerdash
     private static void Seeker_OnAttackPlayer(On.Celeste.Seeker.orig_OnAttackPlayer orig, Seeker self, Player player)
     {
-        DynData<Seeker> seekerData = new(self);
+        DynamicData seekerData = DynamicData.For(self);
         int state = seekerData.Get<StateMachine>("State").State;
         if (SeekerAttacking)
         {
@@ -421,7 +421,7 @@ public static class SeekerDash
     {
         if (SeekerAttacking)
         {
-            DynData<AngryOshiro> oshiroData = new(self);
+            DynamicData oshiroData = DynamicData.For(self);
             Audio.Play(SFX.game_gen_thing_booped, self.Position);
             Celeste.Freeze(0.2f);
             player.Bounce(player.CenterY + 2f);
@@ -471,7 +471,7 @@ public static class SeekerDash
     /// <param name="onEnd">Action to perform on completion.</param>
     private static IEnumerator TrappedDash(this Player player, Entity barrier, Action onEnd = null)
     {
-        DynData<Player> playerData = player.GetData();
+        DynamicData playerData = player.GetData();
 
         player.Dashes = Math.Max(0, player.Dashes - 1);
         Input.Dash.ConsumeBuffer();
@@ -481,7 +481,7 @@ public static class SeekerDash
             Celeste.Freeze(0.05f);
         }
 
-        playerData["dashCooldownTimer"] = 0.2f;
+        playerData.Set("dashCooldownTimer", 0.2f);
         Input.Rumble(RumbleStrength.Strong, RumbleLength.Medium);
         player.Speed = -Vector2.UnitY * 5f;
         yield return null;
@@ -494,7 +494,7 @@ public static class SeekerDash
         DisplacementRenderer.Burst burst = barrier.SceneAs<Level>().Displacement.AddBurst(player.Center, 0.8f, 8f, 64f, 0.5f, Ease.QuadOut, Ease.QuadOut);
         burst.WorldClipCollider = barrier.Collider;
 
-        player.DashDir = (Vector2) m_Player_CorrectDashPrecision.Invoke(player, new object[] { playerData["lastAim"] });
+        player.DashDir = (Vector2) m_Player_CorrectDashPrecision.Invoke(player, new object[] { playerData.Get<Vector2>("lastAim") });
 
         player.SceneAs<Level>().DirectionalShake(player.DashDir, 0.2f);
         m_Player_CallDashEvents.Invoke(player, null);

--- a/src/Entities/Boosters/CurvedBooster.cs
+++ b/src/Entities/Boosters/CurvedBooster.cs
@@ -148,7 +148,7 @@ public class CurvedBooster : CustomBooster
     {
         base.RedDashUpdateBefore(player);
 
-        DynData<Player> data = player.GetData();
+        DynamicData data = player.GetData();
 
         Vector2 prev = player.Position;
 

--- a/src/Entities/Boosters/CustomBooster.cs
+++ b/src/Entities/Boosters/CustomBooster.cs
@@ -9,7 +9,7 @@ namespace Celeste.Mod.CommunalHelper.Entities;
 
 public abstract class CustomBooster : Booster
 {
-    protected DynData<Booster> BoosterData;
+    protected DynamicData BoosterData;
 
     public ParticleType P_CustomAppear, P_CustomBurst;
 
@@ -26,7 +26,7 @@ public abstract class CustomBooster : Booster
     public CustomBooster(Vector2 position, bool redBoost)
         : base(position, redBoost)
     {
-        BoosterData = new DynData<Booster>(this);
+        BoosterData = DynamicData.For(this);
 
         P_CustomAppear = P_Appear;
         P_CustomBurst = redBoost ? P_BurstRed : P_Burst;
@@ -36,16 +36,16 @@ public abstract class CustomBooster : Booster
     {
         Sprite oldSprite = BoosterData.Get<Sprite>("sprite");
         Remove(oldSprite);
-        BoosterData["sprite"] = newSprite;
+        BoosterData.Set("sprite", newSprite);
         Add(newSprite);
     }
 
     protected void SetParticleColors(Color burstColor, Color appearColor)
     {
-        BoosterData["particleType"] = P_CustomBurst = new ParticleType(P_Burst)
+        BoosterData.Set("particleType", P_CustomBurst = new ParticleType(P_Burst)
         {
             Color = burstColor
-        };
+        });
         P_CustomAppear = new ParticleType(P_Appear)
         {
             Color = appearColor
@@ -199,17 +199,16 @@ public abstract class CustomBooster : Booster
             {
                 if (justEntered)
                 {
-                    booster.BoosterData["cannotUseTimer"] = 0.45f;
+                    booster.BoosterData.Set("cannotUseTimer", 0.45f);
+
                     if (booster.RedBoost)
-                    {
                         player.RedBoost(self);
-                    }
                     else
-                    {
                         player.Boost(self);
-                    }
+
                     Audio.Play(booster.enterSoundEvent, self.Position);
                     booster.BoosterData.Get<Wiggler>("wiggler").Start();
+
                     Sprite sprite = booster.BoosterData.Get<Sprite>("sprite");
                     sprite.Play("inside");
                     sprite.FlipX = player.Facing == Facings.Left;

--- a/src/Entities/Boosters/CustomBooster.cs
+++ b/src/Entities/Boosters/CustomBooster.cs
@@ -26,7 +26,7 @@ public abstract class CustomBooster : Booster
     public CustomBooster(Vector2 position, bool redBoost)
         : base(position, redBoost)
     {
-        BoosterData = DynamicData.For(this);
+        BoosterData = new(typeof(Booster), this);
 
         P_CustomAppear = P_Appear;
         P_CustomBurst = redBoost ? P_BurstRed : P_Burst;

--- a/src/Entities/Boosters/DreamBooster.cs
+++ b/src/Entities/Boosters/DreamBooster.cs
@@ -122,7 +122,7 @@ public class DreamBoosterHooks
     {
         if (self is Player player && player.StateMachine.State == Player.StRedDash && player.LastBooster is DreamBooster booster)
         {
-            DynamicData playerData = player.GetData();
+            DynamicData playerData = new(typeof(Actor), self);
             float pos = player.X;
             Vector2 counter = playerData.Get<Vector2>("movementCounter");
             dreamBoostMove = true;
@@ -143,7 +143,7 @@ public class DreamBoosterHooks
     {
         if (self is Player player && player.StateMachine.State == Player.StRedDash && player.LastBooster is DreamBooster booster)
         {
-            DynamicData playerData = player.GetData();
+            DynamicData playerData = new(typeof(Actor), self);
             float pos = player.Y;
             Vector2 counter = playerData.Get<Vector2>("movementCounter");
             dreamBoostMove = true;

--- a/src/Entities/Boosters/DreamBooster.cs
+++ b/src/Entities/Boosters/DreamBooster.cs
@@ -122,14 +122,14 @@ public class DreamBoosterHooks
     {
         if (self is Player player && player.StateMachine.State == Player.StRedDash && player.LastBooster is DreamBooster booster)
         {
-            DynData<Actor> playerData = new(player);
+            DynamicData playerData = player.GetData();
             float pos = player.X;
             Vector2 counter = playerData.Get<Vector2>("movementCounter");
             dreamBoostMove = true;
             if (orig(self, moveH, onCollide, pusher) && !dreamBoostStop)
             {
                 player.X = pos;
-                playerData["movementCounter"] = counter;
+                playerData.Set("movementCounter", counter);
                 player.NaiveMove(Vector2.UnitX * moveH);
             }
             dreamBoostStop = false;
@@ -143,14 +143,14 @@ public class DreamBoosterHooks
     {
         if (self is Player player && player.StateMachine.State == Player.StRedDash && player.LastBooster is DreamBooster booster)
         {
-            DynData<Actor> playerData = new(player);
+            DynamicData playerData = player.GetData();
             float pos = player.Y;
             Vector2 counter = playerData.Get<Vector2>("movementCounter");
             dreamBoostMove = true;
             if (orig(self, moveV, onCollide, pusher) && !dreamBoostStop)
             {
                 player.Y = pos;
-                playerData["movementCounter"] = counter;
+                playerData.Set("movementCounter", counter);
                 player.NaiveMove(Vector2.UnitY * moveV);
             }
             dreamBoostStop = false;
@@ -180,7 +180,7 @@ public class DreamBoosterHooks
                 return;
             }
 
-            if (new DynData<DreamBlock>(block).Get<bool>("playerHasDreamDash"))
+            if (DynamicData.For(block).Get<bool>("playerHasDreamDash"))
             {
                 self.Die(-data.Moved);
                 return;

--- a/src/Entities/Boosters/DreamBoosterCurve.cs
+++ b/src/Entities/Boosters/DreamBoosterCurve.cs
@@ -136,7 +136,7 @@ public class DreamBoosterCurve : DreamBooster
     {
         base.RedDashUpdateBefore(player);
 
-        DynData<Player> data = player.GetData();
+        DynamicData data = player.GetData();
 
         Vector2 prev = player.Position;
 
@@ -155,8 +155,8 @@ public class DreamBoosterCurve : DreamBooster
         // this is here so that the player doesn't die to spikes that it shouldn't die to.
         player.Speed = derivative.SafeNormalize();
 
-        player.MoveToX(next.X, (Collision) data["onCollideH"]);
-        player.MoveToY(next.Y + offY, (Collision) data["onCollideV"]);
+        player.MoveToX(next.X, data.Get<Collision>("onCollideH"));
+        player.MoveToY(next.Y + offY, data.Get<Collision>("onCollideV"));
 
         // Then finish overriding.
         GravityHelper.EndOverride?.Invoke();

--- a/src/Entities/CassetteBlocks/CassetteJumpFixController.cs
+++ b/src/Entities/CassetteBlocks/CassetteJumpFixController.cs
@@ -63,8 +63,8 @@ public class CassetteJumpFixController : Entity
         if (MustApply(self.Scene))
         {
             self.MoveV(amount, 0f);
-            DynData<CassetteBlock> data = new(self);
-            data["blockHeight"] = data.Get<int>("blockHeight") - amount;
+            DynamicData data = DynamicData.For(self);
+            data.Set("blockHeight", data.Get<int>("blockHeight") - amount);
         }
         else
             orig(self, amount);

--- a/src/Entities/CassetteBlocks/CustomCassetteBlock.cs
+++ b/src/Entities/CassetteBlocks/CustomCassetteBlock.cs
@@ -74,7 +74,7 @@ public class CustomCassetteBlock : CassetteBlock
     // Whether the block is collidable according to cassette state
     private bool virtualCollidable = true;
 
-    protected DynData<CassetteBlock> blockData;
+    protected DynamicData blockData;
 
     public CustomCassetteBlock(EntityData data, Vector2 offset, EntityID id)
         : this(data.Position + offset, id, data.Width, data.Height, data.Int("index"), data.Float("tempo", 1f), false, data.HexColorNullable("customColor")) { }
@@ -82,13 +82,13 @@ public class CustomCassetteBlock : CassetteBlock
     public CustomCassetteBlock(Vector2 position, EntityID id, int width, int height, int index, float tempo, bool dynamicHitbox = false, Color? overrideColor = null)
         : base(position, id, width, height, index, tempo)
     {
-        blockData = new DynData<CassetteBlock>(this);
+        blockData = new(typeof(CassetteBlock), this);
 
         Index = index;
         color = overrideColor ?? colorOptions[index];
         pressedColor = color.Mult(Calc.HexToColor("667da5"));
 
-        blockData["color"] = color;
+        blockData.Set("color", color);
 
         this.dynamicHitbox = dynamicHitbox;
         if (dynamicHitbox)

--- a/src/Entities/Chains/ChainedKevin.cs
+++ b/src/Entities/Chains/ChainedKevin.cs
@@ -16,7 +16,7 @@ internal class ChainedKevin : CrushBlock
     private readonly bool chainOutline;
     private readonly MTexture chainTexture;
 
-    private DynData<CrushBlock> crushBlockData;
+    private DynamicData crushBlockData;
     private List<Image> idleImages, activeTopImages, activeRightImages, activeLeftImages, activeBottomImages;
 
     public ChainedKevin(EntityData data, Vector2 offset)
@@ -171,7 +171,7 @@ internal class ChainedKevin : CrushBlock
     {
         if (self is ChainedKevin chainedKevin)
         {
-            chainedKevin.crushBlockData = new DynData<CrushBlock>(chainedKevin);
+            chainedKevin.crushBlockData = new(typeof(CrushBlock), chainedKevin);
             chainedKevin.vectorDirection = (chainedKevin.direction = data.Enum("direction", Directions.Right)).Vector();
             chainedKevin.centeredChain = data.Bool("centeredChain");
         }

--- a/src/Entities/ConnectedBlocks/ConnectedSolid.cs
+++ b/src/Entities/ConnectedBlocks/ConnectedSolid.cs
@@ -76,6 +76,8 @@ public class ConnectedSolid : Solid
     public List<Image> InnerCornerTiles = new();
     public List<Image> FillerTiles = new();
 
+    private readonly DynamicData data;
+
     public ConnectedSolid(Vector2 position, int width, int height, bool safe)
         : base(position, width, height, safe)
     {
@@ -84,6 +86,8 @@ public class ConnectedSolid : Solid
         MasterWidth = width;
         MasterHeight = height;
         MasterCollider = Collider;
+
+        data = new(typeof(Solid), this);
     }
 
     public override void Awake(Scene scene)
@@ -394,7 +398,7 @@ public class ConnectedSolid : Solid
         GetRiders();
         Player player = Scene.Tracker.GetEntity<Player>();
 
-        HashSet<Actor> riders = new DynData<Solid>(this).Get<HashSet<Actor>>("riders");
+        HashSet<Actor> riders = data.Get<HashSet<Actor>>("riders");
 
         if (player != null && Input.MoveX.Value == Math.Sign(move) && Math.Sign(player.Speed.X) == Math.Sign(move) && !riders.Contains(player) && CollideCheck(player, Position + (Vector2.UnitX * move) - Vector2.UnitY))
         {
@@ -457,7 +461,7 @@ public class ConnectedSolid : Solid
         //base.MoveVExact(move);
         GetRiders();
 
-        HashSet<Actor> riders = new DynData<Solid>(this).Get<HashSet<Actor>>("riders");
+        HashSet<Actor> riders = data.Get<HashSet<Actor>>("riders");
 
         Y += move;
         MoveStaticMovers(Vector2.UnitY * move);

--- a/src/Entities/DreamBlocks/CustomDreamBlock.cs
+++ b/src/Entities/DreamBlocks/CustomDreamBlock.cs
@@ -110,7 +110,7 @@ public abstract class CustomDreamBlock : DreamBlock
     private bool delayedSetupParticles;
     protected bool awake;
 
-    protected DynData<DreamBlock> baseData;
+    protected DynamicData baseData;
 
     public CustomDreamBlock(EntityData data, Vector2 offset)
         : this(data.Position + offset, data.Width, data.Height, data.Bool("featherMode"), data.Bool("oneUse"), GetRefillCount(data), data.Bool("below"), data.Bool("quickDestroy")) { }
@@ -118,7 +118,7 @@ public abstract class CustomDreamBlock : DreamBlock
     public CustomDreamBlock(Vector2 position, int width, int height, bool featherMode, bool oneUse, int refillCount, bool below, bool quickDestroy)
         : base(position, width, height, null, false, oneUse, below)
     {
-        baseData = new DynData<DreamBlock>(this);
+        baseData = new(typeof(DreamBlock), this);
         QuickDestroy = quickDestroy;
         RefillCount = refillCount;
 
@@ -171,7 +171,7 @@ public abstract class CustomDreamBlock : DreamBlock
     {
         float countFactor = (FeatherMode ? 0.5f : 0.7f) * RefillCount != -1 ? 1.2f : 1;
         particles = new DreamParticle[(int) (canvasWidth / 8f * (canvasHeight / 8f) * 0.7f * countFactor)];
-        baseData["particles"] = Array.CreateInstance(DreamParticle.t_DreamParticle, particles.Length);
+        baseData.Set("particles", Array.CreateInstance(DreamParticle.t_DreamParticle, particles.Length));
 
         // Necessary to get the player's spritemode
         if (!awake && RefillCount != -1)
@@ -297,7 +297,7 @@ public abstract class CustomDreamBlock : DreamBlock
             {
                 shake.Y = Calc.Random.Next(-1, 2);
             }
-            baseData["shake"] = shake;
+            baseData.Set("shake", shake);
             shakeToggle = !shakeToggle;
             if (!shattering)
                 ShakeParticles();
@@ -602,7 +602,7 @@ public abstract class CustomDreamBlock : DreamBlock
     private static void Player_DreamDashBegin(On.Celeste.Player.orig_DreamDashBegin orig, Player player)
     {
         orig(player);
-        DynData<Player> playerData = player.GetData();
+        DynamicData playerData = player.GetData();
         DreamBlock dreamBlock = playerData.Get<DreamBlock>("dreamBlock");
         if (dreamBlock is CustomDreamBlock customDreamBlock)
         {
@@ -625,7 +625,7 @@ public abstract class CustomDreamBlock : DreamBlock
 
     private static int Player_DreamDashUpdate(On.Celeste.Player.orig_DreamDashUpdate orig, Player player)
     {
-        DynData<Player> playerData = player.GetData();
+        DynamicData playerData = player.GetData();
         DreamBlock dreamBlock = playerData.Get<DreamBlock>("dreamBlock");
         if (dreamBlock is CustomDreamBlock customDreamBlock && customDreamBlock.FeatherMode)
         {
@@ -652,7 +652,7 @@ public abstract class CustomDreamBlock : DreamBlock
         if (cursor.TryGotoNext(instr => instr.MatchCallvirt<Player>("RefillDash")))
         {
             cursor.Emit(OpCodes.Ldarg_0);
-            cursor.EmitDelegate<Func<Player, bool>>(player => player.GetData()["dreamBlock"] is CustomDreamBlock block && block.RefillCount == -2);
+            cursor.EmitDelegate<Func<Player, bool>>(player => player.GetData().Get<DreamBlock>("dreamBlock") is CustomDreamBlock block && block.RefillCount == -2);
             cursor.Emit(OpCodes.Brtrue_S, cursor.Next.Next);
         }
     }

--- a/src/Entities/DreamBlocks/DreamBlockDebris.cs
+++ b/src/Entities/DreamBlocks/DreamBlockDebris.cs
@@ -21,11 +21,11 @@ public class DreamBlockDebris : Debris
     private Color? disabledPointColor;
     private Vector2 pointOffset;
 
-    private readonly DynData<Debris> baseData;
+    private readonly DynamicData baseData;
 
     public DreamBlockDebris()
     {
-        baseData = new DynData<Debris>(this);
+        baseData = new(typeof(Debris), this);
     }
 
     public DreamBlockDebris Init(Vector2 pos, DreamBlockDummy block = null)
@@ -48,7 +48,7 @@ public class DreamBlockDebris : Debris
 
         Add(sprite);
         sprite.Play(Block.PlayerHasDreamDash ? "active" : "disabled", randomizeFrame: true);
-        baseData["image"] = this.sprite = sprite;
+        baseData.Set("image", this.sprite = sprite);
 
         if (Calc.Random.Next(4) == 0)
         {

--- a/src/Entities/DreamBlocks/DreamCrumbleWallOnRumble.cs
+++ b/src/Entities/DreamBlocks/DreamCrumbleWallOnRumble.cs
@@ -9,7 +9,7 @@ namespace Celeste.Mod.CommunalHelper.Entities;
 public class DreamCrumbleWallOnRumble : CustomDreamBlock
 {
     /// <summary>
-    /// DynData field for storing the List&lt;<see cref="DreamCrumbleWallOnRumble"/>&gt; in a <see cref="RumbleTrigger"/>
+    /// DynamicData field for storing the List&lt;<see cref="DreamCrumbleWallOnRumble"/>&gt; in a <see cref="RumbleTrigger"/>
     /// </summary>
     public const string RUMBLETRIGGER_DREAMCRUMBLES = "communalHelperDreamCrumbles";
 
@@ -74,7 +74,7 @@ public class DreamCrumbleWallOnRumble : CustomDreamBlock
     {
         orig(self, scene);
 
-        DynData<RumbleTrigger> triggerData = new(self);
+        DynamicData triggerData = DynamicData.For(self);
         bool constrainHeight = triggerData.Get<bool>("constrainHeight");
 
         // Reflection is slow
@@ -99,12 +99,12 @@ public class DreamCrumbleWallOnRumble : CustomDreamBlock
         }
         // Slightly unsafe, but only if someone else does some weird stuff with RumbleTriggers
         if (!triggered)
-            triggerData[RUMBLETRIGGER_DREAMCRUMBLES] = crumbles;
+            triggerData.Set(RUMBLETRIGGER_DREAMCRUMBLES, crumbles);
     }
 
     private static IEnumerator RumbleTrigger_RumbleRoutine(On.Celeste.RumbleTrigger.orig_RumbleRoutine orig, RumbleTrigger self, float delay)
     {
-        DynData<RumbleTrigger> triggerData = new(self);
+        DynamicData triggerData = DynamicData.For(self);
 
         yield return new SwapImmediately(orig(self, delay));
 

--- a/src/Entities/DreamBlocks/DreamDashCollider.cs
+++ b/src/Entities/DreamBlocks/DreamDashCollider.cs
@@ -106,17 +106,17 @@ internal class DreamDashCollider : Component
     private static void Player_DashBegin(On.Celeste.Player.orig_DashBegin orig, Player self)
     {
         orig(self);
-        self.GetData()[Player_canEnterDreamDashCollider] = true;
+        self.GetData().Set(Player_canEnterDreamDashCollider, true);
     }
 
     private static void Player_DreamDashEnd(On.Celeste.Player.orig_DreamDashEnd orig, Player self)
     {
-        DynData<Player> playerData = self.GetData();
-        if ((DreamBlock) playerData["dreamBlock"] is DreamBlockDummy dummy)
+        DynamicData playerData = self.GetData();
+        if (playerData.Get<DreamBlock>("dreamBlock") is DreamBlockDummy dummy)
         {
             foreach (DreamDashCollider collider in dummy.Entity.Components.GetAll<DreamDashCollider>())
             {
-                playerData[Player_canEnterDreamDashCollider] = false;
+                playerData.Set(Player_canEnterDreamDashCollider, false);
                 collider.OnExit?.Invoke(self);
             }
         }

--- a/src/Entities/DreamBlocks/DreamJellyfish.cs
+++ b/src/Entities/DreamBlocks/DreamJellyfish.cs
@@ -37,7 +37,7 @@ internal class DreamJellyfish : Glider
         set => dreamDashCollider.Active = value;
     }
 
-    private readonly DynData<Glider> gliderData;
+    private readonly DynamicData gliderData;
 
     public Sprite Sprite;
 
@@ -47,11 +47,11 @@ internal class DreamJellyfish : Glider
     public DreamJellyfish(Vector2 position, bool bubble, bool tutorial)
         : base(position, bubble, tutorial)
     {
-        gliderData = new DynData<Glider>(this);
+        gliderData = new DynamicData(typeof(Glider), this);
 
         Sprite oldSprite = gliderData.Get<Sprite>("sprite");
         Remove(oldSprite);
-        gliderData["sprite"] = Sprite = CommunalHelperGFX.SpriteBank.Create("dreamJellyfish");
+        gliderData.Set("sprite", Sprite = CommunalHelperGFX.SpriteBank.Create("dreamJellyfish"));
         Add(Sprite);
 
         Visible = Sprite.Visible = false;
@@ -127,8 +127,8 @@ internal class DreamJellyfish : Glider
         if (Input.GrabCheck && player.DashDir.Y <= 0)
         {
             // force-allow pickup
-            player.GetData()["minHoldTimer"] = 0f;
-            new DynData<Holdable>(Hold)["cannotHoldTimer"] = 0;
+            player.GetData().Set("minHoldTimer", 0f);
+            DynamicData.For(Hold).Set("cannotHoldTimer", 0);
 
             if ((bool) m_Player_Pickup.Invoke(player, new object[] { Hold }))
             {

--- a/src/Entities/HeartGems/CSGEN_HeartGemShards.cs
+++ b/src/Entities/HeartGems/CSGEN_HeartGemShards.cs
@@ -8,7 +8,7 @@ namespace Celeste.Mod.CommunalHelper.Entities;
 public class CSGEN_HeartGemShards : CutsceneEntity
 {
     private readonly HeartGem heart;
-    private readonly DynData<HeartGem> heartData;
+    private readonly DynamicData heartData;
 
     private Vector2 cameraStart;
 
@@ -20,7 +20,7 @@ public class CSGEN_HeartGemShards : CutsceneEntity
         : base(true, false)
     {
         this.heart = heart;
-        heartData = new DynData<HeartGem>(heart);
+        heartData = new(typeof(HeartGem), heart);
     }
 
     public override void OnBegin(Level level)

--- a/src/Entities/HeartGems/MultiDashHeartGem.cs
+++ b/src/Entities/HeartGems/MultiDashHeartGem.cs
@@ -19,12 +19,12 @@ internal class MultiDashHeartGem : HeartGem
     private int health = 3;
     private readonly string[] cutscenes = new string[3];
 
-    private readonly DynData<HeartGem> baseData;
+    private readonly DynamicData baseData;
 
     public MultiDashHeartGem(EntityData data, Vector2 offset)
         : base(data, offset)
     {
-        baseData = new DynData<HeartGem>(this);
+        baseData = new(typeof(HeartGem), this);
 
         // Load cutscene ids
         string cutsceneList = data.Attr("cutscenes");
@@ -83,12 +83,12 @@ internal class MultiDashHeartGem : HeartGem
                         if (gem.baseData.Get<float>("bounceSfxDelay") <= 0f)
                         {
                             Audio.Play(SFX.game_gen_crystalheart_bounce, gem.Position);
-                            gem.baseData["bounceSfxDelay"] = 0.1f;
+                            gem.baseData.Set("bounceSfxDelay", 0.1f);
                         }
                         player.PointBounce(self.Center);
                         gem.baseData.Get<Wiggler>("moveWiggler").Start();
                         gem.ScaleWiggler.Start();
-                        gem.baseData["moveWiggleDir"] = (gem.Center - player.Center).SafeNormalize(Vector2.UnitY);
+                        gem.baseData.Set("moveWiggleDir", (gem.Center - player.Center).SafeNormalize(Vector2.UnitY));
                         Input.Rumble(RumbleStrength.Medium, RumbleLength.Medium);
                     }
                     Console.WriteLine(gem.health);
@@ -115,12 +115,12 @@ internal class MultiDashHeartGem : HeartGem
                     if (gem.baseData.Get<float>("bounceSfxDelay") <= 0f)
                     {
                         Audio.Play(SFX.game_gen_crystalheart_bounce, gem.Position);
-                        gem.baseData["bounceSfxDelay"] = 0.1f;
+                        gem.baseData.Set("bounceSfxDelay", 0.1f);
                     }
                     h.PointBounce(self.Center);
                     gem.baseData.Get<Wiggler>("moveWiggler").Start();
                     gem.ScaleWiggler.Start();
-                    gem.baseData["moveWiggleDir"] = (gem.Center - player.Center).SafeNormalize(Vector2.UnitY);
+                    gem.baseData.Set("moveWiggleDir", (gem.Center - player.Center).SafeNormalize(Vector2.UnitY));
                     Input.Rumble(RumbleStrength.Medium, RumbleLength.Medium);
                 }
                 else

--- a/src/Entities/HeartGems/SummitGem.cs
+++ b/src/Entities/HeartGems/SummitGem.cs
@@ -24,7 +24,7 @@ public class CustomSummitGem : SummitGem
     public string CustomGemSID;
 
     protected Color? particleColor;
-    protected DynData<SummitGem> baseData;
+    protected DynamicData baseData;
 
     static CustomSummitGem()
     {
@@ -37,7 +37,7 @@ public class CustomSummitGem : SummitGem
     public CustomSummitGem(EntityData data, Vector2 offset, EntityID gid)
         : base(data, offset, gid)
     {
-        baseData = new DynData<SummitGem>(this);
+        baseData = new(typeof(SummitGem), this);
 
         GemID = data.Int("index");
 
@@ -71,7 +71,7 @@ public class CustomSummitGem : SummitGem
             particleColor = Calc.HexToColor(meta.Color);
         }
 
-        baseData["sprite"] = sprite;
+        baseData.Set("sprite", sprite);
     }
 
     private IEnumerator SmashRoutine(Player player, Level level)

--- a/src/Entities/Misc/DreamBlockDummy.cs
+++ b/src/Entities/Misc/DreamBlockDummy.cs
@@ -25,7 +25,7 @@ public class DreamBlockDummy : DreamBlock
 
     public Action OnSetup;
 
-    public DynData<DreamBlock> Data;
+    public DynamicData Data;
 
     public DreamBlockDummy(Entity entity)
         : base(Vector2.Zero, 0, 0, null, false, false)
@@ -33,7 +33,7 @@ public class DreamBlockDummy : DreamBlock
         Collidable = Active = Visible = false;
         Entity = entity;
 
-        Data = new DynData<DreamBlock>(this);
+        Data = new(typeof(DreamBlock), this);
     }
 
     [MonoModLinkTo("Monocle.Entity", "System.Void Added(Monocle.Scene)")]
@@ -45,7 +45,7 @@ public class DreamBlockDummy : DreamBlock
     public override void Added(Scene scene)
     {
         base_Added(scene);
-        Data["playerHasDreamDash"] = SceneAs<Level>().Session.Inventory.DreamDash;
+        Data.Set("playerHasDreamDash", SceneAs<Level>().Session.Inventory.DreamDash);
     }
 
     public override void Update() { }
@@ -84,7 +84,7 @@ public class DreamBlockDummy : DreamBlock
     {
         if (self is DreamBlockDummy dummy && dummy.OnActivate != null)
         {
-            dummy.Data["playerHasDreamDash"] = true;
+            dummy.Data.Set("playerHasDreamDash", true);
             dummy.Entity.Add(new Coroutine(dummy.OnActivate()));
             return null;
         }
@@ -95,7 +95,7 @@ public class DreamBlockDummy : DreamBlock
     {
         if (self is DreamBlockDummy dummy && dummy.OnFastActivate != null)
         {
-            dummy.Data["playerHasDreamDash"] = true;
+            dummy.Data.Set("playerHasDreamDash", true);
             dummy.Entity.Add(new Coroutine(dummy.OnFastActivate()));
             return null;
         }
@@ -106,7 +106,7 @@ public class DreamBlockDummy : DreamBlock
     {
         if (self is DreamBlockDummy dummy && dummy.OnActivateNoRoutine != null)
         {
-            dummy.Data["playerHasDreamDash"] = true;
+            dummy.Data.Set("playerHasDreamDash", true);
             dummy.OnActivateNoRoutine();
             return;
         }
@@ -117,7 +117,7 @@ public class DreamBlockDummy : DreamBlock
     {
         if (self is DreamBlockDummy dummy && dummy.OnDeactivate != null)
         {
-            dummy.Data["playerHasDreamDash"] = false;
+            dummy.Data.Set("playerHasDreamDash", false);
             dummy.Entity.Add(new Coroutine(dummy.OnDeactivate()));
             return null;
         }
@@ -128,7 +128,7 @@ public class DreamBlockDummy : DreamBlock
     {
         if (self is DreamBlockDummy dummy && dummy.OnFastDeactivate != null)
         {
-            dummy.Data["playerHasDreamDash"] = false;
+            dummy.Data.Set("playerHasDreamDash", false);
             dummy.Entity.Add(new Coroutine(dummy.OnFastDeactivate()));
             return null;
         }
@@ -139,7 +139,7 @@ public class DreamBlockDummy : DreamBlock
     {
         if (self is DreamBlockDummy dummy && dummy.OnDeactivateNoRoutine != null)
         {
-            dummy.Data["playerHasDreamDash"] = false;
+            dummy.Data.Set("playerHasDreamDash", false);
             dummy.OnDeactivateNoRoutine();
             return;
         }

--- a/src/Entities/Misc/RailedMoveBlock.cs
+++ b/src/Entities/Misc/RailedMoveBlock.cs
@@ -126,7 +126,7 @@ internal class RailedMoveBlock : Solid
     public static readonly Color StopBgFill = Calc.HexToColor("cc2541");
     public static readonly Color PlacementErrorBgFill = Calc.HexToColor("cc7c27");
 
-    private readonly DynData<Platform> platformData;
+    private readonly DynamicData platformData;
     private Vector2 start, target, dir;
     private float percent;
     private readonly float length;
@@ -236,7 +236,7 @@ internal class RailedMoveBlock : Solid
         sfx.Play(CustomSFX.game_railedMoveBlock_railedmoveblock_move, "arrow_stop", 1f);
         Add(new LightOcclude(0.5f));
 
-        platformData = new DynData<Platform>(this);
+        platformData = new(typeof(Platform), this);
     }
 
     private void AddImage(MTexture tex, Vector2 position, float rotation, Vector2 scale, List<Image> addTo)

--- a/src/Entities/Misc/ResetStateCrystal.cs
+++ b/src/Entities/Misc/ResetStateCrystal.cs
@@ -6,12 +6,12 @@ namespace Celeste.Mod.CommunalHelper.Entities;
 [CustomEntity("CommunalHelper/ResetStateCrystal")]
 public class ResetStateCrystal : Refill
 {
-    private readonly DynData<Refill> baseData;
+    private readonly DynamicData baseData;
 
     public ResetStateCrystal(EntityData data, Vector2 offset)
         : base(data, offset)
     {
-        baseData = new DynData<Refill>(this);
+        baseData = new(typeof(Refill), this);
 
         Remove(baseData.Get<Sprite>("sprite"));
         Sprite sprite = new(GFX.Game, "objects/CommunalHelper/resetStateCrystal/");
@@ -20,7 +20,7 @@ public class ResetStateCrystal : Refill
         sprite.CenterOrigin();
         sprite.Color = Calc.HexToColor("676767");
         Add(sprite);
-        baseData["sprite"] = sprite;
+        baseData.Set("sprite", sprite);
         Remove(Get<PlayerCollider>());
 
         Add(new PlayerCollider(OnCollide));
@@ -32,7 +32,7 @@ public class ResetStateCrystal : Refill
         Input.Rumble(RumbleStrength.Medium, RumbleLength.Medium);
         Collidable = false;
         Add(new Coroutine(RefillRoutine(player)));
-        baseData["respawnTimer"] = 2.5f;
+        baseData.Set("respawnTimer", 2.5f);
     }
 
     public IEnumerator RefillRoutine(Player player)

--- a/src/Entities/Panels/AbstractPanel.cs
+++ b/src/Entities/Panels/AbstractPanel.cs
@@ -224,7 +224,7 @@ public abstract class AbstractPanel : Entity
 
     private static int Platform_GetLandOrStepSoundIndex(Func<Platform, Entity, int> orig, Platform self, Entity entity)
     {
-        foreach (StaticMover sm in new DynData<Platform>(self).Get<List<StaticMover>>("staticMovers"))
+        foreach (StaticMover sm in DynamicData.For(self).Get<List<StaticMover>>("staticMovers"))
         {
             if (sm.Entity is AbstractPanel panel && panel.surfaceSoundIndex != null && panel.Orientation == Directions.Up && entity.CollideCheck(panel, entity.Position + Vector2.UnitY))
             {
@@ -236,7 +236,7 @@ public abstract class AbstractPanel : Entity
 
     private static int Platform_GetWallSoundIndex(Func<Platform, Player, int, int> orig, Platform self, Player player, int side)
     {
-        foreach (StaticMover sm in new DynData<Platform>(self).Get<List<StaticMover>>("staticMovers"))
+        foreach (StaticMover sm in DynamicData.For(self).Get<List<StaticMover>>("staticMovers"))
         {
             if (sm.Entity is AbstractPanel panel && panel.surfaceSoundIndex != null)
             {
@@ -265,13 +265,13 @@ public abstract class AbstractPanel : Entity
     {
         bool collidable = solid.Collidable;
         solid.Collidable = true;
-        DynData<Solid> solidData = null;
+        DynamicData solidData = null;
         foreach (AbstractPanel panel in scene.Tracker.GetEntities<AbstractPanel>())
         {
             StaticMover staticMover = panel.staticMover;
             if (panel.overrideAllowStaticMovers && staticMover.Platform == null && staticMover.IsRiding(solid))
             {
-                solidData ??= new DynData<Solid>(solid);
+                solidData ??= DynamicData.For(solid);
                 solidData.Get<List<StaticMover>>("staticMovers").Add(staticMover);
                 staticMover.Platform = solid;
                 staticMover.OnAttach?.Invoke(solid);

--- a/src/Entities/Panels/FrictionlessPanel.cs
+++ b/src/Entities/Panels/FrictionlessPanel.cs
@@ -47,7 +47,7 @@ public class FrictionlessPanel : AbstractPanel
             {
                 if (v && actor is Player player && !(player.StateMachine.State == Player.StClimb))
                 {
-                    DynData<Solid> solidData = new(solid);
+                    DynamicData solidData = DynamicData.For(solid);
                     List<StaticMover> staticMovers = solidData.Get<List<StaticMover>>("staticMovers");
                     foreach (StaticMover mover in staticMovers)
                     {
@@ -79,7 +79,7 @@ public class FrictionlessPanel : AbstractPanel
             {
                 if (v && actor is Player player && player.StateMachine.State == Player.StClimb)
                 {
-                    DynData<Solid> solidData = new(solid);
+                    DynamicData solidData = DynamicData.For(solid);
                     List<StaticMover> staticMovers = solidData.Get<List<StaticMover>>("staticMovers");
                     foreach (StaticMover mover in staticMovers)
                     {

--- a/src/Triggers/SoundAreaTrigger.cs
+++ b/src/Triggers/SoundAreaTrigger.cs
@@ -16,7 +16,7 @@ public class SoundAreaTrigger : Trigger
         string path = data.Attr("event");
 
         SoundSource sound = new(sourcePos - Position, path);
-        eventInstance = new DynData<SoundSource>(sound).Get<EventInstance>("instance");
+        eventInstance = DynamicData.For(sound).Get<EventInstance>("instance");
         Add(sound);
     }
 

--- a/src/Utils/Extensions.cs
+++ b/src/Utils/Extensions.cs
@@ -14,14 +14,7 @@ namespace Celeste.Mod.CommunalHelper;
 
 public static class Extensions
 {
-    private static DynData<Player> cachedPlayerData;
-
-    public static DynData<Player> GetData(this Player player)
-    {
-        return cachedPlayerData != null && cachedPlayerData.IsAlive && cachedPlayerData.Target == player
-            ? cachedPlayerData
-            : (cachedPlayerData = new DynData<Player>(player));
-    }
+    public static DynamicData GetData(this Player player) => DynamicData.For(player);
 
     public static void LoseDreamSeeds(this Player player)
     {
@@ -378,7 +371,7 @@ public static class Extensions
 
     public static void ForceAdd(this EntityList list, params Entity[] entities)
     {
-        DynData<EntityList> listData = new(list);
+        DynamicData listData = DynamicData.For(list);
         HashSet<Entity> current = listData.Get<HashSet<Entity>>("current");
         List<Entity> listEntities = listData.Get<List<Entity>>("entities");
         Scene scene = list.Scene;


### PR DESCRIPTION
Replaces every usage of `DynData<T>` with `DynamicData`, and replaces `DynData.this[string]` indexing with `DynamicData.Get` & `DynamicData.Set` calls.