### PR TITLE
Clean up DynamicData uses

### DIFF
--- a/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
+++ b/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
@@ -550,13 +550,13 @@ public static class DreamTunnelDash
                 player.StateMachine.State = StDreamTunnelDash;
                 solid.Components.GetAll<DreamTunnelInteraction>().ToList().ForEach(i => i.OnPlayerEnter(player));
                 playerData.Set(Player_solid, solid);
-                playerData.Set("dashAttackTimer", 0);
-                playerData.Set("gliderBoostTimer", 0);
+                playerData.Set("dashAttackTimer", 0f);
+                playerData.Set("gliderBoostTimer", 0f);
                 return true;
             }
             else if (solid is DashSwitch)
             {
-                // Why is this necesarry? Good question!
+                // Why is this necessary? Good question!
                 // I don't know the answer, but for some reason, Celeste registers
                 // dashing into a button upwards as colliding with both the button and the
                 // tile behind it. In order to prevent this from making you dash

--- a/src/Entities/Boosters/CurvedBooster.cs
+++ b/src/Entities/Boosters/CurvedBooster.cs
@@ -150,8 +150,6 @@ public class CurvedBooster : CustomBooster
     {
         base.RedDashUpdateBefore(player);
 
-        DynamicData data = player.GetData();
-
         Vector2 prev = player.Position;
 
         travel += 240f * Engine.DeltaTime; // booster speed constant

--- a/src/Entities/DreamBlocks/DreamJellyfish.cs
+++ b/src/Entities/DreamBlocks/DreamJellyfish.cs
@@ -123,7 +123,7 @@ internal class DreamJellyfish : Glider
         {
             // force-allow pickup
             player.GetData().Set("minHoldTimer", 0f);
-            DynamicData.For(Hold).Set("cannotHoldTimer", 0);
+            DynamicData.For(Hold).Set("cannotHoldTimer", 0f);
 
             if ((bool) m_Player_Pickup.Invoke(player, new object[] { Hold }))
             {

--- a/src/Entities/Misc/RailedMoveBlock.cs
+++ b/src/Entities/Misc/RailedMoveBlock.cs
@@ -1,5 +1,4 @@
-﻿using MonoMod.Utils;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Celeste.Mod.CommunalHelper.Entities;
 
@@ -126,7 +125,6 @@ internal class RailedMoveBlock : Solid
     public static readonly Color StopBgFill = Calc.HexToColor("cc2541");
     public static readonly Color PlacementErrorBgFill = Calc.HexToColor("cc7c27");
 
-    private readonly DynamicData platformData;
     private Vector2 start, target, dir;
     private float percent;
     private readonly float length;
@@ -235,8 +233,6 @@ internal class RailedMoveBlock : Solid
         });
         sfx.Play(CustomSFX.game_railedMoveBlock_railedmoveblock_move, "arrow_stop", 1f);
         Add(new LightOcclude(0.5f));
-
-        platformData = new(typeof(Platform), this);
     }
 
     private void AddImage(MTexture tex, Vector2 position, float rotation, Vector2 scale, List<Image> addTo)


### PR DESCRIPTION
Make sure all DynamicData uses have the correct type (prevents MonoMod Crime warnings on core).
Remove unused DynamicData objects (DynamicData creation is expensive).