### PR TITLE
additional elytra mode options

### DIFF
--- a/src/CommunalHelperSettings.cs
+++ b/src/CommunalHelperSettings.cs
@@ -10,6 +10,7 @@ public class CommunalHelperSettings : EverestModuleSettings
         Hold = 1,
         Invert = 2,
         Toggle = 3,
+        ToggleOnce = 4,
     }
     // If saving settings, always return true;
     private bool SaveOverride(bool val)

--- a/src/States/Elytra.cs
+++ b/src/States/Elytra.cs
@@ -341,9 +341,8 @@ public static class Elytra
         On.Celeste.Player.UseRefill += Player_UseRefill;
         On.Celeste.Player.ctor += Player_ctor;
         On.Celeste.Input.UpdateGrab += Input_UpdateGrab;
+        On.Celeste.Input.ResetGrab += Input_ResetGrab;
     }
-
-    
 
     internal static void Unload()
     {
@@ -357,6 +356,7 @@ public static class Elytra
         On.Celeste.Player.UseRefill -= Player_UseRefill;
         On.Celeste.Player.ctor -= Player_ctor;
         On.Celeste.Input.UpdateGrab -= Input_UpdateGrab;
+        On.Celeste.Input.ResetGrab -= Input_ResetGrab;
     }
 
     private static void Player_ctor(On.Celeste.Player.orig_ctor orig, Player self, Vector2 position, PlayerSpriteMode spriteMode)
@@ -492,5 +492,11 @@ public static class Elytra
         {
             elytraToggle = !elytraToggle;
         }
+    }
+
+    private static void Input_ResetGrab(On.Celeste.Input.orig_ResetGrab orig)
+    {
+        orig();
+        elytraToggle = false;
     }
 }

--- a/src/States/Elytra.cs
+++ b/src/States/Elytra.cs
@@ -40,6 +40,7 @@ public static class Elytra
     {
         CommunalHelperSettings.ElytraModes.Invert => !CommunalHelperModule.Settings.DeployElytra.Check,
         CommunalHelperSettings.ElytraModes.Toggle => elytraToggle,
+        CommunalHelperSettings.ElytraModes.ToggleOnce => elytraToggle,
         CommunalHelperSettings.ElytraModes.Hold => CommunalHelperModule.Settings.DeployElytra.Check,
         _ => Settings.Instance.GrabMode switch
         {
@@ -128,6 +129,8 @@ public static class Elytra
             Audio.Stop(sfx);
         data.Set(f_Player_elytraRefillSound, true);
         data.Set(f_Player_elytraCooldown, COOLDOWN);
+        if (CommunalHelperModule.Settings.ElytraMode == CommunalHelperSettings.ElytraModes.ToggleOnce)
+            elytraToggle = false;
     }
 
     public static int GlideUpdate(this Player player)
@@ -487,6 +490,7 @@ public static class Elytra
     {
         orig();
         if ((CommunalHelperModule.Settings.ElytraMode == CommunalHelperSettings.ElytraModes.Toggle ||
+             CommunalHelperModule.Settings.ElytraMode == CommunalHelperSettings.ElytraModes.ToggleOnce ||
              (CommunalHelperModule.Settings.ElytraMode == CommunalHelperSettings.ElytraModes.UseGrabMode && Settings.Instance.GrabMode == GrabModes.Toggle))
              && CommunalHelperModule.Settings.DeployElytra.Pressed)
         {


### PR DESCRIPTION
- made Toggle mode reset on death (same behavior as vanilla grab Toggle mode)
- added Toggle Once option, which is the same as Toggle but resets once the elytra glide ends (functionally meaning an elytra input will activate a single elytra dash, rather than repeatedly activating elytra dashes until it gets disabled manually by another input)