### PR TITLE
Switch all swap block entities to use an improved DrawBlockStyle method

### DIFF
--- a/src/Entities/CassetteBlocks/CassetteSwapBlock.cs
+++ b/src/Entities/CassetteBlocks/CassetteSwapBlock.cs
@@ -37,7 +37,7 @@ public class CassetteSwapBlock : CustomCassetteBlock
 
         private void DrawTarget(Vector2 position, Color color)
         {
-            block.DrawBlockStyle(position, block.moveRect.Width, block.moveRect.Height, block.nineSliceTarget, null, color);
+            Util.DrawBlockStyle(SceneAs<Level>().Camera, position, block.moveRect.Width, block.moveRect.Height, block.nineSliceTarget, null, color);
         }
     }
 
@@ -330,39 +330,5 @@ public class CassetteSwapBlock : CustomCassetteBlock
         particlesRemainder -= num2;
         positionRange *= 0.5f;
         SceneAs<Level>().Particles.Emit(Collidable ? moveParticle : moveParticlePressed, num2, position, positionRange, direction);
-    }
-
-    private void DrawBlockStyle(Vector2 pos, float width, float height, MTexture[,] ninSlice, Sprite middle, Color color)
-    {
-        int tilesX = (int) (width / 8f);
-        int tilesY = (int) (height / 8f);
-        ninSlice[0, 0].Draw(pos + new Vector2(0f, 0f), Vector2.Zero, color);
-        ninSlice[2, 0].Draw(pos + new Vector2(width - 8f, 0f), Vector2.Zero, color);
-        ninSlice[0, 2].Draw(pos + new Vector2(0f, height - 8f), Vector2.Zero, color);
-        ninSlice[2, 2].Draw(pos + new Vector2(width - 8f, height - 8f), Vector2.Zero, color);
-        for (int i = 1; i < tilesX - 1; i++)
-        {
-            ninSlice[1, 0].Draw(pos + new Vector2(i * 8, 0f), Vector2.Zero, color);
-            ninSlice[1, 2].Draw(pos + new Vector2(i * 8, height - 8f), Vector2.Zero, color);
-        }
-        for (int j = 1; j < tilesY - 1; j++)
-        {
-            ninSlice[0, 1].Draw(pos + new Vector2(0f, j * 8), Vector2.Zero, color);
-            ninSlice[2, 1].Draw(pos + new Vector2(width - 8f, j * 8), Vector2.Zero, color);
-        }
-        for (int k = 1; k < tilesX - 1; k++)
-        {
-            for (int l = 1; l < tilesY - 1; l++)
-            {
-                ninSlice[1, 1].Draw(pos + (new Vector2(k, l) * 8f), Vector2.Zero, color);
-            }
-        }
-
-        if (middle != null)
-        {
-            middle.Color = color;
-            middle.RenderPosition = pos + new Vector2(width / 2f, height / 2f);
-            middle.Render();
-        }
     }
 }

--- a/src/Entities/ConnectedBlocks/ConnectedSwapBlock.cs
+++ b/src/Entities/ConnectedBlocks/ConnectedSwapBlock.cs
@@ -35,34 +35,7 @@ public class ConnectedSwapBlock : ConnectedSolid
         public override void Render()
         {
             float scale = 0.5f * (0.5f + (((float) Math.Sin(timer) + 1f) * 0.25f));
-            DrawBlockStyle(new Vector2(block.moveRect.X, block.moveRect.Y), block.moveRect.Width, block.moveRect.Height, block.nineSliceTarget, Color.White * scale);
-        }
-
-        private void DrawBlockStyle(Vector2 pos, float width, float height, MTexture[,] ninSlice, Color color)
-        {
-            int num = (int) (width / 8f);
-            int num2 = (int) (height / 8f);
-            ninSlice[0, 0].Draw(pos + new Vector2(0f, 0f), Vector2.Zero, color);
-            ninSlice[2, 0].Draw(pos + new Vector2(width - 8f, 0f), Vector2.Zero, color);
-            ninSlice[0, 2].Draw(pos + new Vector2(0f, height - 8f), Vector2.Zero, color);
-            ninSlice[2, 2].Draw(pos + new Vector2(width - 8f, height - 8f), Vector2.Zero, color);
-            for (int i = 1; i < num - 1; i++)
-            {
-                ninSlice[1, 0].Draw(pos + new Vector2(i * 8, 0f), Vector2.Zero, color);
-                ninSlice[1, 2].Draw(pos + new Vector2(i * 8, height - 8f), Vector2.Zero, color);
-            }
-            for (int j = 1; j < num2 - 1; j++)
-            {
-                ninSlice[0, 1].Draw(pos + new Vector2(0f, j * 8), Vector2.Zero, color);
-                ninSlice[2, 1].Draw(pos + new Vector2(width - 8f, j * 8), Vector2.Zero, color);
-            }
-            for (int k = 1; k < num - 1; k++)
-            {
-                for (int l = 1; l < num2 - 1; l++)
-                {
-                    ninSlice[1, 1].Draw(pos + (new Vector2(k, l) * 8f), Vector2.Zero, color);
-                }
-            }
+            Util.DrawBlockStyle(SceneAs<Level>().Camera, new Vector2(block.moveRect.X, block.moveRect.Y), block.moveRect.Width, block.moveRect.Height, block.nineSliceTarget, null, Color.White * scale);
         }
     }
 
