### PR TITLE
Keep dash states after room transition

### DIFF
--- a/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
+++ b/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
@@ -29,7 +29,7 @@ public static class DreamTunnelDash
     #endregion
 
     public static int StDreamTunnelDash = -1;
-    private static bool hasDreamTunnelDash;
+    private static bool hasDreamTunnelDash = false;
     public static bool HasDreamTunnelDash
     {
         get => hasDreamTunnelDash || CommunalHelperModule.Settings.AlwaysActiveDreamRefillCharge;
@@ -82,6 +82,8 @@ public static class DreamTunnelDash
             State_DreamDashEqual);
 
         On.Celeste.Level.EnforceBounds += Level_EnforceBounds;
+        On.Celeste.Level.Reload += Level_Reload;
+        On.Celeste.LevelLoader.StartLevel += LevelLoader_StartLevel;
         On.Celeste.Player.OnBoundsH += Player_OnBoundsH;
         On.Celeste.Player.OnBoundsV += Player_OnBoundsV;
 
@@ -110,6 +112,8 @@ public static class DreamTunnelDash
         hook_Player_orig_UpdateSprite.Dispose();
 
         On.Celeste.Level.EnforceBounds -= Level_EnforceBounds;
+        On.Celeste.Level.Reload -= Level_Reload;
+        On.Celeste.LevelLoader.StartLevel -= LevelLoader_StartLevel;
         On.Celeste.Player.OnBoundsH -= Player_OnBoundsH;
         On.Celeste.Player.OnBoundsV -= Player_OnBoundsV;
 
@@ -138,7 +142,7 @@ public static class DreamTunnelDash
     private static void Player_ctor(On.Celeste.Player.orig_ctor orig, Player player, Vector2 position, PlayerSpriteMode spriteMode)
     {
         orig(player, position, spriteMode);
-        HasDreamTunnelDash = dreamTunnelDashAttacking = false;
+        dreamTunnelDashAttacking = false;
 
         if (StDreamTunnelDash != -1)
             Extensions.UnregisterState(StDreamTunnelDash);
@@ -386,6 +390,18 @@ public static class DreamTunnelDash
         orig(self, player);
     }
 
+    private static void Level_Reload(On.Celeste.Level.orig_Reload orig, Level self)
+    {
+        hasDreamTunnelDash = dreamTunnelDashAttacking = false;
+        orig(self);
+    }
+
+    private static void LevelLoader_StartLevel(On.Celeste.LevelLoader.orig_StartLevel orig, LevelLoader self)
+    {
+        hasDreamTunnelDash = dreamTunnelDashAttacking = false;
+        orig(self);
+    }
+
     // Handles cases with locked camera
     private static void Player_OnBoundsH(On.Celeste.Player.orig_OnBoundsH orig, Player self)
     {
@@ -475,7 +491,7 @@ public static class DreamTunnelDash
     private static bool DreamTunnelDashCheck(this Player player, Vector2 dir)
     {
         Vector2 dashdir = player.DashDir;
-        if (player.IsInverted())    
+        if (player.IsInverted())
         {
             dir.Y *= -1;
             dashdir.Y *= -1;

--- a/src/DashStates/SeekerDash/SeekerDash.cs
+++ b/src/DashStates/SeekerDash/SeekerDash.cs
@@ -14,7 +14,7 @@ namespace Celeste.Mod.CommunalHelper.DashStates;
 // Localized glitch/seekerslowdown effect field
 public static class SeekerDash
 {
-    private static bool hasSeekerDash;
+    private static bool hasSeekerDash = false;
     public static bool HasSeekerDash
     {
         get => hasSeekerDash || CommunalHelperModule.Settings.AlwaysActiveSeekerDash;
@@ -66,6 +66,9 @@ public static class SeekerDash
         On.Celeste.Seeker.OnAttackPlayer += Seeker_OnAttackPlayer;
 
         On.Celeste.AngryOshiro.OnPlayer += AngryOshiro_OnPlayer;
+
+        On.Celeste.Level.Reload += Level_Reload;
+        On.Celeste.LevelLoader.StartLevel += LevelLoader_StartLevel;
     }
 
     internal static void Unload()
@@ -101,7 +104,7 @@ public static class SeekerDash
     private static void Player_ctor(On.Celeste.Player.orig_ctor orig, Player self, Vector2 position, PlayerSpriteMode spriteMode)
     {
         orig(self, position, spriteMode);
-        HasSeekerDash = seekerDashAttacking = seekerDashLaunched = launchPossible = false;
+        seekerDashAttacking = seekerDashLaunched = launchPossible = false;
     }
 
     private static void IL_Player_ctor(ILContext il)
@@ -432,6 +435,18 @@ public static class SeekerDash
         }
 
         orig(self, player);
+    }
+
+    private static void Level_Reload(On.Celeste.Level.orig_Reload orig, Level self)
+    {
+        hasSeekerDash = seekerDashAttacking = seekerDashLaunched = launchPossible = false;
+        orig(self);
+    }
+
+    private static void LevelLoader_StartLevel(On.Celeste.LevelLoader.orig_StartLevel orig, LevelLoader self)
+    {
+        hasSeekerDash = seekerDashAttacking = seekerDashLaunched = launchPossible = false;
+        orig(self);
     }
 
     #endregion


### PR DESCRIPTION
Currently if `level.LoadLevel` is called without `IntroTypes.Transition` as an input a new `Player` is created and the dash state of the player get cleared, this PR preserves the dash state in cutscenes and teleports ( [CherryHelper door](https://github.com/aridai-shi/CherryHelper/blob/d9734704de6308652b7548543416d4a4e4680235/Code/Entities/DoorField.cs#L100C27-L100C36) for example ), but still clears it if either `Level.Reload` or `LevelLoader.StartLevel` are called.

This was requested on [Discord](https://discord.com/channels/835962669453410354/1129874633471033494/1153085904496369704).