### PR TITLE
Improve CustomCassetteBlock rendering

### DIFF
--- a/Loenn/entities/cassette_blocks/cassette_falling_block.lua
+++ b/Loenn/entities/cassette_blocks/cassette_falling_block.lua
@@ -6,7 +6,7 @@ local colorNames = communalHelper.cassetteBlockColorNames
 local colors = communalHelper.cassetteBlockHexColors
 
 cassetteFallingBlock.name = "CommunalHelper/CassetteFallingBlock"
-cassetteFallingBlock.minimumSize = {16, 16}
+cassetteFallingBlock.minimumSize = { 16, 16 }
 cassetteFallingBlock.fieldInformation = {
     index = {
         options = colorNames,
@@ -30,13 +30,14 @@ for i = 1, 4 do
             tempo = 1.0,
             width = 16,
             height = 16,
-            customColor = colors[i]
+            customColor = colors[i],
+            oldConnectionBehavior = false,
         }
     }
 end
 
 function cassetteFallingBlock.sprite(room, entity)
-    return communalHelper.getCustomCassetteBlockSprites(room, entity)
+    return communalHelper.getCustomCassetteBlockSprites(room, entity, true, entity.oldConnectionBehavior)
 end
 
 return cassetteFallingBlock

--- a/Loenn/entities/cassette_blocks/cassette_move_block.lua
+++ b/Loenn/entities/cassette_blocks/cassette_move_block.lua
@@ -13,7 +13,7 @@ local moveSpeeds = {
 }
 
 cassetteMoveBlock.name = "CommunalHelper/CassetteMoveBlock"
-cassetteMoveBlock.minimumSize = {16, 16}
+cassetteMoveBlock.minimumSize = { 16, 16 }
 cassetteMoveBlock.fieldInformation = {
     index = {
         options = colorNames,
@@ -47,7 +47,8 @@ for i = 1, 4 do
             height = 16,
             customColor = colors[i],
             direction = "Right",
-            moveSpeed = 60.0
+            moveSpeed = 60.0,
+            oldConnectionBehavior = false,
         }
     }
 end
@@ -60,7 +61,7 @@ local arrowTextures = {
 }
 
 function cassetteMoveBlock.sprite(room, entity)
-    local sprites = communalHelper.getCustomCassetteBlockSprites(room, entity)
+    local sprites = communalHelper.getCustomCassetteBlockSprites(room, entity, true, entity.oldConnectionBehavior)
 
     local width, height = entity.width or 16, entity.height or 16
     local color = communalHelper.getCustomCassetteBlockColor(entity)

--- a/Loenn/entities/cassette_blocks/cassette_swap_block.lua
+++ b/Loenn/entities/cassette_blocks/cassette_swap_block.lua
@@ -8,8 +8,8 @@ local colorNames = communalHelper.cassetteBlockColorNames
 local colors = communalHelper.cassetteBlockHexColors
 
 cassetteSwapBlock.name = "CommunalHelper/CassetteSwapBlock"
-cassetteSwapBlock.minimumSize = {16, 16}
-cassetteSwapBlock.nodeLimits = {1, 1}
+cassetteSwapBlock.minimumSize = { 16, 16 }
+cassetteSwapBlock.nodeLimits = { 1, 1 }
 cassetteSwapBlock.fieldInformation = {
     index = {
         options = colorNames,
@@ -34,13 +34,14 @@ for i = 1, 4 do
             width = 16,
             height = 16,
             customColor = colors[i],
-            noReturn = false
+            noReturn = false,
+            oldConnectionBehavior = false,
         }
     }
 end
 
 local function getBlockSprites(room, entity)
-    local sprites = communalHelper.getCustomCassetteBlockSprites(room, entity)
+    local sprites = communalHelper.getCustomCassetteBlockSprites(room, entity, true, entity.oldConnectionBehavior)
 
     local color = communalHelper.getCustomCassetteBlockColor(entity)
 
@@ -90,7 +91,7 @@ function cassetteSwapBlock.selection(room, entity)
     local nodeX, nodeY = nodes[1].x or x, nodes[1].y or y
     local width, height = entity.width or 8, entity.height or 8
 
