### PR TITLE
Add null check in TransitionListener of CassetteBlockManager

### DIFF
--- a/src/Entities/CassetteBlocks/ManualCassetteController.cs
+++ b/src/Entities/CassetteBlocks/ManualCassetteController.cs
@@ -2,6 +2,7 @@
 using MonoMod.Cil;
 using MonoMod.RuntimeDetour;
 using System.Linq;
+using System.Reflection;
 
 namespace Celeste.Mod.CommunalHelper.Entities;
 
@@ -77,15 +78,19 @@ public class ManualCassetteController : AbstractInputController
     }
 
     private static IDetour hook_Level_orig_LoadLevel;
+    private static IDetour hook_TransitionListener_OnOutBegin_Closure;
+
     internal static new void Load()
     {
-        IL.Celeste.CassetteBlockManager.ctor += CassetteBlockManager_ctor;
+        MethodInfo m_TransitionListener_Closure = typeof(CassetteBlockManager).GetMethod("<.ctor>b__10_0", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        hook_TransitionListener_OnOutBegin_Closure = new ILHook(m_TransitionListener_Closure, TransitionListener_OnOutBegin_Closure);
         hook_Level_orig_LoadLevel = new ILHook(typeof(Level).GetMethod("orig_LoadLevel"), Level_orig_LoadLevel);
     }
 
     internal static new void Unload()
     {
-        IL.Celeste.CassetteBlockManager.ctor -= CassetteBlockManager_ctor;
+        hook_TransitionListener_OnOutBegin_Closure.Dispose();
         hook_Level_orig_LoadLevel.Dispose();
     }
 
@@ -117,26 +122,20 @@ public class ManualCassetteController : AbstractInputController
         });
     }
 
-    private static void CassetteBlockManager_ctor(ILContext il)
+    private static void TransitionListener_OnOutBegin_Closure(ILContext il)
     {
-        // we need to ensure that the TransitionListener.OnOutBegin checks that Scene isn't null before doing anything
-        // so we will replace the Action in TransitionListener.OnOutBegin with our Action
-
+        // we need to add a null check over Scene before doing anything
         ILCursor cursor = new(il);
 
-        cursor.GotoNext(MoveType.Before, instr => instr.MatchStfld("Celeste.TransitionListener", "OnOutBegin"));
+        var m_getScene = typeof(Entity).GetProperty("Scene").GetGetMethod(true);
+
+        ILLabel afterReturnLabel = cursor.DefineLabel();
 
         cursor.Emit(OpCodes.Ldarg_0);
+        cursor.Emit(OpCodes.Callvirt, m_getScene);
+        cursor.Emit(OpCodes.Brtrue, afterReturnLabel);
+        cursor.Emit(OpCodes.Ret);
 
-        cursor.EmitDelegate((Action originalOnOutBeginAction, CassetteBlockManager cassetteBlockManager) =>
-        {
-            return () =>
-            {
-                if (cassetteBlockManager.Scene != null)
-                {
-                    originalOnOutBeginAction();
-                }
-            };
-        });
+        cursor.MarkLabel(afterReturnLabel);
     }
 }


### PR DESCRIPTION
This fixes #130 by adding a null check over `Scene` in the `TransitionListener.OnOutBegin` clouser because we already call `CassetteBlockManager.RemoveSelf` which sets `Scene` to null.