### PR TITLE
cull particles connectedDreamBlock

### DIFF
--- a/src/Entities/DreamBlocks/ConnectedDreamBlock.cs
+++ b/src/Entities/DreamBlocks/ConnectedDreamBlock.cs
@@ -452,7 +452,11 @@ public class ConnectedDreamBlock : CustomDreamBlock
                     position += Calc.AngleToVector(rotation, 4f);
                 }
                 position = PutInside(position, GroupRect);
-
+                
+                Rectangle positionBounds = new Rectangle((int) (position.X + 0.5f), (int) (position.Y + 0.5f), 8, 8);
+                if (!camera.GetBounds().Intersects(positionBounds))
+                    continue;
+    
                 bool particleIsInside = false;
                 foreach (ConnectedDreamBlock block in Group)
                 {


### PR DESCRIPTION
its definitely not the proper way to do it. i didn't use Celeste.Mod.CullHelper.IsRectangleVisible, and i tried to get the texture to cull it based on that but it still lagged a bit, so i left it this way. it looks easy so please someone do it please :)

Closes #176.