### PR TITLE
Fix crush block redirectable

### DIFF
--- a/src/Components/Redirectable/MoveBlockRedirectable.cs
+++ b/src/Components/Redirectable/MoveBlockRedirectable.cs
@@ -26,9 +26,12 @@ public class MoveBlockRedirectable : Redirectable
     private Directions initialDirection;
     private Action<Coroutine> onResumeAction;
     private Action<Coroutine> onBreakAction;
-    public MoveBlockRedirectable(DynamicData Data) : base(Data)
+
+    public MoveBlockRedirectable(DynamicData Data, Func<bool> canSteer = null, Func<Directions> get_Direction = null, Action<Directions> set_Direction = null) : base(Data)
     {
-        IsRedirectable = !(Get_CanSteer?.Invoke() ?? Data.Get<bool>("canSteer"));
+        IsRedirectable = !(canSteer?.Invoke() ?? Data.Get<bool>("canSteer"));
+        Get_Direction = get_Direction;
+        Set_Direction = set_Direction;
         initialAngle = Angle;
         initialDirection = Direction;
         onResumeAction = GetControllerDelegate(Data, 3);
@@ -90,8 +93,6 @@ public class MoveBlockRedirectable : Redirectable
             Data.Set("targetAngle", value);
         }
     }
-
-    public Func<bool>? Get_CanSteer = null;
 
     public Func<SoundSource>? Get_MoveSfx = null;
     public SoundSource MoveSfx => Get_MoveSfx?.Invoke() ?? Data.Get<SoundSource>("moveSfx");

--- a/src/Components/Redirectable/MoveBlockRedirectable.cs
+++ b/src/Components/Redirectable/MoveBlockRedirectable.cs
@@ -24,8 +24,6 @@ public class MoveBlockRedirectable : Redirectable
 
     private float initialAngle;
     private Directions initialDirection;
-    private Action<Coroutine> onResumeAction;
-    private Action<Coroutine> onBreakAction;
 
     public MoveBlockRedirectable(DynamicData Data, Func<bool> canSteer = null, Func<Directions> get_Direction = null, Action<Directions> set_Direction = null) : base(Data)
     {
@@ -34,10 +32,12 @@ public class MoveBlockRedirectable : Redirectable
         Set_Direction = set_Direction;
         initialAngle = Angle;
         initialDirection = Direction;
-        onResumeAction = GetControllerDelegate(Data, 3);
-        onBreakAction = GetControllerDelegate(Data, 4);
+        OnResumeAction = GetControllerDelegate(Data, 3);
+        OnBreakAction = GetControllerDelegate(Data, 4);
     }
 
+    public Action<Coroutine> OnResumeAction;
+    public Action<Coroutine> OnBreakAction;
     public Func<float>? Get_Speed = null;
     public Action<float>? Set_Speed = null;
 
@@ -137,12 +137,12 @@ public class MoveBlockRedirectable : Redirectable
 
     public override void OnResume(Coroutine moveCoroutine)
     {
-        onResumeAction(moveCoroutine);
+        OnResumeAction(moveCoroutine);
     }
 
     public override void OnBreak(Coroutine moveCoroutine)
     {
-        onBreakAction(moveCoroutine);
+        OnBreakAction(moveCoroutine);
     }
 
     public override void BeforeBreakAnimation()

--- a/src/Entities/CassetteBlocks/CassetteMoveBlock.cs
+++ b/src/Entities/CassetteBlocks/CassetteMoveBlock.cs
@@ -77,18 +77,14 @@ public class CassetteMoveBlock : CustomCassetteBlock
         P_Break = new ParticleType(MoveBlock.P_Break) { Color = color };
         P_BreakPressed = new ParticleType(MoveBlock.P_Break) { Color = pressedColor };
 
