### PR TITLE
Clean up DynData uses

### DIFF
--- a/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
+++ b/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
@@ -491,8 +491,8 @@ namespace Celeste.Mod.CommunalHelper.DashStates {
                     player.StateMachine.State = StDreamTunnelDash;
                     solid.Components.GetAll<DreamTunnelInteraction>().ToList().ForEach(i => i.OnPlayerEnter(player));
                     playerData[Player_solid] = solid;
-                    playerData["dashAttackTimer"] = 0;
-                    playerData["gliderBoostTimer"] = 0;
+                    playerData["dashAttackTimer"] = 0f;
+                    playerData["gliderBoostTimer"] = 0f;
                     return true;
                 } else if (solid is DashSwitch) {
                     // Why is this necesarry? Good question!

--- a/src/Entities/BoosterStuff/CurvedBooster.cs
+++ b/src/Entities/BoosterStuff/CurvedBooster.cs
@@ -128,8 +128,6 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         protected override int? RedDashUpdateBefore(Player player) {
             base.RedDashUpdateBefore(player);
 
-            DynData<Player> data = player.GetData();
-
             Vector2 prev = player.Position;
 
             travel += 240f * Engine.DeltaTime; // booster speed constant

--- a/src/Entities/DreamStuff/DreamJellyfish.cs
+++ b/src/Entities/DreamStuff/DreamJellyfish.cs
@@ -102,7 +102,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             if (Input.GrabCheck && player.DashDir.Y <= 0) {
                 // force-allow pickup
                 player.GetData()["minHoldTimer"] = 0f;
-                new DynData<Holdable>(Hold)["cannotHoldTimer"] = 0;
+                new DynData<Holdable>(Hold)["cannotHoldTimer"] = 0f;
 
                 if ((bool) m_Player_Pickup.Invoke(player, new object[] { Hold })) {
                     player.StateMachine.State = Player.StPickup;

--- a/src/Entities/Misc/RailedMoveBlock.cs
+++ b/src/Entities/Misc/RailedMoveBlock.cs
@@ -117,8 +117,7 @@ namespace Celeste.Mod.CommunalHelper.Entities {
         public static readonly Color MoveBgFill = Calc.HexToColor("30b335");
         public static readonly Color StopBgFill = Calc.HexToColor("cc2541");
         public static readonly Color PlacementErrorBgFill = Calc.HexToColor("cc7c27");
-
-        private DynData<Platform> platformData;
+        
         private Vector2 start, target, dir;
         private float percent, length;
 
@@ -217,8 +216,6 @@ namespace Celeste.Mod.CommunalHelper.Entities {
             });
             sfx.Play(CustomSFX.game_railedMoveBlock_railedmoveblock_move, "arrow_stop", 1f);
             Add(new LightOcclude(0.5f));
-
-            platformData = new DynData<Platform>(this);
         }
 
         private void AddImage(MTexture tex, Vector2 position, float rotation, Vector2 scale, List<Image> addTo) {


### PR DESCRIPTION
Make sure all DynData uses have the correct type (prevents MonoMod Crime warnings on core).
Remove unused DynData objects (DynData creation is expensive).