### PR TITLE
ReverseHelper/ReversedDreamBlock compatibility 

### DIFF
--- a/src/CommunalHelperModule.cs
+++ b/src/CommunalHelperModule.cs
@@ -117,6 +117,7 @@ public class CommunalHelperModule : EverestModule
 
         typeof(Imports.CavernHelper).ModInterop();
         typeof(Imports.GravityHelper).ModInterop();
+        typeof(Imports.ReverseHelper).ModInterop();
 
         #endregion
 
@@ -221,6 +222,9 @@ public class CommunalHelperModule : EverestModule
 
         BetaCube.Initialize();
 
+        Imports.ReverseHelper.RegisterDreamBlockLike?.Invoke(typeof(DreamTunnelEntry),
+            e => (e as DreamTunnelEntry).ActivateNoRoutine(),
+            e => (e as DreamTunnelEntry).DeactivateNoRoutine());
         /*
          * Some Communal Helper mechanics don't work well with Gravity Helper.
          * To fix this, Gravity Helper has implemented hooks that patch some of Communal Helper's methods.

--- a/src/Imports/ReverseHelper.cs
+++ b/src/Imports/ReverseHelper.cs
@@ -1,0 +1,12 @@
+﻿using MonoMod.ModInterop;
+
+namespace Celeste.Mod.CommunalHelper.Imports;
+
+/// <summary>
+/// Import methods defined here: <see href="https://github.com/wuke32767/CelesteReverseHelper/blob/main/ReverseHelperInterop.cs">CavernInterop</see>.
+/// </summary>
+[ModImportName("ReverseHelper.DreamBlock")]
+public static class ReverseHelper
+{
+    public static Action<Type, Action<Entity>, Action<Entity>> RegisterDreamBlockLike;
+}


### PR DESCRIPTION
You can also choose not to add an optional dependency. There're already compatibility stuff before ReverseHelper adding interop.
I'm about to remove them after CommunalHelper updated.