### PR TITLE
fix dream jellyfish throwable persistence

### DIFF
--- a/src/Entities/DreamBlocks/DreamJellyfish.cs
+++ b/src/Entities/DreamBlocks/DreamJellyfish.cs
@@ -119,7 +119,7 @@ internal class DreamJellyfish : Glider
     public void OnDreamDashExit(Player player)
     {
         DisableDreamDash();
-        if (Input.GrabCheck && player.DashDir.Y <= 0)
+        if (Input.GrabCheck && player.DashDir.Y <= 0 && player.Holding == null)
         {
             // force-allow pickup
             player.GetData().Set("minHoldTimer", 0f);


### PR DESCRIPTION
If the player tries to smuggle an `Holdable` entity though the dream jellyfish it will cause the original held item to think its still held by the player even though we are holding the dream jelly, this is caused by the fact that we call  `player.Pickup` even if the player is already holding `Holdable`.
This is fixed by adding a check to ensure the player isn't holding anything before calling  `player.Pickup`.
[Reported here](https://discord.com/channels/835962669453410354/1178726490720964720/1178726490720964720)