### PR TITLE
Railed Move Blocks - Attached Above, and Eased Vertical Movement additions

### DIFF
--- a/Loenn/entities/misc/railed_move_block.lua
+++ b/Loenn/entities/misc/railed_move_block.lua
@@ -35,10 +35,13 @@ for i, steeringMode in ipairs(steeringModes) do
             width = 16,
             height = 16,
             steeringMode = steeringMode,
-            speed = 120.0
+            speed = 120.0,
+			easedVerticalMovement = false,
+			attachedAbove = false
         }
     }
 end
+
 
 local ninePatchOptions = {
     mode = "border",

--- a/Loenn/entities/misc/railed_move_block.lua
+++ b/Loenn/entities/misc/railed_move_block.lua
@@ -36,8 +36,8 @@ for i, steeringMode in ipairs(steeringModes) do
             height = 16,
             steeringMode = steeringMode,
             speed = 120.0,
-			easedVerticalMovement = false,
-			attachedAbove = false
+	    easedVerticalMovement = false,
+	    attachedAbove = false
         }
     }
 end

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -567,7 +567,7 @@ entities.CommunalHelper/RailedMoveBlock.placements.name.both=Railed Move Block (
 entities.CommunalHelper/RailedMoveBlock.attributes.description.steeringMode=Represents the way in which you can steer the block using the side buttons.\n\n- "Horizontal" will enable buttons on the left and right side of the block.\n- "Vertical" will enable one button at the top of the block.\n- "Both" will enable the two above.
 entities.CommunalHelper/RailedMoveBlock.attributes.description.speed=The maximum speed this block can go at.
 entities.CommunalHelper/RailedMoveBlock.attributes.description.easedVerticalMovement=If checked, diagonal inputs will more easily move the Railed Move Block vertically. This is used to make some moves easier on analog.
-entities.CommunalHelper/RailedMoveBlock.attributes.description.attachedAbove=If checked, attached entities will be rendered above the steering buttons. (Springs,spikes etc.) 
+entities.CommunalHelper/RailedMoveBlock.attributes.description.attachedAbove=If checked, attached entities will be rendered above the steering buttons. (Springs, spikes, etc.) 
 
 # Reset State Crystal
 entities.CommunalHelper/ResetStateCrystal.placements.name.reset_state_crystal=Reset State Crystal

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -566,6 +566,8 @@ entities.CommunalHelper/RailedMoveBlock.placements.name.vertical=Railed Move Blo
 entities.CommunalHelper/RailedMoveBlock.placements.name.both=Railed Move Block (Both)
 entities.CommunalHelper/RailedMoveBlock.attributes.description.steeringMode=Represents the way in which you can steer the block using the side buttons.\n\n- "Horizontal" will enable buttons on the left and right side of the block.\n- "Vertical" will enable one button at the top of the block.\n- "Both" will enable the two above.
 entities.CommunalHelper/RailedMoveBlock.attributes.description.speed=The maximum speed this block can go at.
+entities.CommunalHelper/RailedMoveBlock.attributes.description.easedVerticalMovement=If checked, diagonal inputs will more easily move the Railed Move Block vertically. This is used to make some moves easier on analog.
+entities.CommunalHelper/RailedMoveBlock.attributes.description.attachedAbove=If checked, attached entities will be rendered above the steering buttons. (Springs,spikes etc.) 
 
 # Reset State Crystal
 entities.CommunalHelper/ResetStateCrystal.placements.name.reset_state_crystal=Reset State Crystal

--- a/src/Entities/Misc/RailedMoveBlock.cs
+++ b/src/Entities/Misc/RailedMoveBlock.cs
@@ -238,7 +238,6 @@ internal class RailedMoveBlock : Solid
         });
         sfx.Play(CustomSFX.game_railedMoveBlock_railedmoveblock_move, "arrow_stop", 1f);
         Add(new LightOcclude(0.5f));
-
     }
 
     private void AddImage(MTexture tex, Vector2 position, float rotation, Vector2 scale, List<Image> addTo)
@@ -260,7 +259,6 @@ internal class RailedMoveBlock : Solid
 
         scene.Add(border = new Border(this));
         scene.Add(pathRenderer = new RailedMoveBlockPathRenderer(this));
