### PR TITLE
Fix vertical inputs affecting speed during stable angle frames

### DIFF
--- a/src/States/Elytra.cs
+++ b/src/States/Elytra.cs
@@ -202,23 +202,26 @@ public static class Elytra
 
         // determine new speed :
         newSpeed = oldSpeed;
-        if (newAngle < STABLE_ANGLE)
+        if (stableTimer <= 0f)
         {
-            // going above middle angle, slow down.
-            // if the player goes at a higher speed than the maximum speed, decelerate faster.
-            float decel = oldSpeed > MAX_SPEED
-                ? FAST_DECEL
-                : DECEL;
-            newSpeed = Calc.Approach(oldSpeed, MIN_SPEED, Engine.DeltaTime * decel * absYInput);
-        }
-        else if (newAngle > STABLE_ANGLE)
-        {
-            // speed up, relative to how vertical the player's input is.
+            if (newAngle < STABLE_ANGLE)
+            {
+                // going above middle angle, slow down.
+                // if the player goes at a higher speed than the maximum speed, decelerate faster.
+                float decel = oldSpeed > MAX_SPEED
+                    ? FAST_DECEL
+                    : DECEL;
+                newSpeed = Calc.Approach(oldSpeed, MIN_SPEED, Engine.DeltaTime * decel * absYInput);
+            }
+            else if (newAngle > STABLE_ANGLE)
+            {
+                // speed up, relative to how vertical the player's input is.
 
-            // if the speed is already greater than the max diving speed, then don't change it.
-            // in that case, it's only going to decrease if the player decides to glide up.
-            if (oldSpeed < MAX_SPEED)
-                newSpeed = Calc.Approach(oldSpeed, MAX_SPEED, Engine.DeltaTime * ACCEL * absYInput);
+                // if the speed is already greater than the max diving speed, then don't change it.
+                // in that case, it's only going to decrease if the player decides to glide up.
+                if (oldSpeed < MAX_SPEED)
+                    newSpeed = Calc.Approach(oldSpeed, MAX_SPEED, Engine.DeltaTime * ACCEL * absYInput);
+            }
         }
 
         // update new values.


### PR DESCRIPTION
closes #155.

during stable angle frames, vertical inputs don't affect the angle you move at, and applying speed penatlies or boosts for changing your angle can lead to unexpected behaviour, like losing most of your speed from an upwards speed ring by holding up.

with the fix, holding up can appear to give you more height out of a speed ring than holding neutral, but the same height can be obtained pre-fix by holding up immediately after stable frames end, so this doesn't enable any new movement.

(the diff github displays is kind of weird, the only change is wrapping the `if (newAngle < STABLE_ANGLE) ... else ...` in `if (stableTimer <= 0f) { ... }`.)