-    return utils.rectangle(x, y, width, height), {utils.rectangle(nodeX, nodeY, width, height)}
+    return utils.rectangle(x, y, width, height), { utils.rectangle(nodeX, nodeY, width, height) }
 end
 
 return cassetteSwapBlock

--- a/Loenn/entities/cassette_blocks/cassette_zip_mover.lua
+++ b/Loenn/entities/cassette_blocks/cassette_zip_mover.lua
@@ -8,15 +8,15 @@ local colorNames = communalHelper.cassetteBlockColorNames
 local colors = communalHelper.cassetteBlockHexColors
 
 local ropeColors = {
-    {110 / 255, 189 / 255, 245 / 255, 1.0},
-    {194 / 255, 116 / 255, 171 / 255, 1.0},
-    {227 / 255, 214 / 255, 148 / 255, 1.0},
-    {128 / 255, 224 / 255, 141 / 255, 1.0}
+    { 110 / 255, 189 / 255, 245 / 255, 1.0 },
+    { 194 / 255, 116 / 255, 171 / 255, 1.0 },
+    { 227 / 255, 214 / 255, 148 / 255, 1.0 },
+    { 128 / 255, 224 / 255, 141 / 255, 1.0 }
 }
 
 cassetteZipMover.name = "CommunalHelper/CassetteZipMover"
-cassetteZipMover.minimumSize = {16, 16}
-cassetteZipMover.nodeLimits = {1, -1}
+cassetteZipMover.minimumSize = { 16, 16 }
+cassetteZipMover.nodeLimits = { 1, -1 }
 cassetteZipMover.nodeVisibility = "never"
 cassetteZipMover.fieldInformation = {
     index = {
@@ -45,13 +45,14 @@ for i = 1, 4 do
             waiting = false,
             ticking = false,
             noReturn = false,
-            customColor = colors[i]
+            customColor = colors[i],
+            oldConnectionBehavior = false,
         }
     }
 end
 
 function cassetteZipMover.sprite(room, entity)
-    local sprites = communalHelper.getCustomCassetteBlockSprites(room, entity)
+    local sprites = communalHelper.getCustomCassetteBlockSprites(room, entity, true, entity.oldConnectionBehavior)
 
     local x, y = entity.x or 0, entity.y or 0
     local width, height = entity.width or 16, entity.height or 16
@@ -63,8 +64,9 @@ function cassetteZipMover.sprite(room, entity)
     local i = entity.index or 0
     local ropeColor = (entity.customColor ~= "" and color) or ropeColors[i + 1] or ropeColors[1]
 
-    local nodes = entity.nodes or {{x = 0, y = 0}}
-    local nodeSprites = communalHelper.getZipMoverNodeSprites(x, y, width, height, nodes, "objects/CommunalHelper/cassetteZipMover/cog", color, ropeColor)
+    local nodes = entity.nodes or { { x = 0, y = 0 } }
+    local nodeSprites = communalHelper.getZipMoverNodeSprites(x, y, width, height, nodes,
+        "objects/CommunalHelper/cassetteZipMover/cog", color, ropeColor)
     for _, sprite in ipairs(nodeSprites) do
         table.insert(sprites, sprite)
     end
@@ -88,7 +90,7 @@ function cassetteZipMover.selection(room, entity)
 
     local mainRectangle = utils.rectangle(x, y, width, height)
 
-    local nodes = entity.nodes or {{x = 0, y = 0}}
+    local nodes = entity.nodes or { { x = 0, y = 0 } }
     local nodeRectangles = {}
     for _, node in ipairs(nodes) do
         local centerNodeX, centerNodeY = node.x + halfWidth, node.y + halfHeight

--- a/Loenn/entities/cassette_blocks/custom_cassette_block.lua
+++ b/Loenn/entities/cassette_blocks/custom_cassette_block.lua
@@ -6,7 +6,7 @@ local colorNames = communalHelper.cassetteBlockColorNames
 local colors = communalHelper.cassetteBlockHexColors
 
 customCassetteBlock.name = "CommunalHelper/CustomCassetteBlock"