-
 
         if (attachedAbove)
         {
@@ -323,7 +321,6 @@ internal class RailedMoveBlock : Solid
 
         if (dir != Vector2.Zero)
         {
-
             float newSpeed = 0f;
 
             icon = idleIcon;
@@ -350,8 +347,6 @@ internal class RailedMoveBlock : Solid
                 newFillColor = MoveBgFill;
                 icon = Input.MoveX.Value == 1 ? RightIcon : LeftIcon;
             }
-
-        
 
             if (Math.Sign(speed) != Math.Sign(newSpeed))
             {

--- a/src/Entities/Misc/RailedMoveBlock.cs
+++ b/src/Entities/Misc/RailedMoveBlock.cs
@@ -264,9 +264,9 @@ internal class RailedMoveBlock : Solid
 
         if (attachedAbove)
         {
-            foreach (StaticMover staticMover in this.staticMovers)
+            foreach (StaticMover staticMover in staticMovers)
             {
-                staticMover.Entity.Depth = this.Depth - 1;
+                staticMover.Entity.Depth = Depth - 1;
             }
         }
     }
@@ -327,33 +327,31 @@ internal class RailedMoveBlock : Solid
             float newSpeed = 0f;
 
             icon = idleIcon;
-            if (easedVerticalMovement)
+
+            if ((topPressed || bottomPressed) && HasPlayerRider())
             {
-                if ((topPressed || bottomPressed) && HasPlayerRider() && (Input.Feather.Value.Y > 0.4f || Input.Feather.Value.Y < -0.4f))
+                if (easedVerticalMovement && (Input.Feather.Value.Y > 0.4f || Input.Feather.Value.Y < -0.4f))
                 {
                     newSpeed = moveSpeed * Math.Sign(Input.Feather.Value.Y) * (dir.Y > 0f ? 1f : -1f);
                     newFillColor = MoveBgFill;
-                    icon = Input.MoveY.Value == 1 ? DownIcon : UpIcon;
+                    icon = Math.Sign(Input.Feather.Value.Y) == 1 ? DownIcon : UpIcon;
                 }
-            }
-            else
-            {
-                if ((topPressed || bottomPressed) && HasPlayerRider() && (Input.MoveY.Value !=0))
+                else if (Input.MoveY.Value != 0)
                 {
                     newSpeed = moveSpeed * Input.MoveY.Value * (dir.Y > 0f ? 1f : -1f);
                     newFillColor = MoveBgFill;
                     icon = Input.MoveY.Value == 1 ? DownIcon : UpIcon;
                 }
-
             }
 
-            if ((leftPressed || rightPressed) && HasPlayerClimbing() && Input.MoveX.Value != 0)
+            else if ((leftPressed || rightPressed) && HasPlayerClimbing() && Input.MoveX.Value != 0)
             {
                 newSpeed = moveSpeed * Input.MoveX.Value * (dir.X > 0f ? 1f : -1f);
                 newFillColor = MoveBgFill;
                 icon = Input.MoveX.Value == 1 ? RightIcon : LeftIcon;
             }
 
+        
 
             if (Math.Sign(speed) != Math.Sign(newSpeed))
             {

--- a/src/Entities/Misc/RailedMoveBlock.cs
+++ b/src/Entities/Misc/RailedMoveBlock.cs
@@ -1,4 +1,3 @@
-using MonoMod.Utils;
 using System.Collections.Generic;
 
 
@@ -130,7 +129,6 @@ internal class RailedMoveBlock : Solid
     public static readonly Color StopBgFill = Calc.HexToColor("cc2541");
     public static readonly Color PlacementErrorBgFill = Calc.HexToColor("cc7c27");
 
-    private readonly DynamicData platformData;
     private Vector2 start, target, dir;
     private float percent;
     private readonly float length;
@@ -241,7 +239,6 @@ internal class RailedMoveBlock : Solid
         sfx.Play(CustomSFX.game_railedMoveBlock_railedmoveblock_move, "arrow_stop", 1f);
         Add(new LightOcclude(0.5f));
 
-        platformData = new(typeof(Platform), this);
     }
 
     private void AddImage(MTexture tex, Vector2 position, float rotation, Vector2 scale, List<Image> addTo)


### PR DESCRIPTION
This addition will add two features to Railed Move Blocks.

Attached Above - clicking this option will allow static movers to render above the railed move block steering buttons.

Eased Vertical Movement - clicking this option will allow diagonal inputs to more easily move the railed move block vertically. This is mainly for players on analog. My upcoming map uses a new move/mechanic that requires the player to move the railed move blocks with diagonal inputs. It was very tight and clunky on analog. This code fixes the problem. DM me if you want to see what it is used for, I can send a video. 

This is my first ever PR, so I apologize if I did something incorrectly. I plan to release my map once these changes are live!
DM on discord for any questions/concerns

morkypep50#5249
Closes #132.