### PR TITLE
Add "Reusable" property to "TimedTriggerSpikes"

### DIFF
--- a/Loenn/entities/misc/timed_trigger_spikes.lua
+++ b/Loenn/entities/misc/timed_trigger_spikes.lua
@@ -15,6 +15,8 @@ for _, dir in ipairs(directions) do
         placement.data.WaitForPlayer = false
         placement.data.Grouped = false
         placement.data.Rainbow = false
+        placement.data.Reusable = false
+        placement.data.ReusableTimer = 0.0
     end
 
     table.insert(timedTriggerSpikes, spikes)

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -236,6 +236,14 @@ entities.CommunalHelper/TimedTriggerSpikesUp.attributes.description.Rainbow=Make
 entities.CommunalHelper/TimedTriggerSpikesRight.attributes.description.Rainbow=Makes these spikes rainbow.
 entities.CommunalHelper/TimedTriggerSpikesDown.attributes.description.Rainbow=Makes these spikes rainbow.
 entities.CommunalHelper/TimedTriggerSpikesLeft.attributes.description.Rainbow=Makes these spikes rainbow.
+entities.CommunalHelper/TimedTriggerSpikesUp.attributes.description.Reusable=Setting this to true will make the spike reusable and can be triggered multi-times.
+entities.CommunalHelper/TimedTriggerSpikesRight.attributes.description.Reusable=Setting this to true will make the spike reusable and can be triggered multi-times.
+entities.CommunalHelper/TimedTriggerSpikesDown.attributes.description.Reusable=Setting this to true will make the spike reusable and can be triggered multi-times.
+entities.CommunalHelper/TimedTriggerSpikesLeft.attributes.description.Reusable=Setting this to true will make the spike reusable and can be triggered multi-times.
+entities.CommunalHelper/TimedTriggerSpikesUp.attributes.description.ReusableTimer=The time the spike will cost to be reusable when "Reusable" is set to true.
+entities.CommunalHelper/TimedTriggerSpikesRight.attributes.description.ReusableTimer=The time the spike will cost to be reusable when "Reusable" is set to true.
+entities.CommunalHelper/TimedTriggerSpikesDown.attributes.description.ReusableTimer=The time the spike will cost to be reusable when "Reusable" is set to true.
+entities.CommunalHelper/TimedTriggerSpikesLeft.attributes.description.ReusableTimer=The time the spike will cost to be reusable when "Reusable" is set to true.
 
 # Connected Solid Extension
 entities.CommunalHelper/SolidExtension.placements.name.collidable=Connected Solid Extension


### PR DESCRIPTION
This pr added "Reusable" property to the entity "TimedTriggerSpikes".
The "Reusable" property allows users to retract the timed spikes after it's triggered, and the retract delay equals to the "Reusable Timer", if the 'Reusable' property isn't enabled, then the spikes work as normal timed spikes.
~~Sorry for my poor julia that I didn't add support for Ahorn~~