@@ -421,7 +394,7 @@ public class ConnectedSwapBlock : ConnectedSolid
     {
         if (!IsGroupVisibleAt(pos))
             return;
-        
+
         foreach (Image tile in ninSlice)
         {
             tile.RenderPosition += pos;

--- a/src/Entities/DreamBlocks/DreamSwapBlock.cs
+++ b/src/Entities/DreamBlocks/DreamSwapBlock.cs
@@ -29,7 +29,7 @@ public class DreamSwapBlock : CustomDreamBlock
         {
             float scale = 0.5f * (0.5f + (((float) Math.Sin(timer) + 1f) * 0.25f));
             scale = Calc.LerpClamp(scale, 1, block.ColorLerp);
-            block.DrawBlockStyle(new Vector2(block.moveRect.X, block.moveRect.Y), block.moveRect.Width, block.moveRect.Height, block.nineSliceTarget, null, ActiveLineColor * scale);
+            Util.DrawBlockStyle(SceneAs<Level>().Camera, new Vector2(block.moveRect.X, block.moveRect.Y), block.moveRect.Width, block.moveRect.Height, block.nineSliceTarget, null, ActiveLineColor * scale);
         }
     }
 
@@ -370,38 +370,5 @@ public class DreamSwapBlock : CustomDreamBlock
         SceneAs<Level>().Particles.Emit(dreamParticles[particleIndex], amount, position, positionRange, direction);
         ++particleIndex;
         particleIndex %= 4;
-    }
-
-    private void DrawBlockStyle(Vector2 pos, float width, float height, MTexture[,] ninSlice, Sprite middle, Color color)
-    {
-        int tilesX = (int) (width / 8f);
-        int tilesY = (int) (height / 8f);
-        ninSlice[0, 0].Draw(pos + new Vector2(0f, 0f), Vector2.Zero, color);
-        ninSlice[2, 0].Draw(pos + new Vector2(width - 8f, 0f), Vector2.Zero, color);
-        ninSlice[0, 2].Draw(pos + new Vector2(0f, height - 8f), Vector2.Zero, color);
-        ninSlice[2, 2].Draw(pos + new Vector2(width - 8f, height - 8f), Vector2.Zero, color);
-        for (int i = 1; i < tilesX - 1; i++)
-        {
-            ninSlice[1, 0].Draw(pos + new Vector2(i * 8, 0f), Vector2.Zero, color);
-            ninSlice[1, 2].Draw(pos + new Vector2(i * 8, height - 8f), Vector2.Zero, color);
-        }
-        for (int i = 1; i < tilesY - 1; i++)
-        {
-            ninSlice[0, 1].Draw(pos + new Vector2(0f, i * 8), Vector2.Zero, color);
-            ninSlice[2, 1].Draw(pos + new Vector2(width - 8f, i * 8), Vector2.Zero, color);
-        }
-        for (int i = 1; i < tilesX - 1; i++)
-        {
-            for (int j = 1; j < tilesY - 1; j++)
-            {
-                ninSlice[1, 1].Draw(pos + (new Vector2(i, j) * 8f), Vector2.Zero, color);
-            }
-        }
-        if (middle != null)
-        {
-            middle.Color = color;
-            middle.RenderPosition = pos + new Vector2(width / 2f, height / 2f);
-            middle.Render();
-        }
     }
 }