-        Add(new MoveBlockRedirectable(new MonoMod.Utils.DynamicData(this))
-        {
-            Get_CanSteer = () => false,
-            Get_Direction = () => Direction,
-            Set_Direction = dir =>
+        Add(new MoveBlockRedirectable(new MonoMod.Utils.DynamicData(this), () => false, () => Direction, dir =>
             {
                 int index = (int) Math.Floor(((0f - angle + ((float) Math.PI * 2f)) % ((float) Math.PI * 2f) / ((float) Math.PI * 2f) * 8f) + 0.5f);
                 arrow.Texture = GFX.Game.GetAtlasSubtextures("objects/CommunalHelper/cassetteMoveBlock/arrow")[index];
                 arrowPressed.Texture = GFX.Game.GetAtlasSubtextures("objects/CommunalHelper/cassetteMoveBlock/arrowPressed")[index];
                 Direction = dir;
             }
-        });
+        ));
     }
 
     public CassetteMoveBlock(EntityData data, Vector2 offset, EntityID id)

--- a/src/Entities/ConnectedBlocks/ConnectedMoveBlock.cs
+++ b/src/Entities/ConnectedBlocks/ConnectedMoveBlock.cs
@@ -289,7 +289,6 @@ public class ConnectedMoveBlock : ConnectedSolid
             else
                 State = MovementState.Breaking;
             yield return 0.2f;
-
             targetSpeed = moveSpeed;
             moveSfx.Play(SFX.game_04_arrowblock_move_loop);
             moveSfx.Param("arrow_stop", 0f);
@@ -744,7 +743,24 @@ public class ConnectedMoveBlock : ConnectedSolid
         // Allow this block to be redirected by MoveBlockRedirects if it has a single rectangular collider.
         if (Colliders.Length == 1)
         {
-            Add(new MoveBlockRedirectable(new DynamicData(this), () => false, () => Direction, dir => Direction = dir));
+            DynamicData dynamicData = new(this);
+            Add(new MoveBlockRedirectable(dynamicData, () => false, () => Direction, dir => Direction = dir)
+            {
+                Get_Speed = () => speed,
+                Set_Speed = (speed) => this.speed = speed,
+                Get_TargetSpeed = () => targetSpeed,
+                Set_TargetSpeed = (targetSpeed) => this.targetSpeed = targetSpeed,
+                Get_MoveSfx = () => moveSfx,
+                OnBreakAction = (coroutine) =>
+                {
+                    State = MovementState.Breaking;
+                    MoveBlockRedirectable.GetControllerDelegate(dynamicData, 5)(coroutine);
+                },
+                OnResumeAction = (coroutine) =>
+                {
+                    MoveBlockRedirectable.GetControllerDelegate(dynamicData, 4)(coroutine);
+                },
+            });
         }
     }
 

--- a/src/Entities/ConnectedBlocks/ConnectedMoveBlock.cs
+++ b/src/Entities/ConnectedBlocks/ConnectedMoveBlock.cs
@@ -744,12 +744,7 @@ public class ConnectedMoveBlock : ConnectedSolid
         // Allow this block to be redirected by MoveBlockRedirects if it has a single rectangular collider.
         if (Colliders.Length == 1)
         {
-            Add(new MoveBlockRedirectable(new DynamicData(this))
-            {
-                Get_CanSteer = () => false,
-                Get_Direction = () => Direction,
-                Set_Direction = dir => Direction = dir,
-            });
+            Add(new MoveBlockRedirectable(new DynamicData(this), () => false, () => Direction, dir => Direction = dir));
         }
     }
 

--- a/src/Entities/DreamBlocks/DreamMoveBlock.cs
+++ b/src/Entities/DreamBlocks/DreamMoveBlock.cs
@@ -108,12 +108,7 @@ public class DreamMoveBlock : CustomDreamBlock
         Add(controller = new Coroutine(Controller()));
         Add(new LightOcclude(0.5f));
 
