### PR TITLE
Add alpha to Cloudscapes

### DIFF
--- a/Loenn/effects/cloudscape.lua
+++ b/Loenn/effects/cloudscape.lua
@@ -48,13 +48,17 @@ cloudscape.fieldInformation = {
     rotationExponent = {
         minimumValue = 0.0,
         maximumValue = 2.0
+    },
+    alpha = {
+        minimumValue = 0.0,
+        maximumValue = 1.0
     }
 }
 
 cloudscape.defaultData = {
     seed = "",
-    colors = "6d8ada,aea0c1,d9cbbc",
-    bgColor = "4f9af7",
+    colors = "6d8adaff,aea0c1ff,d9cbbcff",
+    bgColor = "4f9af7ff",
     innerRadius = 40.0,
     outerRadius = 400.0,
     rings = 24,
@@ -77,6 +81,7 @@ cloudscape.defaultData = {
     rotationExponent = 2.0,
     hasBackgroundColor = true,
     additive = false,
+    alpha = 1.0,
 }
 
 return cloudscape

--- a/src/Backdrops/Cloudscape/Cloudscape.cs
+++ b/src/Backdrops/Cloudscape/Cloudscape.cs
@@ -61,6 +61,7 @@ public class Cloudscape : Backdrop
 
         public bool HasBackgroundColor { get; } = true;
         public bool Additive { get; } = false;
+        public float BufferAlpha { get; } = 1.0f;
 
         public Options() { }
 
@@ -70,9 +71,9 @@ public class Cloudscape : Backdrop
 
             Colors = child.Attr("colors", "6d8ada,aea0c1,d9cbbc")
                           .Split(',')
-                          .Select(str => Calc.HexToColor(str.Trim()))
+                          .Select(str => Util.HexToColorWithAlphaNonPremultiplied(str.Trim()))
                           .ToArray();
-            Sky = Calc.HexToColor(child.Attr("bgColor", "4f9af7").Trim());
+            Sky = Util.HexToColorWithAlphaNonPremultiplied(child.Attr("bgColor", "4f9af7").Trim());
 
             InnerRadius = MathHelper.Max(child.AttrFloat("innerRadius", 40f), 10);
             OuterRadius = child.AttrFloat("outerRadius", 400f);
@@ -102,6 +103,7 @@ public class Cloudscape : Backdrop
 
             HasBackgroundColor = child.AttrBool("hasBackgroundColor", true);
             Additive = child.AttrBool("additive", false);
+            BufferAlpha = child.AttrFloat("alpha", 1f);
         }
     }
 
@@ -209,6 +211,7 @@ public class Cloudscape : Backdrop
     private readonly Ring[] rings;
 
     private readonly Color[] colors;
+    private readonly float BufferAlpha;
 
     public Cloudscape(BinaryPacker.Element child)
         : this(new Options(child)) { }
@@ -241,6 +244,8 @@ public class Cloudscape : Backdrop
         innerRotation = options.InnerRotation;
         outerRotation = options.OuterRotation;
         rotationExponent = options.RotationExponent;
+
+        BufferAlpha = options.BufferAlpha;
 
         Calc.PushRandom(options.Seed);
 
@@ -441,7 +446,7 @@ public class Cloudscape : Backdrop
 
         BackdropRenderer renderer = (scene as Level).Background;
         renderer.StartSpritebatch(blend);
-        Draw.SpriteBatch.Draw(buffer, Vector2.Zero, Color.White);
+        Draw.SpriteBatch.Draw(buffer, Vector2.Zero, Color.White * BufferAlpha);
         renderer.EndSpritebatch();
     }
 

--- a/src/Backdrops/Cloudscape/Cloudscape.cs
+++ b/src/Backdrops/Cloudscape/Cloudscape.cs
@@ -23,11 +23,11 @@ public class Cloudscape : Backdrop
 
         public Color[] Colors { get; } = new[]
         {
-            Calc.HexToColor("6d8ada"),
-            Calc.HexToColor("aea0c1"),
-            Calc.HexToColor("d9cbbc"),
+            Util.HexToColorWithAlphaNonPremultiplied("6d8adaff"),
+            Util.HexToColorWithAlphaNonPremultiplied("aea0c1ff"),
+            Util.HexToColorWithAlphaNonPremultiplied("d9cbbcff"),
         };
-        public Color Sky { get; } = Calc.HexToColor("4f9af7");
+        public Color Sky { get; } = Util.HexToColorWithAlphaNonPremultiplied("4f9af7ff");
 
         public float InnerRadius { get; } = 40.0f;
         public float OuterRadius { get; } = 400.0f;
@@ -69,11 +69,11 @@ public class Cloudscape : Backdrop
         {
             Seed = child.Attr("seed").GetHashCode();
 
-            Colors = child.Attr("colors", "6d8ada,aea0c1,d9cbbc")
+            Colors = child.Attr("colors", "6d8adaff,aea0c1ff,d9cbbcff")
                           .Split(',')
                           .Select(str => Util.HexToColorWithAlphaNonPremultiplied(str.Trim()))
                           .ToArray();
-            Sky = Util.HexToColorWithAlphaNonPremultiplied(child.Attr("bgColor", "4f9af7").Trim());
+            Sky = Util.HexToColorWithAlphaNonPremultiplied(child.Attr("bgColor", "4f9af7ff").Trim());
 
             InnerRadius = MathHelper.Max(child.AttrFloat("innerRadius", 40f), 10);
             OuterRadius = child.AttrFloat("outerRadius", 400f);

--- a/src/Utils/Util.cs
+++ b/src/Utils/Util.cs
@@ -57,6 +57,36 @@ public static class Util
         return CopyColor(Calc.HexToColor(str.Trim('#')), alpha);
     }
 
+    public static Color HexToColorWithAlphaNonPremultiplied(string hex)
+    {
+        int num = 0;
+        if (hex.Length >= 1 && hex[0] == '#')
+        {
+            num = 1;
+        }
+
+        switch (hex.Length - num)
+        {
+            case 6:
+            {
+                int r2 = Calc.HexToByte(hex[num++]) * 16 + Calc.HexToByte(hex[num++]);
+                int g = Calc.HexToByte(hex[num++]) * 16 + Calc.HexToByte(hex[num++]);
+                int b = Calc.HexToByte(hex[num++]) * 16 + Calc.HexToByte(hex[num++]);
+                return new Color(r2, g, b);
+            }
+            case 8:
+            {
+                int r = Calc.HexToByte(hex[num++]) * 16 + Calc.HexToByte(hex[num++]);
+                int g = Calc.HexToByte(hex[num++]) * 16 + Calc.HexToByte(hex[num++]);
+                int b = Calc.HexToByte(hex[num++]) * 16 + Calc.HexToByte(hex[num++]);
+                int alpha = Calc.HexToByte(hex[num++]) * 16 + Calc.HexToByte(hex[num++]);
+                return new Color(r, g, b) * (alpha / 255f); //don't set alpha, multiply the color, i really still don't understand this... :3c
+            }
+            default:
+                return Color.White;
+        }
+    }
+
     public static int ToInt(bool b)
     {
         return b ? 1 : 0;


### PR DESCRIPTION
`colors` and `bgColor` now have RGBA format support, which allows for separate cloud ring and background alpha control;
New `alpha` param controls the alpha of the Cloudscape's `VirtualRenderTarget`;
Implemented for Issue #162 