### PR TITLE
Implement camera culling for Connected Solids

### DIFF
--- a/src/Entities/ConnectedBlocks/ConnectedMoveBlock.cs
+++ b/src/Entities/ConnectedBlocks/ConnectedMoveBlock.cs
@@ -779,6 +779,9 @@ public class ConnectedMoveBlock : ConnectedSolid
 
     public override void Render()
     {
+        if (!IsGroupVisible())
+            return;
+        
         Vector2 position = Position;
         Position += Shake;
 

--- a/src/Entities/ConnectedBlocks/ConnectedSolid.cs
+++ b/src/Entities/ConnectedBlocks/ConnectedSolid.cs
@@ -1,4 +1,5 @@
 ﻿using Celeste.Mod.CommunalHelper.Imports;
+using Celeste.Mod.Helpers;
 using MonoMod.Utils;
 using System.Collections.Generic;
 using System.Linq;
@@ -37,6 +38,14 @@ public class ConnectedSolid : Solid
 
     public Vector2 GroupBoundsMin, GroupBoundsMax;
     public Vector2 GroupCenter => Position + GroupOffset + ((GroupBoundsMax - GroupBoundsMin) / 2f);
+
+    public Rectangle GetGroupBoundsAt(Vector2 position)
+    {
+        Vector2 pos = position + GroupOffset + Shake;
+        Vector2 size = GroupBoundsMax - GroupBoundsMin;
+            
+        return new Rectangle((int) pos.X, (int) pos.Y, (int)size.X, (int)size.Y);
+    }
 
     // AllColliders contains colliders that didn't have a hitbox.
     public Hitbox[] Colliders, AllColliders;
@@ -511,5 +520,13 @@ public class ConnectedSolid : Solid
         riders.Clear();
 
         GravityHelper.EndOverride?.Invoke();
+    }
+    
+    public bool IsGroupVisible() => IsGroupVisibleAt(Position);
+    
+    public bool IsGroupVisibleAt(Vector2 pos)
+    {
+        Rectangle bounds = GetGroupBoundsAt(pos);
+        return CullHelper.IsRectangleVisible(bounds.X, bounds.Y, bounds.Width, bounds.Height);
     }
 }

--- a/src/Entities/ConnectedBlocks/ConnectedSwapBlock.cs
+++ b/src/Entities/ConnectedBlocks/ConnectedSwapBlock.cs
@@ -419,6 +419,9 @@ public class ConnectedSwapBlock : ConnectedSolid
 
     private void DrawBlock(Vector2 pos, List<Image> ninSlice, Sprite middle, Color color)
     {
+        if (!IsGroupVisibleAt(pos))
+            return;
+        
         foreach (Image tile in ninSlice)
         {
             tile.RenderPosition += pos;

--- a/src/Entities/ConnectedBlocks/ConnectedTempleCrackedBlock.cs
+++ b/src/Entities/ConnectedBlocks/ConnectedTempleCrackedBlock.cs
@@ -200,6 +200,9 @@ public class ConnectedTempleCrackedBlock : ConnectedSolid
 
     public override void Render()
     {
+        if (!IsGroupVisible())
+            return;
+        
         if (!autoTiled)
         {
             AutoTile(texture);

--- a/src/Entities/ConnectedBlocks/ConnectedZipMover.cs
+++ b/src/Entities/ConnectedBlocks/ConnectedZipMover.cs
@@ -160,24 +160,25 @@ public class ConnectedZipMover : ConnectedSolid
         {
             Rectangle cameraBounds = level.Camera.GetBounds();
 
-            if (!cameraBounds.Intersects(bounds))
-                return;
-
-            foreach (Segment seg in segments)
-                if (seg.Seen = cameraBounds.Intersects(seg.Bounds))
-                    seg.RenderShadow(zipMover.percent);
-
-            foreach (Segment seg in segments)
-                if (seg.Seen)
-                    seg.Render(zipMover.percent, color, lightColor);
-
-            float rotation = zipMover.percent * MathHelper.TwoPi;
-            foreach (Vector2 node in nodes)
+            if (cameraBounds.Intersects(bounds))
             {
-                zipMover.cog.DrawCentered(node + Vector2.UnitY, Color.Black, 1f, rotation);
-                zipMover.cog.DrawCentered(node, Color.White, 1f, rotation);
+                foreach (Segment seg in segments)
+                    if (seg.Seen = cameraBounds.Intersects(seg.Bounds))
+                        seg.RenderShadow(zipMover.percent);
+
+                foreach (Segment seg in segments)
+                    if (seg.Seen)
+                        seg.Render(zipMover.percent, color, lightColor);
+
+                float rotation = zipMover.percent * MathHelper.TwoPi;
+                foreach (Vector2 node in nodes)
+                {
+                    zipMover.cog.DrawCentered(node + Vector2.UnitY, Color.Black, 1f, rotation);
+                    zipMover.cog.DrawCentered(node, Color.White, 1f, rotation);
+                }
             }
 
+            // 'bounds' doesn't include the zip mover itself, it will do its own camera cull checks
             zipMover.DrawBorder();
         }
     }
@@ -381,11 +382,19 @@ public class ConnectedZipMover : ConnectedSolid
 
     public override void Render()
     {
+        if (!IsGroupVisible())
+            return;
+        
+        Rectangle cameraBounds = (Scene as Level)?.Camera.GetBounds() ?? new();
+        
         Vector2 originalPosition = Position;
         Position += Shake;
 
         foreach (Hitbox extension in Colliders)
         {
+            if (!cameraBounds.Intersects(extension.Bounds))
+                continue;
+            
             if (theme == Themes.Moon)
             {
                 Draw.Rect(extension.Left + 2f + X, extension.Top + Y, extension.Width - 4f, extension.Height, backgroundColor);
@@ -463,9 +472,14 @@ public class ConnectedZipMover : ConnectedSolid
 
     public void DrawBorder()
     {
-        if (drawBlackBorder)
-            foreach (Hitbox extension in AllColliders)
-                Draw.HollowRect(new Rectangle(
+        if (!drawBlackBorder)
+            return;
+        
+        if (!IsGroupVisible())
+            return;
+        
+        foreach (Hitbox extension in AllColliders)
+            Draw.HollowRect(new Rectangle(
                     (int) (X + extension.Left - 1f + Shake.X),
                     (int) (Y + extension.Top - 1f + Shake.Y),
                     (int) extension.Width + 2,


### PR DESCRIPTION
Simple broad-phase camera checks for better perf in large rooms. Better performance for large solids could be achieved by checking which parts of the solids are visible and only rendering those, but this will do for now.

Also fixes a bug where zip mover borders wouldn't be rendered if its path was off-screen, even if the block itself was on-screen