-customCassetteBlock.minimumSize = {16, 16}
+customCassetteBlock.minimumSize = { 16, 16 }
 customCassetteBlock.fieldInformation = {
     index = {
         options = colorNames,
@@ -30,13 +30,14 @@ for i = 1, 4 do
             tempo = 1.0,
             width = 16,
             height = 16,
-            customColor = colors[i]
+            customColor = colors[i],
+            oldConnectionBehavior = false,
         }
     }
 end
 
 function customCassetteBlock.sprite(room, entity)
-    return communalHelper.getCustomCassetteBlockSprites(room, entity)
+    return communalHelper.getCustomCassetteBlockSprites(room, entity, false, entity.oldConnectionBehavior)
 end
 
 return customCassetteBlock

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -144,6 +144,7 @@ entities.CommunalHelper/CustomCassetteBlock.placements.name.cassette_block_3=Cus
 entities.CommunalHelper/CustomCassetteBlock.attributes.description.index=The color of the Custom Cassette Block.
 entities.CommunalHelper/CustomCassetteBlock.attributes.description.tempo=The tempo of the cassette music in the room.
 entities.CommunalHelper/CustomCassetteBlock.attributes.description.customColor=Optional hexadecimal color code, visual-only change.
+entities.CommunalHelper/CustomCassetteBlock.attributes.description.oldConnectionBehavior=Revert back to the old texture connection behavior (cassette entities connect to anything around them that is on the same index).\nHas strange interactions if blocks with this property touch blocks without.
 
 # Cassette Falling Block
 entities.CommunalHelper/CassetteFallingBlock.placements.name.cassette_block_0=Cassette Falling Block (0 - Blue)
@@ -153,6 +154,7 @@ entities.CommunalHelper/CassetteFallingBlock.placements.name.cassette_block_3=Ca
 entities.CommunalHelper/CassetteFallingBlock.attributes.description.index=The color of the Cassette Falling Block.
 entities.CommunalHelper/CassetteFallingBlock.attributes.description.tempo=The tempo of the cassette music in the room.
 entities.CommunalHelper/CassetteFallingBlock.attributes.description.customColor=Optional hexadecimal color code, visual-only change.
+entities.CommunalHelper/CustomCassetteBlock.attributes.description.oldConnectionBehavior=Revert back to the old texture connection behavior (cassette entities connect to anything around them that is on the same index).\nHas strange interactions if blocks with this property touch blocks without.
 
 # Cassette Zip Mover
 entities.CommunalHelper/CassetteZipMover.placements.name.cassette_block_0=Cassette Zip Mover (0 - Blue)
@@ -166,6 +168,7 @@ entities.CommunalHelper/CassetteZipMover.attributes.description.permanent=Whethe
 entities.CommunalHelper/CassetteZipMover.attributes.description.waiting=Whether this block requires the player to trigger it each node in the path.
 entities.CommunalHelper/CassetteZipMover.attributes.description.ticking=Causes this block to tick 5 times at every node before going back to its starting point, unless the player triggers it again. If `permanent` is true and the player doesn't trigger the Zip Mover in time, it'll lock in place.
 entities.CommunalHelper/CassetteZipMover.attributes.description.customColor=Optional hexadecimal color code, visual-only change.
+entities.CommunalHelper/CustomCassetteBlock.attributes.description.oldConnectionBehavior=Revert back to the old texture connection behavior (cassette entities connect to anything around them that is on the same index).\nHas strange interactions if blocks with this property touch blocks without.
 
 # Cassette Move Block
 entities.CommunalHelper/CassetteMoveBlock.placements.name.cassette_block_0=Cassette Move Block (0 - Blue)
@@ -177,6 +180,7 @@ entities.CommunalHelper/CassetteMoveBlock.attributes.description.moveSpeed=The s
 entities.CommunalHelper/CassetteMoveBlock.attributes.description.index=The color of the Cassette Move Block.
 entities.CommunalHelper/CassetteMoveBlock.attributes.description.tempo=The tempo of the cassette music in the room.
 entities.CommunalHelper/CassetteMoveBlock.attributes.description.customColor=Optional hexadecimal color code, visual-only change.
+entities.CommunalHelper/CustomCassetteBlock.attributes.description.oldConnectionBehavior=Revert back to the old texture connection behavior (cassette entities connect to anything around them that is on the same index).\nHas strange interactions if blocks with this property touch blocks without.
 
 # Cassette Swap Block
 entities.CommunalHelper/CassetteSwapBlock.placements.name.cassette_block_0=Cassette Swap Block (0 - Blue)
