### PR TITLE
Fix weird behavior when julmping out of curved boosters

### DIFF
--- a/src/Entities/Boosters/CurvedBooster.cs
+++ b/src/Entities/Boosters/CurvedBooster.cs
@@ -165,7 +165,9 @@ public class CurvedBooster : CustomBooster
 
         // player's speed won't matter, we won't allow it to move while in a curved booster.
         // this is here so that the player doesn't die to spikes that it shouldn't die to.
-        player.Speed = derivative.SafeNormalize();
+        player.DashDir = player.Speed = derivative.SafeNormalize();
+        if (player.DashDir.X != 0.0f)
+            player.Facing = (Facings) Math.Sign(player.DashDir.X);
 
         bool stopped = false;
         player.MoveToX(next.X, _ => stopped = true);

--- a/src/Entities/Boosters/DreamBoosterCurve.cs
+++ b/src/Entities/Boosters/DreamBoosterCurve.cs
@@ -153,7 +153,9 @@ public class DreamBoosterCurve : DreamBooster
 
         // player's speed won't matter, we won't allow it to move while in a curved booster.
         // this is here so that the player doesn't die to spikes that it shouldn't die to.
-        player.Speed = derivative.SafeNormalize();
+        player.DashDir = player.Speed = derivative.SafeNormalize();
+        if (player.DashDir.X != 0.0f)
+            player.Facing = (Facings) Math.Sign(player.DashDir.X);
 
         player.MoveToX(next.X, (Collision) data["onCollideH"]);
         player.MoveToY(next.Y + offY, (Collision) data["onCollideV"]);


### PR DESCRIPTION
Curved Boosters and Dream Curved Boosters used to give you weird boosts when jumping out of them. This is fixed by manually updating `Player.DashDir` and `Player.Facing` each time the player is moved along the curve (meaning its direction & facing has changed).