-        Add(new MoveBlockRedirectable(new MonoMod.Utils.DynamicData(this))
-        {
-            Get_CanSteer = () => false,
-            Get_Direction = () => Direction,
-            Set_Direction = dir => Direction = dir
-        });
+        Add(new MoveBlockRedirectable(new MonoMod.Utils.DynamicData(this), () => false, () => Direction, dir => Direction = dir));
     }
 
     private IEnumerator Controller()

--- a/src/Entities/Misc/MoveSwapBlock.cs
+++ b/src/Entities/Misc/MoveSwapBlock.cs
@@ -198,11 +198,13 @@ public class MoveSwapBlock : SwapBlock
         Add(moveBlockSfx = new SoundSource());
         Add(new Coroutine(Controller()));
 
-        DynamicData dynamicData = new DynamicData(this);
+        DynamicData dynamicData = new(this);
         Add(new MoveBlockRedirectable(dynamicData, () => false, () => MoveDirection, dir => MoveDirection = dir)
         {
             Get_Speed = () => moveSpeed,
+            Set_Speed = (speed) => moveSpeed = speed,
             Get_TargetSpeed = () => targetMoveSpeed,
+            Set_TargetSpeed = (targetSpeed) => targetMoveSpeed = targetSpeed,
             Get_MoveSfx = () => moveBlockSfx,
             OnBreakAction = (coroutine) =>
             {

--- a/src/Entities/Misc/MoveSwapBlock.cs
+++ b/src/Entities/Misc/MoveSwapBlock.cs
@@ -198,13 +198,11 @@ public class MoveSwapBlock : SwapBlock
         Add(moveBlockSfx = new SoundSource());
         Add(new Coroutine(Controller()));
 
-        Add(new MoveBlockRedirectable(new DynamicData(this))
+        Add(new MoveBlockRedirectable(new DynamicData(this), () => false, () => MoveDirection, dir => MoveDirection = dir)
         {
             Get_Speed = () => moveSpeed,
             Get_TargetSpeed = () => targetMoveSpeed,
             Get_MoveSfx = () => moveBlockSfx,
-            Get_Direction = () => MoveDirection,
-            Set_Direction = dir => MoveDirection = dir,
         });
     }
 

--- a/src/Entities/Misc/MoveSwapBlock.cs
+++ b/src/Entities/Misc/MoveSwapBlock.cs
@@ -198,11 +198,17 @@ public class MoveSwapBlock : SwapBlock
         Add(moveBlockSfx = new SoundSource());
         Add(new Coroutine(Controller()));
 
-        Add(new MoveBlockRedirectable(new DynamicData(this), () => false, () => MoveDirection, dir => MoveDirection = dir)
+        DynamicData dynamicData = new DynamicData(this);
+        Add(new MoveBlockRedirectable(dynamicData, () => false, () => MoveDirection, dir => MoveDirection = dir)
         {
             Get_Speed = () => moveSpeed,
             Get_TargetSpeed = () => targetMoveSpeed,
             Get_MoveSfx = () => moveBlockSfx,
+            OnBreakAction = (coroutine) =>
+            {
+                State = MovementState.Breaking;
+                MoveBlockRedirectable.GetControllerDelegate(dynamicData, 4)(coroutine);
+            },
         });
     }
 
@@ -456,6 +462,7 @@ public class MoveSwapBlock : SwapBlock
             Audio.Play(SFX.game_04_arrowblock_break, Position);
             moveBlockSfx.Stop();
             State = MovementState.Breaking;
+
             moveSpeed = targetMoveSpeed = 0f;
             angle = targetAngle = homeAngle;
 


### PR DESCRIPTION
This PR  contains 3 bug fixes:
1. a`MoveBlockRedirctable` constructor was using a null value
2. `MoveSwapBlock` was activating while broken from a `MoveBlockRedirect`
3. `connectedMoveBlock` not breaking on `MoveBlockRedirect`

It seems that `MoveSwapBlock` is still buggy with `MoveBlockRedirect`. If `MoveBlockRedirect` is set to slow redirect and the `MoveBlockRedirect` direction is perpendicular to the `MoveSwapBlock` direction, the game could crash. 