@@ -187,6 +191,7 @@ entities.CommunalHelper/CassetteSwapBlock.attributes.description.noReturn=Whethe
 entities.CommunalHelper/CassetteSwapBlock.attributes.description.index=The color of the Cassette Swap Block.
 entities.CommunalHelper/CassetteSwapBlock.attributes.description.tempo=The tempo of the cassette music in the room.
 entities.CommunalHelper/CassetteSwapBlock.attributes.description.customColor=Optional hexadecimal color code, visual-only change.
+entities.CommunalHelper/CustomCassetteBlock.attributes.description.oldConnectionBehavior=Revert back to the old texture connection behavior (cassette entities connect to anything around them that is on the same index).\nHas strange interactions if blocks with this property touch blocks without.
 
 # Cassette Jump Fix Controller
 entities.CommunalHelper/CassetteJumpFixController.placements.name.controller=Cassette Jump Fix Controller

--- a/Loenn/libraries/communal_helper.lua
+++ b/Loenn/libraries/communal_helper.lua
@@ -11,9 +11,9 @@ local communalHelper = {}
 
 function communalHelper.hexToColor(hex, default)
     local success, r, g, b, a = utils.parseHexColor(hex)
-    local color = default or {1.0, 1.0, 1.0, 1.0}
+    local color = default or { 1.0, 1.0, 1.0, 1.0 }
     if success then
-        color = {r, g, b, a}
+        color = { r, g, b, a }
     end
     return color
 end
