### PR TITLE
Fix Dash State Trigger

### DIFF
--- a/src/DashStates/DashStateTrigger.cs
+++ b/src/DashStates/DashStateTrigger.cs
@@ -15,7 +15,7 @@ namespace Celeste.Mod.CommunalHelper.DashStates {
 
         public DashStates DashState;
 
-        protected DashStateTrigger(EntityData data, Vector2 offset)
+        public DashStateTrigger(EntityData data, Vector2 offset)
             : base(data, offset) {
             Mode = data.Enum("mode", Modes.Trigger);
             DashState = data.Enum("dashState", DashStates.DreamTunnelDash);


### PR DESCRIPTION
Dash State Trigger wasn't loaded because the CustomEntity attribute only looks for public constructors.