### PR TITLE
fix dream falling blocks not landing properly

### DIFF
--- a/Ahorn/entities/dreamBlocks/DreamFallingBlock.jl
+++ b/Ahorn/entities/dreamBlocks/DreamFallingBlock.jl
@@ -15,6 +15,7 @@ const entityData = appendkwargs(CustomDreamBlockData, :(
     indicatorAtStart::Bool=false,
     chained::Bool=false,
     chainTexture::String="objects/CommunalHelper/chains/chain",
+    legacyLandingBehavior::Bool=false,
 ))
 @mapdefdata Entity "CommunalHelper/DreamFallingBlock" DreamFallingBlock entityData
 

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -114,6 +114,7 @@ placements.entities.CommunalHelper/DreamFallingBlock.tooltips.indicator=Renders 
 placements.entities.CommunalHelper/DreamFallingBlock.tooltips.indicatorAtStart=Makes the indicator (if enabled) visible before the block is triggered.
 placements.entities.CommunalHelper/DreamFallingBlock.tooltips.quickDestroy=Makes this Dream Falling Block shatter a little faster.
 placements.entities.CommunalHelper/DreamFallingBlock.tooltips.chainTexture=The texture for this Dream Falling Block's chain (if chained).
+placements.entities.CommunalHelper/DreamFallingBlock.tooltips.legacyLandingBehavior=Whether the Dream Falling Block should not emit particles or make sound when landing, and immediately resume falling if the platform it lands on is removed.
 
 # -- Dream Move Block --
 placements.entities.CommunalHelper/DreamMoveBlock.tooltips.below=Determines whether the Dream Move Block should render below foreground tiles.

--- a/Loenn/entities/dream_blocks/dream_falling_block.lua
+++ b/Loenn/entities/dream_blocks/dream_falling_block.lua
@@ -41,7 +41,8 @@ dreamFallingBlock.placements = {
             quickDestroy = false,
             noCollide = false,
             forceShake = false,
-            chained = false
+            chained = false,
+            legacyLandingBehavior = false
         }
     },
     {
@@ -63,7 +64,8 @@ dreamFallingBlock.placements = {
             indicator = false,
             indicatorAtStart = false,
             chained = true,
-            chainTexture = "objects/CommunalHelper/chains/chain"
+            chainTexture = "objects/CommunalHelper/chains/chain",
+            legacyLandingBehavior = false
         }
     }
 }

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -330,6 +330,7 @@ entities.CommunalHelper/DreamFallingBlock.attributes.description.indicator=Rende
 entities.CommunalHelper/DreamFallingBlock.attributes.description.indicatorAtStart=Makes the indicator (if enabled) visible before the block is triggered.
 entities.CommunalHelper/DreamFallingBlock.attributes.description.quickDestroy=Makes this Dream Falling Block shatter a little faster.
 entities.CommunalHelper/DreamFallingBlock.attributes.description.chainTexture=The texture for this Dream Falling Block's chain (if chained).
+entities.CommunalHelper/DreamFallingBlock.attributes.description.legacyLandingBehavior=Whether the Dream Falling Block should not emit particles or make sound when landing, and immediately resume falling if the platform it lands on is removed.
 
 # Dream Switch Gate
 entities.CommunalHelper/DreamSwitchGate.placements.name.dream_switch_gate=Dream Switch Gate

--- a/src/Entities/DreamBlocks/DreamFallingBlock.cs
+++ b/src/Entities/DreamBlocks/DreamFallingBlock.cs
@@ -17,11 +17,14 @@ public class DreamFallingBlock : CustomDreamBlock
     protected bool removeWhenOutOfLevel = false;
     protected virtual bool Held => CollideCheck<Platform>(Position + new Vector2(0f, 1f));
 
+    private readonly bool legacyLandingBehavior;
+
     public DreamFallingBlock(EntityData data, Vector2 offset)
         : base(data, offset)
     {
         noCollide = data.Bool("noCollide", false);
         forceShake = data.Bool("forceShake", false);
+        legacyLandingBehavior = data.Bool("legacyLandingBehavior", true);
 
         Add(new Coroutine(Sequence()));
     }
@@ -197,7 +200,7 @@ public class DreamFallingBlock : CustomDreamBlock
 
     protected virtual bool ShouldStopFalling()
     {
-        return false;
+        return !legacyLandingBehavior && hasLanded;
     }
 
     private void ShakeSfx()


### PR DESCRIPTION
apparently the method which was supposed to check whether a dream falling block should stop falling was always returning `false`, this fixes that by making it return `hasLanded` instead (which is what i assume it was meant to do?)
only affects newly placed blocks by default so if any maps are depending on the old behavior they shouldn't break i think (this has been a thing since 2021 apparently so i'm assuming someone has used it somewhere at some point)