@@ -21,10 +21,10 @@ end
 -- cassette blocks
 
 communalHelper.cassetteBlockColors = {
-    {73 / 255, 170 / 255, 240 / 255},
-    {240 / 255, 73 / 255, 190 / 255},
-    {252 / 255, 220 / 255, 58 / 255},
-    {56 / 255, 224 / 255, 78 / 255}
+    { 73 / 255,  170 / 255, 240 / 255 },
+    { 240 / 255, 73 / 255,  190 / 255 },
+    { 252 / 255, 220 / 255, 58 / 255 },
+    { 56 / 255,  224 / 255, 78 / 255 }
 }
 
 communalHelper.cassetteBlockColorNames = {
@@ -41,9 +41,17 @@ communalHelper.cassetteBlockHexColors = {
     "38e04e"
 }
 
-local function getSearchPredicate(entity)
+local function getSearchPredicateOld(entity)
     return function(target)
         return entity._name == target._name and entity.index == target.index
+    end
+end
+
+local function getSearchPredicateNew(entity)
+    return function(target)
+        return entity._name == target._name
+            and entity.index == target.index
+            and entity.customColor == target.customColor
     end
 end
 
@@ -107,11 +115,13 @@ end
 
 function communalHelper.getCustomCassetteBlockColor(entity)
     local index = entity.index or 0
-    return (entity.customColor ~= "" and communalHelper.hexToColor(entity.customColor)) or communalHelper.cassetteBlockColors[index + 1] or communalHelper.cassetteBlockColors[1]
+    return (entity.customColor ~= "" and communalHelper.hexToColor(entity.customColor)) or
+        communalHelper.cassetteBlockColors[index + 1] or communalHelper.cassetteBlockColors[1]
 end
 
-function communalHelper.getCustomCassetteBlockSprites(room, entity)
-    local relevantBlocks = utils.filter(getSearchPredicate(entity), room.entities)
+function communalHelper.getCustomCassetteBlockSprites(room, entity, lonely, oldBehavior)
+    local relevantBlocks = (lonely and not oldBehavior) and { entity } or
+        utils.filter(oldBehavior and getSearchPredicateOld(entity) or getSearchPredicateNew(entity), room.entities)
 
     connectedEntities.appendIfMissing(relevantBlocks, entity)
 
@@ -148,7 +158,7 @@ local function addNodeSprites(sprites, cogTexture, cogColor, ropeColor, centerX,
     nodeCogSprite:setPosition(centerNodeX, centerNodeY)
     nodeCogSprite:setJustification(0.5, 0.5)
 
-    local points = {centerX, centerY, centerNodeX, centerNodeY}
+    local points = { centerX, centerY, centerNodeX, centerNodeY }
     local leftLine = drawableLine.fromPoints(points, ropeColor, 1)
     local rightLine = drawableLine.fromPoints(points, ropeColor, 1)
 
@@ -205,7 +215,7 @@ function communalHelper.getTrailSprites(x, y, nodeX, nodeY, width, height, trail
     local frameSprites = frameNinePatch:getDrawableSprite()
 
     local depth = trailDepth or 8999
-    local color = trailColor or {1, 1, 1, 1}
+    local color = trailColor or { 1, 1, 1, 1 }
     for _, sprite in ipairs(frameSprites) do
         sprite.depth = depth
         sprite:setColor(color)
@@ -224,12 +234,12 @@ end
 
 -- dream blocks
 
-local featherColor = {0, 0.5, 0.5}
-local oneUseColor = {178 / 255, 34 / 255, 34 / 255}
+local featherColor = { 0, 0.5, 0.5 }
+local oneUseColor = { 178 / 255, 34 / 255, 34 / 255 }
 
 function communalHelper.getCustomDreamBlockSprites(x, y, width, height, feather, oneUse)
-    local fill = feather and featherColor or {0, 0, 0}
-    local border = oneUse and oneUseColor or {1, 1, 1}
+    local fill = feather and featherColor or { 0, 0, 0 }
+    local border = oneUse and oneUseColor or { 1, 1, 1 }
 
     local rectangleSprite = drawableRectangle.fromRectangle("bordered", x, y, width, height, fill, border)
     rectangleSprite.depth = 0
@@ -270,10 +280,12 @@ function communalHelper.getPanelSprite(entity, color)
     local right = orientation == "Right"
     local vertical = left or right
 
-    local rect = drawableRectangle.fromRectangle("fill", x, y, vertical and 8 or width, vertical and height or 8, color or {1.0, 0.5, 0.0, 0.4}):getDrawableSprite()
-    local border = drawableRectangle.fromRectangle("fill", right and (x + 7) or x, down and (y + 7) or y, vertical and 1 or width, vertical and height or 1):getDrawableSprite()
+    local rect = drawableRectangle.fromRectangle("fill", x, y, vertical and 8 or width, vertical and height or 8,
+        color or { 1.0, 0.5, 0.0, 0.4 }):getDrawableSprite()
+    local border = drawableRectangle.fromRectangle("fill", right and (x + 7) or x, down and (y + 7) or y,
+        vertical and 1 or width, vertical and height or 1):getDrawableSprite()
 
-    return {rect, border}
+    return { rect, border }
 end
 
 function communalHelper.fixAndGetPanelRectangle(entity)
@@ -323,13 +335,15 @@ function communalHelper.getCubicCurve(start, stop, controlA, controlB, resolutio
 
     return res
 end
-function communalHelper.lerp(a,b,t) return a * (1-t) + b * t end
-function communalHelper.colorLerp(col1, col2, lerp) 
+
+function communalHelper.lerp(a, b, t) return a * (1 - t) + b * t end
+
+function communalHelper.colorLerp(col1, col2, lerp)
     local ret = {
-        communalHelper.lerp(col1.r or col1[1] or 1,col2.r or col2[1] or 1,lerp),
-        communalHelper.lerp(col1.g or col1[2] or 1,col2.g or col2[2] or 1,lerp),
-        communalHelper.lerp(col1.b or col1[3] or 1,col2.b or col2[3] or 1,lerp),
-        communalHelper.lerp(col1.a or col1[4] or 1,col2.a or col2[4] or 1,lerp)
+        communalHelper.lerp(col1.r or col1[1] or 1, col2.r or col2[1] or 1, lerp),
+        communalHelper.lerp(col1.g or col1[2] or 1, col2.g or col2[2] or 1, lerp),
+        communalHelper.lerp(col1.b or col1[3] or 1, col2.b or col2[3] or 1, lerp),
+        communalHelper.lerp(col1.a or col1[4] or 1, col2.a or col2[4] or 1, lerp)
     }
     ret.r = ret[1]
     ret.g = ret[2]

--- a/Loenn/libraries/communal_helper.lua
+++ b/Loenn/libraries/communal_helper.lua
@@ -41,20 +41,6 @@ communalHelper.cassetteBlockHexColors = {
     "38e04e"
 }
 
-local function getSearchPredicateOld(entity)
-    return function(target)
-        return entity._name == target._name and entity.index == target.index
-    end
-end
-
-local function getSearchPredicateNew(entity)
-    return function(target)
-        return entity._name == target._name
-            and entity.index == target.index
-            and entity.customColor == target.customColor
-    end
-end
-
 local function getTileSprite(entity, x, y, frame, color, depth, rectangles)
     local hasAdjacent = connectedEntities.hasAdjacent
 
@@ -121,7 +107,9 @@ end
 
 function communalHelper.getCustomCassetteBlockSprites(room, entity, lonely, oldBehavior)
     local relevantBlocks = (lonely and not oldBehavior) and { entity } or
-        utils.filter(oldBehavior and getSearchPredicateOld(entity) or getSearchPredicateNew(entity), room.entities)
+        utils.filter( function(target) 
+            return entity._name == target._name and entity.index == target.index and (not oldBehavior or entity.customColor == target.customColor) 
+        end, room.entities)
 
     connectedEntities.appendIfMissing(relevantBlocks, entity)
 

--- a/src/Entities/CassetteBlocks/CassetteFallingBlock.cs
+++ b/src/Entities/CassetteBlocks/CassetteFallingBlock.cs
@@ -10,14 +10,14 @@ public class CassetteFallingBlock : CustomCassetteBlock
 
     public bool HasStartedFalling { get; private set; }
 
-    public CassetteFallingBlock(Vector2 position, EntityID id, int width, int height, int index, float tempo, Color? overrideColor)
-        : base(position, id, width, height, index, tempo, dynamicHitbox: true, overrideColor)
+    public CassetteFallingBlock(Vector2 position, EntityID id, int width, int height, int index, float tempo, bool oldConnectionBehavior, Color? overrideColor)
+        : base(position, id, width, height, index, tempo, true, oldConnectionBehavior, dynamicHitbox: true, overrideColor)
     {
         Add(new Coroutine(Sequence()));
     }
 
     public CassetteFallingBlock(EntityData data, Vector2 offset, EntityID id)
-        : this(data.Position + offset, id, data.Width, data.Height, data.Int("index"), data.Float("tempo", 1f), data.HexColorNullable("customColor"))
+        : this(data.Position + offset, id, data.Width, data.Height, data.Int("index"), data.Float("tempo", 1f), data.Bool("oldConnectionBehavior"), data.HexColorNullable("customColor"))
     {
     }
 

--- a/src/Entities/CassetteBlocks/CassetteFallingBlock.cs
+++ b/src/Entities/CassetteBlocks/CassetteFallingBlock.cs
@@ -17,7 +17,7 @@ public class CassetteFallingBlock : CustomCassetteBlock
     }
 
     public CassetteFallingBlock(EntityData data, Vector2 offset, EntityID id)
-        : this(data.Position + offset, id, data.Width, data.Height, data.Int("index"), data.Float("tempo", 1f), data.Bool("oldConnectionBehavior"), data.HexColorNullable("customColor"))
+        : this(data.Position + offset, id, data.Width, data.Height, data.Int("index"), data.Float("tempo", 1f), data.Bool("oldConnectionBehavior", true), data.HexColorNullable("customColor"))
     {
     }
 

--- a/src/Entities/CassetteBlocks/CassetteMoveBlock.cs
+++ b/src/Entities/CassetteBlocks/CassetteMoveBlock.cs
@@ -59,8 +59,8 @@ public class CassetteMoveBlock : CustomCassetteBlock
     private readonly ParticleType P_Break;
     private readonly ParticleType P_BreakPressed;
 
-    public CassetteMoveBlock(Vector2 position, EntityID id, int width, int height, Directions direction, float moveSpeed, int index, float tempo, Color? overrideColor)
-        : base(position, id, width, height, index, tempo, dynamicHitbox: true, overrideColor)
+    public CassetteMoveBlock(Vector2 position, EntityID id, int width, int height, Directions direction, float moveSpeed, int index, float tempo, bool oldConnectionBehavior, Color? overrideColor)
+        : base(position, id, width, height, index, tempo, true, oldConnectionBehavior, dynamicHitbox: true, overrideColor)
     {
         startPosition = position;
         Direction = direction;
@@ -88,7 +88,7 @@ public class CassetteMoveBlock : CustomCassetteBlock
     }
 
     public CassetteMoveBlock(EntityData data, Vector2 offset, EntityID id)
-        : this(data.Position + offset, id, data.Width, data.Height, data.Enum("direction", Directions.Left), data.Bool("fast") ? FastMoveSpeed : data.Float("moveSpeed", MoveSpeed), data.Int("index"), data.Float("tempo", 1f), data.HexColorNullable("customColor"))
+        : this(data.Position + offset, id, data.Width, data.Height, data.Enum("direction", Directions.Left), data.Bool("fast") ? FastMoveSpeed : data.Float("moveSpeed", MoveSpeed), data.Int("index"), data.Float("tempo", 1f), data.Bool("oldConnectionBehavior"), data.HexColorNullable("customColor"))
     {
     }
 

--- a/src/Entities/CassetteBlocks/CassetteMoveBlock.cs
+++ b/src/Entities/CassetteBlocks/CassetteMoveBlock.cs
@@ -88,7 +88,7 @@ public class CassetteMoveBlock : CustomCassetteBlock
     }
 
     public CassetteMoveBlock(EntityData data, Vector2 offset, EntityID id)
-        : this(data.Position + offset, id, data.Width, data.Height, data.Enum("direction", Directions.Left), data.Bool("fast") ? FastMoveSpeed : data.Float("moveSpeed", MoveSpeed), data.Int("index"), data.Float("tempo", 1f), data.Bool("oldConnectionBehavior"), data.HexColorNullable("customColor"))
+        : this(data.Position + offset, id, data.Width, data.Height, data.Enum("direction", Directions.Left), data.Bool("fast") ? FastMoveSpeed : data.Float("moveSpeed", MoveSpeed), data.Int("index"), data.Float("tempo", 1f), data.Bool("oldConnectionBehavior", true), data.HexColorNullable("customColor"))
     {
     }
 

--- a/src/Entities/CassetteBlocks/CassetteSwapBlock.cs
+++ b/src/Entities/CassetteBlocks/CassetteSwapBlock.cs
@@ -108,7 +108,7 @@ public class CassetteSwapBlock : CustomCassetteBlock
     }
 
     public CassetteSwapBlock(EntityData data, Vector2 offset, EntityID id)
-        : this(data.Position + offset, id, data.Width, data.Height, data.Nodes[0] + offset, data.Int("index"), data.Float("tempo", 1f), data.Bool("oldConnectionBehavior"), data.Bool("noReturn", false), data.HexColorNullable("customColor"))
+        : this(data.Position + offset, id, data.Width, data.Height, data.Nodes[0] + offset, data.Int("index"), data.Float("tempo", 1f), data.Bool("oldConnectionBehavior", true), data.Bool("noReturn", false), data.HexColorNullable("customColor"))
     {
     }
 

--- a/src/Entities/CassetteBlocks/CassetteSwapBlock.cs
+++ b/src/Entities/CassetteBlocks/CassetteSwapBlock.cs
@@ -66,8 +66,8 @@ public class CassetteSwapBlock : CustomCassetteBlock
 
     private readonly bool noReturn;
 
-    public CassetteSwapBlock(Vector2 position, EntityID id, int width, int height, Vector2 node, int index, float tempo, bool noReturn, Color? overrideColor)
-        : base(position, id, width, height, index, tempo, false, overrideColor)
+    public CassetteSwapBlock(Vector2 position, EntityID id, int width, int height, Vector2 node, int index, float tempo, bool oldConnectionBehavior, bool noReturn, Color? overrideColor)
+        : base(position, id, width, height, index, tempo, true, oldConnectionBehavior, false, overrideColor)
     {
         start = Position;
         end = node;
@@ -108,7 +108,7 @@ public class CassetteSwapBlock : CustomCassetteBlock
     }
 
     public CassetteSwapBlock(EntityData data, Vector2 offset, EntityID id)
-        : this(data.Position + offset, id, data.Width, data.Height, data.Nodes[0] + offset, data.Int("index"), data.Float("tempo", 1f), data.Bool("noReturn", false), data.HexColorNullable("customColor"))
+        : this(data.Position + offset, id, data.Width, data.Height, data.Nodes[0] + offset, data.Int("index"), data.Float("tempo", 1f), data.Bool("oldConnectionBehavior"), data.Bool("noReturn", false), data.HexColorNullable("customColor"))
     {
     }
 

--- a/src/Entities/CassetteBlocks/CassetteZipMover.cs
+++ b/src/Entities/CassetteBlocks/CassetteZipMover.cs
@@ -215,8 +215,8 @@ public class CassetteZipMover : CustomCassetteBlock
 
     private static MTexture cog, cogPressed, cogWhite;
 
-    public CassetteZipMover(Vector2 position, EntityID id, int width, int height, Vector2[] nodes, int index, float tempo, bool noReturn, bool perm, bool waits, bool ticking, Color? overrideColor)
-        : base(position, id, width, height, index, tempo, false, overrideColor)
+    public CassetteZipMover(Vector2 position, EntityID id, int width, int height, Vector2[] nodes, int index, float tempo, bool oldConnectionBehavior, bool noReturn, bool perm, bool waits, bool ticking, Color? overrideColor)
+        : base(position, id, width, height, index, tempo, true, oldConnectionBehavior, false, overrideColor)
     {
         this.noReturn = noReturn;
         permanent = perm;
@@ -232,7 +232,7 @@ public class CassetteZipMover : CustomCassetteBlock
     }
 
     public CassetteZipMover(EntityData data, Vector2 offset, EntityID id)
-        : this(data.Position + offset, id, data.Width, data.Height, data.NodesWithPosition(offset), data.Int("index"), data.Float("tempo", 1f),
+        : this(data.Position + offset, id, data.Width, data.Height, data.NodesWithPosition(offset), data.Int("index"), data.Float("tempo", 1f), data.Bool("oldConnectionBehavior"),
               data.Bool("noReturn", false),
               data.Bool("permanent"),
               data.Bool("waiting"),

--- a/src/Entities/CassetteBlocks/CassetteZipMover.cs
+++ b/src/Entities/CassetteBlocks/CassetteZipMover.cs
@@ -232,7 +232,7 @@ public class CassetteZipMover : CustomCassetteBlock
     }
 
     public CassetteZipMover(EntityData data, Vector2 offset, EntityID id)
-        : this(data.Position + offset, id, data.Width, data.Height, data.NodesWithPosition(offset), data.Int("index"), data.Float("tempo", 1f), data.Bool("oldConnectionBehavior"),
+        : this(data.Position + offset, id, data.Width, data.Height, data.NodesWithPosition(offset), data.Int("index"), data.Float("tempo", 1f), data.Bool("oldConnectionBehavior", true),
               data.Bool("noReturn", false),
               data.Bool("permanent"),
               data.Bool("waiting"),

--- a/src/Entities/CassetteBlocks/CustomCassetteBlock.cs
+++ b/src/Entities/CassetteBlocks/CustomCassetteBlock.cs
@@ -96,7 +96,7 @@ public class CustomCassetteBlock : CassetteBlock
     }
 
     public CustomCassetteBlock(EntityData data, Vector2 offset, EntityID id)
-        : this(data.Position + offset, id, data.Width, data.Height, data.Int("index"), data.Float("tempo", 1f), false, data.Bool("oldConnectionBehavior"), false, data.HexColorNullable("customColor")) { }
+        : this(data.Position + offset, id, data.Width, data.Height, data.Int("index"), data.Float("tempo", 1f), false, data.Bool("oldConnectionBehavior", true), false, data.HexColorNullable("customColor")) { }
 
     public CustomCassetteBlock(Vector2 position, EntityID id, int width, int height, int index, float tempo, bool lonely, bool oldConnectionBehavior, bool dynamicHitbox = false, Color? overrideColor = null)
         : base(position, id, width, height, index, tempo)


### PR DESCRIPTION
Improve cassette block rendering by making cassette zip movers and such not connect to normal custom cassette blocks, and also make custom cassette blocks of different colors not connect even if they have the same index. A new attribute on cassette entities, `oldConnectionBehavior`, was also added which will force the old rendering for that specific block alongside updates to the Lönn plugins to reflect the new behavior.