--- a/src/Entities/Misc/MoveSwapBlock.cs
+++ b/src/Entities/Misc/MoveSwapBlock.cs
@@ -958,7 +958,11 @@ public class MoveSwapBlock : SwapBlock
 
     private static void SwapBlock_DrawBlockStyle(On.Celeste.SwapBlock.orig_DrawBlockStyle orig, SwapBlock self, Vector2 pos, float width, float height, MTexture[,] ninSlice, Sprite middle, Color color)
     {
-        orig(self, pos, width, height, ninSlice, middle, color);
+        if (self is MoveSwapBlock)
+            // Use optimized DrawBlockStyle
+            Util.DrawBlockStyle(self.SceneAs<Level>().Camera, pos, width, height, ninSlice, middle, color);
+        else
+            orig(self, pos, width, height, ninSlice, middle, color);
 
         // DrawBlockStyle is also used by the SwapBlock PathRenderer, which just passes null to the middle argument
         if (self is MoveSwapBlock block && middle != null)

--- a/src/Utils/Extensions.cs
+++ b/src/Utils/Extensions.cs
@@ -551,7 +551,7 @@ public static class Extensions
 
         return new(left, top, right - left, bottom - top);
     }
-    
+
     public static bool Collides(this Camera self, Entity entity, Collider collider, float extend = 32f) =>
         entity.Position.X + collider.Right >= self.Left - extend &&
         entity.Position.X + collider.Left <= self.Right + extend &&
@@ -787,4 +787,10 @@ public static class Extensions
         => DynamicData.For(sfx)
                       .Get<EventInstance>("instance")
                       .setTimelinePosition(0);
+
+    public static void DrawIfInRect(this MTexture mTexture, Rectangle rect, Vector2 pos, Vector2 origin, Color color)
+    {
+        if (rect.Contains(new Rectangle((int) pos.X - (int) origin.X, (int) pos.Y - (int) origin.Y, mTexture.Width, mTexture.Height)))
+            mTexture.Draw(pos, origin, color);
+    }
 }

--- a/src/Utils/Util.cs
+++ b/src/Utils/Util.cs
@@ -275,4 +275,43 @@ public static class Util
         }
         action(1.0f);
     }
+
+    public static void DrawBlockStyle(Camera camera, Vector2 pos, float width, float height, MTexture[,] ninSlice, Sprite middle, Color color)
+    {
+        Rectangle cameraBounds = camera.GetBounds();
+        if (pos.X + width < cameraBounds.Left || pos.Y + height < cameraBounds.Top || pos.X > cameraBounds.Right || pos.Y > cameraBounds.Bottom)
+            return;
+
+        cameraBounds.Inflate(ninSlice[0, 0].Width, ninSlice[0, 0].Height);
+
+        int tilesX = (int) (width / 8f);
+        int tilesY = (int) (height / 8f);
+        ninSlice[0, 0].DrawIfInRect(cameraBounds, pos + new Vector2(0f, 0f), Vector2.Zero, color);
+        ninSlice[2, 0].DrawIfInRect(cameraBounds, pos + new Vector2(width - 8f, 0f), Vector2.Zero, color);
+        ninSlice[0, 2].DrawIfInRect(cameraBounds, pos + new Vector2(0f, height - 8f), Vector2.Zero, color);
+        ninSlice[2, 2].DrawIfInRect(cameraBounds, pos + new Vector2(width - 8f, height - 8f), Vector2.Zero, color);
+        for (int i = 1; i < tilesX - 1; i++)
+        {
+            ninSlice[1, 0].DrawIfInRect(cameraBounds, pos + new Vector2(i * 8, 0f), Vector2.Zero, color);
+            ninSlice[1, 2].DrawIfInRect(cameraBounds, pos + new Vector2(i * 8, height - 8f), Vector2.Zero, color);
+        }
+        for (int i = 1; i < tilesY - 1; i++)
+        {
+            ninSlice[0, 1].DrawIfInRect(cameraBounds, pos + new Vector2(0f, i * 8), Vector2.Zero, color);
+            ninSlice[2, 1].DrawIfInRect(cameraBounds, pos + new Vector2(width - 8f, i * 8), Vector2.Zero, color);
+        }
+        for (int i = 1; i < tilesX - 1; i++)
+        {
+            for (int j = 1; j < tilesY - 1; j++)
+            {
+                ninSlice[1, 1].DrawIfInRect(cameraBounds, pos + (new Vector2(i, j) * 8f), Vector2.Zero, color);
+            }
+        }
+        if (middle != null)
+        {
+            middle.Color = color;
+            middle.RenderPosition = pos + new Vector2(width / 2f, height / 2f);
+            middle.Render();
+        }
+    }
 }


### PR DESCRIPTION
Swap block PathRenderers will now cull offscreen textures