### PR TITLE
Linked Dream Zip Movers and `ropeColor` attribute

### DIFF
--- a/Loenn/entities/dream_blocks/dream_zip_mover.lua
+++ b/Loenn/entities/dream_blocks/dream_zip_mover.lua
@@ -11,7 +11,11 @@ dreamZipMover.nodeLimits = {1, -1}
 dreamZipMover.fieldInformation = {
     refillCount = {
         fieldType = "integer"
-    }
+    },
+    ropeColor = {
+        fieldType = "color",
+        allowEmpty = true,
+    },
 }
 
 function dreamZipMover.depth(room, entity)
@@ -34,12 +38,14 @@ dreamZipMover.placements = {
             permanent = false,
             waiting = false,
             ticking = false,
-            noReturn = false
+            noReturn = false,
+            ropeColor = "",
+            linked = false,
         }
     }
 }
 
-local zipMoverRoleColor = {102 / 255, 57 / 255, 49 / 255}
+local zipMoverRopeColor = {102 / 255, 57 / 255, 49 / 255}
 local dreamAestheticRopeColor = {0.9, 0.9, 0.9}
 
 function dreamZipMover.sprite(room, entity)
@@ -52,7 +58,15 @@ function dreamZipMover.sprite(room, entity)
 
     local dreamAesthetic = entity.dreamAesthetic
     local cogTexture = dreamAesthetic and "objects/CommunalHelper/dreamZipMover/cog" or "objects/zipmover/cog"
-    local ropeColor = entity.dreamAesthetic and dreamAestheticRopeColor or zipMoverRoleColor
+
+    local ropeColor
+    if entity.dreamAesthetic then
+        ropeColor = dreamAestheticRopeColor
+    elseif entity.ropeColor and entity.ropeColor ~= "" then
+        ropeColor = entity.ropeColor
+    else
+        ropeColor = zipMoverRopeColor
+    end
 
     local nodes = entity.nodes or {{x = 0, y = 0}}
     local nodeSprites = communalHelper.getZipMoverNodeSprites(x, y, width, height, nodes, cogTexture, {1, 1, 1}, ropeColor)

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -255,6 +255,8 @@ entities.CommunalHelper/DreamZipMover.attributes.description.permanent=Whether t
 entities.CommunalHelper/DreamZipMover.attributes.description.waiting=Whether this block requires the player to trigger it each node in the path.
 entities.CommunalHelper/DreamZipMover.attributes.description.ticking=Causes this block to tick 5 times at every node before going back to its starting point, unless the player triggers it again. If `permanent` is true and the player doesn't trigger the Zip Mover in time, it'll lock in place.
 entities.CommunalHelper/DreamZipMover.attributes.description.quickDestroy=Makes this Dream Zip Mover shatter a little faster.
+entities.CommunalHelper/DreamZipMover.attributes.description.ropeColor=Overrides the default rope color. Also used for linking together zippers, if the `Linked` option is enabled.
+entities.CommunalHelper/DreamZipMover.attributes.description.linked=Whether the zipper is linked to other zippers with the same rope color.\nWhen a linked zipper gets activated, all other zippers linked to that rope color will be activated as well.
 
 # Connected Dream Block
 entities.CommunalHelper/ConnectedDreamBlock.placements.name.normal=Connected Dream Block (Normal)


### PR DESCRIPTION
Implements support for linked dream zip movers, and adds a new `ropeColor` attribute.
They get linked based on the rope color.

This implementation is equivalent to Adventure Helper's linked zippers, and they can even interact with eachother thanks to that.

Also fixes a bug with path rendering, where the path's shadow would rotate the opposite direction to the actual path... Now it's consistent with vanilla zippers.