### PR TITLE
Allow changing the break and respawn time of all custom move blocks

### DIFF
--- a/Loenn/entities/cassette_blocks/cassette_move_block.lua
+++ b/Loenn/entities/cassette_blocks/cassette_move_block.lua
@@ -49,6 +49,8 @@ for i = 1, 4 do
             direction = "Right",
             moveSpeed = 60.0,
             oldConnectionBehavior = false,
+            crashTime = 0.15,
+            regenTime = 3.0,
         }
     }
 end

--- a/Loenn/entities/cassette_blocks/cassette_move_block.lua
+++ b/Loenn/entities/cassette_blocks/cassette_move_block.lua
@@ -51,6 +51,7 @@ for i = 1, 4 do
             oldConnectionBehavior = false,
             crashTime = 0.15,
             regenTime = 3.0,
+            shakeOnCollision = true,
         }
     }
 end

--- a/Loenn/entities/connected_blocks/connected_move_block.lua
+++ b/Loenn/entities/connected_blocks/connected_move_block.lua
@@ -59,6 +59,7 @@ for i, direction in ipairs(enums.move_block_directions) do
             outline = true,
             crashTime = 0.15,
             regenTime = 3.0,
+            shakeOnCollision = true,
         }
     }
 end
@@ -78,6 +79,7 @@ connectedMoveBlock.placements[5] = {
         outline = true,
         crashTime = 0.15,
         regenTime = 3.0,
+        shakeOnCollision = true,
     }
 }
 connectedMoveBlock.placements[6] = {
@@ -96,6 +98,7 @@ connectedMoveBlock.placements[6] = {
         outline = true,
         crashTime = 0.15,
         regenTime = 3.0,
+        shakeOnCollision = true,
         activatorFlags = "_pressed",
         breakerFlags = "_obstructed",
         onActivateFlags = "",

--- a/Loenn/entities/connected_blocks/connected_move_block.lua
+++ b/Loenn/entities/connected_blocks/connected_move_block.lua
@@ -20,7 +20,7 @@ local arrowTextures = {
 
 connectedMoveBlock.name = "CommunalHelper/ConnectedMoveBlock"
 connectedMoveBlock.depth = -1
-connectedMoveBlock.minimumSize = {16, 16}
+connectedMoveBlock.minimumSize = { 16, 16 }
 connectedMoveBlock.fieldInformation = {
     direction = {
         options = enums.move_block_directions,
@@ -56,7 +56,9 @@ for i, direction in ipairs(enums.move_block_directions) do
             idleColor = "474070",
             pressedColor = "30b335",
             breakColor = "cc2541",
-            outline = true
+            outline = true,
+            crashTime = 0.15,
+            regenTime = 3.0,
         }
     }
 end
@@ -73,7 +75,9 @@ connectedMoveBlock.placements[5] = {
         idleColor = "474070",
         pressedColor = "30b335",
         breakColor = "cc2541",
-        outline = true
+        outline = true,
+        crashTime = 0.15,
+        regenTime = 3.0,
     }
 }
 connectedMoveBlock.placements[6] = {
@@ -90,6 +94,8 @@ connectedMoveBlock.placements[6] = {
         pressedColor = "30b335",
         breakColor = "cc2541",
         outline = true,
+        crashTime = 0.15,
+        regenTime = 3.0,
         activatorFlags = "_pressed",
         breakerFlags = "_obstructed",
         onActivateFlags = "",
@@ -99,7 +105,7 @@ connectedMoveBlock.placements[6] = {
     }
 }
 
-local highlightColor = {59 / 255, 50 / 255, 101 / 255}
+local highlightColor = { 59 / 255, 50 / 255, 101 / 255 }
 
 local function getSearchPredicate()
     return function(target)
@@ -190,7 +196,8 @@ function connectedMoveBlock.sprite(room, entity)
 
     local sprites = {}
 
-    local highlightRectangle = drawableRectangle.fromRectangle("fill", x + 2, y + 2, width - 4, height - 4, highlightColor)
+    local highlightRectangle = drawableRectangle.fromRectangle("fill", x + 2, y + 2, width - 4, height - 4,
+        highlightColor)
     table.insert(sprites, highlightRectangle:getDrawableSprite())
 
     local relevantBlocks = utils.filter(getSearchPredicate(), room.entities)
@@ -216,8 +223,10 @@ function connectedMoveBlock.sprite(room, entity)
     arrowSprite:addPosition(math.floor(width / 2), math.floor(height / 2))
 
     local arrowSpriteWidth, arrowSpriteHeight = arrowSprite.meta.width, arrowSprite.meta.height
-    local arrowX, arrowY = x + math.floor((width - arrowSpriteWidth) / 2), y + math.floor((height - arrowSpriteHeight) / 2)
-    local arrowRectangle = drawableRectangle.fromRectangle("fill", arrowX, arrowY, arrowSpriteWidth, arrowSpriteHeight, highlightColor)
+    local arrowX, arrowY = x + math.floor((width - arrowSpriteWidth) / 2),
+        y + math.floor((height - arrowSpriteHeight) / 2)
+    local arrowRectangle = drawableRectangle.fromRectangle("fill", arrowX, arrowY, arrowSpriteWidth, arrowSpriteHeight,
+        highlightColor)
 
     table.insert(sprites, arrowRectangle:getDrawableSprite())
     table.insert(sprites, arrowSprite)

--- a/Loenn/entities/connected_blocks/equation_move_block.lua
+++ b/Loenn/entities/connected_blocks/equation_move_block.lua
@@ -31,7 +31,7 @@ local equations = {
 
 equationMoveBlock.name = "CommunalHelper/EquationMoveBlock"
 equationMoveBlock.depth = -1
-equationMoveBlock.minimumSize = {16, 16}
+equationMoveBlock.minimumSize = { 16, 16 }
 equationMoveBlock.fieldInformation = {
     direction = {
         options = enums.move_block_directions,
@@ -77,7 +77,9 @@ for i, direction in ipairs(enums.move_block_directions) do
             idleColor = "474070",
             pressedColor = "30b335",
             breakColor = "cc2541",
-            outline = true
+            outline = true,
+            crashTime = 0.15,
+            regenTime = 3.0,
         }
     }
 end
@@ -96,7 +98,9 @@ equationMoveBlock.placements[5] = {
         idleColor = "474070",
         pressedColor = "30b335",
         breakColor = "cc2541",
-        outline = true
+        outline = true,
+        crashTime = 0.15,
+        regenTime = 3.0,
     }
 }
 equationMoveBlock.placements[6] = {
@@ -115,6 +119,8 @@ equationMoveBlock.placements[6] = {
         pressedColor = "30b335",
         breakColor = "cc2541",
         outline = true,
+        crashTime = 0.15,
+        regenTime = 3.0,
         activatorFlags = "_pressed",
         breakerFlags = "_obstructed",
         onActivateFlags = "",
@@ -124,7 +130,7 @@ equationMoveBlock.placements[6] = {
     }
 }
 
-local highlightColor = {59 / 255, 50 / 255, 101 / 255}
+local highlightColor = { 59 / 255, 50 / 255, 101 / 255 }
 
 local function getSearchPredicate()
     return function(target)
@@ -215,7 +221,8 @@ function equationMoveBlock.sprite(room, entity)
 
     local sprites = {}
 
-    local highlightRectangle = drawableRectangle.fromRectangle("fill", x + 2, y + 2, width - 4, height - 4, highlightColor)
+    local highlightRectangle = drawableRectangle.fromRectangle("fill", x + 2, y + 2, width - 4, height - 4,
+        highlightColor)
     table.insert(sprites, highlightRectangle:getDrawableSprite())
 
     local relevantBlocks = utils.filter(getSearchPredicate(), room.entities)
@@ -241,8 +248,10 @@ function equationMoveBlock.sprite(room, entity)
     arrowSprite:addPosition(math.floor(width / 2), math.floor(height / 2))
 
     local arrowSpriteWidth, arrowSpriteHeight = arrowSprite.meta.width, arrowSprite.meta.height
-    local arrowX, arrowY = x + math.floor((width - arrowSpriteWidth) / 2), y + math.floor((height - arrowSpriteHeight) / 2)
-    local arrowRectangle = drawableRectangle.fromRectangle("fill", arrowX, arrowY, arrowSpriteWidth, arrowSpriteHeight, highlightColor)
+    local arrowX, arrowY = x + math.floor((width - arrowSpriteWidth) / 2),
+        y + math.floor((height - arrowSpriteHeight) / 2)
+    local arrowRectangle = drawableRectangle.fromRectangle("fill", arrowX, arrowY, arrowSpriteWidth, arrowSpriteHeight,
+        highlightColor)
 
     table.insert(sprites, arrowRectangle:getDrawableSprite())
     table.insert(sprites, arrowSprite)

--- a/Loenn/entities/connected_blocks/equation_move_block.lua
+++ b/Loenn/entities/connected_blocks/equation_move_block.lua
@@ -80,6 +80,7 @@ for i, direction in ipairs(enums.move_block_directions) do
             outline = true,
             crashTime = 0.15,
             regenTime = 3.0,
+            shakeOnCollision = true,
         }
     }
 end
@@ -101,6 +102,7 @@ equationMoveBlock.placements[5] = {
         outline = true,
         crashTime = 0.15,
         regenTime = 3.0,
+        shakeOnCollision = true,
     }
 }
 equationMoveBlock.placements[6] = {
@@ -121,6 +123,7 @@ equationMoveBlock.placements[6] = {
         outline = true,
         crashTime = 0.15,
         regenTime = 3.0,
+        shakeOnCollision = true,
         activatorFlags = "_pressed",
         breakerFlags = "_obstructed",
         onActivateFlags = "",

--- a/Loenn/entities/dream_blocks/dream_move_block.lua
+++ b/Loenn/entities/dream_blocks/dream_move_block.lua
@@ -11,7 +11,7 @@ local moveSpeeds = {
 }
 
 dreamMoveBlock.name = "CommunalHelper/DreamMoveBlock"
-dreamMoveBlock.minimumSize = {16, 16}
+dreamMoveBlock.minimumSize = { 16, 16 }
 dreamMoveBlock.fieldInformation = {
     direction = {
         options = enums.move_block_directions,
@@ -69,6 +69,8 @@ dreamMoveBlock.placements = {
             moveSpeed = 60.0,
             noCollide = false,
             canSteer = false,
+            crashTime = 0.15,
+            regenTime = 3.0,
             idleButtonsColor = "FFFFFF",
             movingButtonsColor = "FFFFFF",
             idleArrowColor = "FFFFFF",

--- a/Loenn/entities/dream_blocks/dream_move_block.lua
+++ b/Loenn/entities/dream_blocks/dream_move_block.lua
@@ -71,6 +71,7 @@ dreamMoveBlock.placements = {
             canSteer = false,
             crashTime = 0.15,
             regenTime = 3.0,
+            shakeOnCollision = true,
             idleButtonsColor = "FFFFFF",
             movingButtonsColor = "FFFFFF",
             idleArrowColor = "FFFFFF",
@@ -88,7 +89,8 @@ dreamMoveBlock.fieldOrder = {
     "direction", "moveSpeed",
     "idleButtonsColor", "idleArrowColor", "idleWobbleLinesColor",
     "movingButtonsColor", "movingArrowColor", "movingWobbleLinesColor",
-    "breakingWobbleLinesColor", "breakingCrossColor"
+    "breakingWobbleLinesColor", "breakingCrossColor",
+    "crashTime", "regenTime", "shakeOnCollision"
 }
 
 local arrowTextures = {

--- a/Loenn/entities/misc/move_swap_block.lua
+++ b/Loenn/entities/misc/move_swap_block.lua
@@ -7,8 +7,8 @@ local communalHelper = require("mods").requireFromPlugin("libraries.communal_hel
 local moveSwapBlock = {}
 
 moveSwapBlock.name = "CommunalHelper/MoveSwapBlock"
-moveSwapBlock.minimumSize = {16, 16}
-moveSwapBlock.nodeLimits = {1, 1}
+moveSwapBlock.minimumSize = { 16, 16 }
+moveSwapBlock.nodeLimits = { 1, 1 }
 moveSwapBlock.fieldInformation = {
     theme = {
         editable = false
@@ -42,7 +42,9 @@ moveSwapBlock.placements = {
             freezeOnSwap = true,
             moveSpeed = 60.0,
             moveAcceleration = 300.0,
-            swapSpeedMultiplier = 1.0
+            swapSpeedMultiplier = 1.0,
+            crashTime = 0.15,
+            regenTime = 3.0,
         }
     }
 }
@@ -65,13 +67,13 @@ local themeTextures = {
 }
 
 local middleSpriteData = {
-    ["Up"] = {rot = 0, ox = 0, oy = -1},
-    ["Right"] = {rot = math.pi / 2, ox = 1, oy = 0},
-    ["Down"] = {rot = math.pi, ox = 0, oy = 1},
-    ["Left"] = {rot = math.pi / 2 * 3, ox = -1, oy = 0}
+    ["Up"] = { rot = 0, ox = 0, oy = -1 },
+    ["Right"] = { rot = math.pi / 2, ox = 1, oy = 0 },
+    ["Down"] = { rot = math.pi, ox = 0, oy = 1 },
+    ["Left"] = { rot = math.pi / 2 * 3, ox = -1, oy = 0 }
 }
 
-local nodeFrameColor = {1.0, 1.0, 1.0, 0.7}
+local nodeFrameColor = { 1.0, 1.0, 1.0, 0.7 }
 
 local frameNinePatchOptions = {
     mode = "fill",
@@ -97,7 +99,7 @@ local function addBlockSprites(sprites, entity, position, frameTexture, middleTe
     local direction = entity.direction or "Right"
     local middleData = middleSpriteData[direction]
 
-    local arrowSprite = drawableSprite.fromTexture(middleTexture, {rotation = middleData.rot})
+    local arrowSprite = drawableSprite.fromTexture(middleTexture, { rotation = middleData.rot })
     arrowSprite:addPosition(x + math.floor(width / 2), y + math.floor(height / 2))
     arrowSprite.depth = blockDepth
 
@@ -153,7 +155,7 @@ function moveSwapBlock.selection(room, entity)
     local nodeX, nodeY = nodes[1].x or x, nodes[1].y or y
     local width, height = entity.width or 8, entity.height or 8
 
-    return utils.rectangle(x, y, width, height), {utils.rectangle(nodeX, nodeY, width, height)}
+    return utils.rectangle(x, y, width, height), { utils.rectangle(nodeX, nodeY, width, height) }
 end
 
 return moveSwapBlock

--- a/Loenn/entities/misc/move_swap_block.lua
+++ b/Loenn/entities/misc/move_swap_block.lua
@@ -45,6 +45,7 @@ moveSwapBlock.placements = {
             swapSpeedMultiplier = 1.0,
             crashTime = 0.15,
             regenTime = 3.0,
+            shakeOnCollision = true,
         }
     }
 }

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -186,6 +186,7 @@ entities.CommunalHelper/CassetteMoveBlock.attributes.name.crashTime=Break Time
 entities.CommunalHelper/CassetteMoveBlock.attributes.name.regenTime=Respawn Time
 entities.CommunalHelper/CassetteMoveBlock.attributes.description.crashTime=The time it takes for this Cassette Move Block to break when hitting a solid in seconds.
 entities.CommunalHelper/CassetteMoveBlock.attributes.description.regenTime=The time it takes for this Cassette Move Block to respawn after breaking in seconds.
+entities.CommunalHelper/CassetteMoveBlock.attributes.description.shakeOnCollision=Whether this Cassette Move Block should start shaking if it collides with a solid for longer than the default break time.
 
 # Cassette Swap Block
 entities.CommunalHelper/CassetteSwapBlock.placements.name.cassette_block_0=Cassette Swap Block (0 - Blue)
@@ -313,6 +314,7 @@ entities.CommunalHelper/DreamMoveBlock.attributes.name.crashTime=Break Time
 entities.CommunalHelper/DreamMoveBlock.attributes.name.regenTime=Respawn Time
 entities.CommunalHelper/DreamMoveBlock.attributes.description.crashTime=The time it takes for this Dream Move Block to break when hitting a solid in seconds.
 entities.CommunalHelper/DreamMoveBlock.attributes.description.regenTime=The time it takes for this Dream Move Block to respawn after breaking in seconds.
+entities.CommunalHelper/DreamMoveBlock.attributes.description.shakeOnCollision=Whether this Dream Move Block should start shaking if it collides with a solid for longer than the default break time.
 entities.CommunalHelper/DreamMoveBlock.Attributes.description.idleButtonsColor=Body and buttons's color when the block is idle.
 entities.CommunalHelper/DreamMoveBlock.Attributes.description.idleArrowColor=Arrow's color when the block is idle.
 entities.CommunalHelper/DreamMoveBlock.Attributes.description.idleWobbleLinesColor=Wobble lines's color when the block is idle.
@@ -423,6 +425,7 @@ entities.CommunalHelper/ConnectedMoveBlock.attributes.name.crashTime=Break Time
 entities.CommunalHelper/ConnectedMoveBlock.attributes.name.regenTime=Respawn Time
 entities.CommunalHelper/ConnectedMoveBlock.attributes.description.crashTime=The time it takes for this Connected Move Block to break when hitting a solid in seconds.
 entities.CommunalHelper/ConnectedMoveBlock.attributes.description.regenTime=The time it takes for this Connected Move Block to respawn after breaking in seconds.
+entities.CommunalHelper/ConnectedMoveBlock.attributes.description.shakeOnCollision=Whether this Connected Move Block should start shaking if it collides with a solid for longer than the default break time.
 
 # Connected Temple Cracked Block
 entities.CommunalHelper/ConnectedTempleCrackedBlock.placements.name.normal=Connected Temple Cracked Block
@@ -456,6 +459,7 @@ entities.CommunalHelper/EquationMoveBlock.attributes.name.crashTime=Break Time
 entities.CommunalHelper/EquationMoveBlock.attributes.name.regenTime=Respawn Time
 entities.CommunalHelper/EquationMoveBlock.attributes.description.crashTime=The time it takes for this Equation Move Block to break when hitting a solid in seconds.
 entities.CommunalHelper/EquationMoveBlock.attributes.description.regenTime=The time it takes for this Equation Move Block to respawn after breaking in seconds.
+entities.CommunalHelper/EquationMoveBlock.attributes.description.shakeOnCollision=Whether this Equation Move Block should start shaking if it collides with a solid for longer than the default break time.
 
 # Bouncy Panel
 entities.CommunalHelper/BouncyPanel.placements.name.up=Bouncy Panel (Up)
@@ -599,6 +603,7 @@ entities.CommunalHelper/MoveSwapBlock.attributes.name.crashTime=Break Time
 entities.CommunalHelper/MoveSwapBlock.attributes.name.regenTime=Respawn Time
 entities.CommunalHelper/MoveSwapBlock.attributes.description.crashTime=The time it takes for this Move Swap Block to break when hitting a solid in seconds.
 entities.CommunalHelper/MoveSwapBlock.attributes.description.regenTime=The time it takes for this Move Swap Block to respawn after breaking in seconds.
+entities.CommunalHelper/MoveSwapBlock.attributes.description.shakeOnCollision=Whether this Move Swap Block should start shaking if it collides with a solid for longer than the default break time.
 
 # Player Bubble Region
 entities.CommunalHelper/PlayerBubbleRegion.placements.name.player_bubble_region=Player Bubble Region

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -182,6 +182,10 @@ entities.CommunalHelper/CassetteMoveBlock.attributes.description.index=The color
 entities.CommunalHelper/CassetteMoveBlock.attributes.description.tempo=The tempo of the cassette music in the room.
 entities.CommunalHelper/CassetteMoveBlock.attributes.description.customColor=Optional hexadecimal color code, visual-only change.
 entities.CommunalHelper/CassetteMoveBlock.attributes.description.oldConnectionBehavior=Force the old texture connection behavior (cassette entities connect to anything around them that is on the same index).
+entities.CommunalHelper/CassetteMoveBlock.attributes.name.crashTime=Break Time
+entities.CommunalHelper/CassetteMoveBlock.attributes.name.regenTime=Respawn Time
+entities.CommunalHelper/CassetteMoveBlock.attributes.description.crashTime=The time it takes for this Cassette Move Block to break when hitting a solid in seconds.
+entities.CommunalHelper/CassetteMoveBlock.attributes.description.regenTime=The time it takes for this Cassette Move Block to respawn after breaking in seconds.
 
 # Cassette Swap Block
 entities.CommunalHelper/CassetteSwapBlock.placements.name.cassette_block_0=Cassette Swap Block (0 - Blue)
@@ -305,6 +309,10 @@ entities.CommunalHelper/DreamMoveBlock.attributes.description.noCollide=Whether 
 entities.CommunalHelper/DreamMoveBlock.attributes.description.featherMode=Whether the Dream Move Block has the Dream Block Feather controls enabled.
 entities.CommunalHelper/DreamMoveBlock.attributes.description.oneUse=Whether the Dream Move Block should shatter upon exit.
 entities.CommunalHelper/DreamMoveBlock.attributes.description.quickDestroy=Makes this Dream Move Block shatter a little faster.
+entities.CommunalHelper/DreamMoveBlock.attributes.name.crashTime=Break Time
+entities.CommunalHelper/DreamMoveBlock.attributes.name.regenTime=Respawn Time
+entities.CommunalHelper/DreamMoveBlock.attributes.description.crashTime=The time it takes for this Dream Move Block to break when hitting a solid in seconds.
+entities.CommunalHelper/DreamMoveBlock.attributes.description.regenTime=The time it takes for this Dream Move Block to respawn after breaking in seconds.
 entities.CommunalHelper/DreamMoveBlock.Attributes.description.idleButtonsColor=Body and buttons's color when the block is idle.
 entities.CommunalHelper/DreamMoveBlock.Attributes.description.idleArrowColor=Arrow's color when the block is idle.
 entities.CommunalHelper/DreamMoveBlock.Attributes.description.idleWobbleLinesColor=Wobble lines's color when the block is idle.
@@ -411,6 +419,10 @@ entities.CommunalHelper/ConnectedMoveBlock.attributes.description.idleColor=The 
 entities.CommunalHelper/ConnectedMoveBlock.attributes.description.pressedColor=The color of the arrow when moving.
 entities.CommunalHelper/ConnectedMoveBlock.attributes.description.breakColor=The color of the arrow when breaking.
 entities.CommunalHelper/ConnectedMoveBlock.attributes.description.outline=Gives this Move Block an outline.
+entities.CommunalHelper/ConnectedMoveBlock.attributes.name.crashTime=Break Time
+entities.CommunalHelper/ConnectedMoveBlock.attributes.name.regenTime=Respawn Time
+entities.CommunalHelper/ConnectedMoveBlock.attributes.description.crashTime=The time it takes for this Connected Move Block to break when hitting a solid in seconds.
+entities.CommunalHelper/ConnectedMoveBlock.attributes.description.regenTime=The time it takes for this Connected Move Block to respawn after breaking in seconds.
 
 # Connected Temple Cracked Block
 entities.CommunalHelper/ConnectedTempleCrackedBlock.placements.name.normal=Connected Temple Cracked Block
@@ -440,6 +452,10 @@ entities.CommunalHelper/EquationMoveBlock.attributes.description.constantB=The v
 entities.CommunalHelper/EquationMoveBlock.attributes.description.onActivateFlags=Flags set when this block is activated.
 entities.CommunalHelper/EquationMoveBlock.attributes.description.onBreakFlags=Flags set when this block is broken.
 entities.CommunalHelper/EquationMoveBlock.attributes.description.waitForFlags=Makes this block start off invisible and waiting for flags to become visible (and collidable).
+entities.CommunalHelper/EquationMoveBlock.attributes.name.crashTime=Break Time
+entities.CommunalHelper/EquationMoveBlock.attributes.name.regenTime=Respawn Time
+entities.CommunalHelper/EquationMoveBlock.attributes.description.crashTime=The time it takes for this Equation Move Block to break when hitting a solid in seconds.
+entities.CommunalHelper/EquationMoveBlock.attributes.description.regenTime=The time it takes for this Equation Move Block to respawn after breaking in seconds.
 
 # Bouncy Panel
 entities.CommunalHelper/BouncyPanel.placements.name.up=Bouncy Panel (Up)
@@ -579,6 +595,10 @@ entities.CommunalHelper/MoveSwapBlock.attributes.description.moveSpeed=The maxim
 entities.CommunalHelper/MoveSwapBlock.attributes.description.returns=Whether the block will return after swapping.
 entities.CommunalHelper/MoveSwapBlock.attributes.description.swapSpeedMultiplier=The speed multiplier for swapping.
 entities.CommunalHelper/MoveSwapBlock.attributes.description.theme=Unsupported by this entity!
+entities.CommunalHelper/MoveSwapBlock.attributes.name.crashTime=Break Time
+entities.CommunalHelper/MoveSwapBlock.attributes.name.regenTime=Respawn Time
+entities.CommunalHelper/MoveSwapBlock.attributes.description.crashTime=The time it takes for this Move Swap Block to break when hitting a solid in seconds.
+entities.CommunalHelper/MoveSwapBlock.attributes.description.regenTime=The time it takes for this Move Swap Block to respawn after breaking in seconds.
 
 # Player Bubble Region
 entities.CommunalHelper/PlayerBubbleRegion.placements.name.player_bubble_region=Player Bubble Region

--- a/src/Entities/CassetteBlocks/CassetteMoveBlock.cs
+++ b/src/Entities/CassetteBlocks/CassetteMoveBlock.cs
@@ -30,6 +30,7 @@ public class CassetteMoveBlock : CustomCassetteBlock
     private const float CrashStartShakingTime = 0.15f;
     private readonly float crashTime;
     private readonly float regenTime;
+    private readonly bool shakeOnCollision;
 
     private readonly float moveSpeed;
     public Directions Direction;
@@ -60,7 +61,7 @@ public class CassetteMoveBlock : CustomCassetteBlock
     private readonly ParticleType P_Break;
     private readonly ParticleType P_BreakPressed;
 
-    public CassetteMoveBlock(Vector2 position, EntityID id, int width, int height, Directions direction, float moveSpeed, int index, float tempo, bool oldConnectionBehavior, Color? overrideColor, float crashTime, float regenTime)
+    public CassetteMoveBlock(Vector2 position, EntityID id, int width, int height, Directions direction, float moveSpeed, int index, float tempo, bool oldConnectionBehavior, Color? overrideColor, float crashTime, float regenTime, bool shakeOnCollision)
         : base(position, id, width, height, index, tempo, true, oldConnectionBehavior, dynamicHitbox: true, overrideColor)
     {
         startPosition = position;
@@ -71,6 +72,7 @@ public class CassetteMoveBlock : CustomCassetteBlock
 
         this.crashTime = crashTime;
         this.regenTime = regenTime;
+        this.shakeOnCollision = shakeOnCollision;
 
         Add(moveSfx = new SoundSource());
         Add(new Coroutine(Controller()));
@@ -92,7 +94,7 @@ public class CassetteMoveBlock : CustomCassetteBlock
     }
 
     public CassetteMoveBlock(EntityData data, Vector2 offset, EntityID id)
-        : this(data.Position + offset, id, data.Width, data.Height, data.Enum("direction", Directions.Left), data.Bool("fast") ? FastMoveSpeed : data.Float("moveSpeed", MoveSpeed), data.Int("index"), data.Float("tempo", 1f), data.Bool("oldConnectionBehavior", true), data.HexColorNullable("customColor"), data.Float("crashTime", 0.15f), data.Float("regenTime", 3f))
+        : this(data.Position + offset, id, data.Width, data.Height, data.Enum("direction", Directions.Left), data.Bool("fast") ? FastMoveSpeed : data.Float("moveSpeed", MoveSpeed), data.Int("index"), data.Float("tempo", 1f), data.Bool("oldConnectionBehavior", true), data.HexColorNullable("customColor"), data.Float("crashTime", 0.15f), data.Float("regenTime", 3f), data.Bool("shakeOnCollision", true))
     {
     }
 
@@ -185,7 +187,7 @@ public class CassetteMoveBlock : CustomCassetteBlock
                 {
                     moveSfx.Param("arrow_stop", 1f);
                     crashResetTimer = CrashResetTime;
-                    if (crashStartShakingTimer < 0f)
+                    if (crashStartShakingTimer < 0f && shakeOnCollision)
                         StartShaking();
                     if (!(crashTimer > 0f))
                     {

--- a/src/Entities/CassetteBlocks/CassetteMoveBlock.cs
+++ b/src/Entities/CassetteBlocks/CassetteMoveBlock.cs
@@ -185,7 +185,7 @@ public class CassetteMoveBlock : CustomCassetteBlock
                 }
                 if (hit)
                 {
-                    moveSfx.Param("arrow_stop", 1f);
+                    moveSfx.Param("arrow_stop", crashTimer > 0.15f ? 0.5f : 1f);
                     crashResetTimer = CrashResetTime;
                     if (crashStartShakingTimer < 0f && shakeOnCollision)
                         StartShaking();

--- a/src/Entities/CassetteBlocks/CassetteMoveBlock.cs
+++ b/src/Entities/CassetteBlocks/CassetteMoveBlock.cs
@@ -203,6 +203,7 @@ public class CassetteMoveBlock : CustomCassetteBlock
                     }
                     else
                     {
+                        StopShaking();
                         crashTimer = crashTime;
                         crashStartShakingTimer = CrashStartShakingTime;
                     }

--- a/src/Entities/ConnectedBlocks/ConnectedMoveBlock.cs
+++ b/src/Entities/ConnectedBlocks/ConnectedMoveBlock.cs
@@ -361,6 +361,7 @@ public class ConnectedMoveBlock : ConnectedSolid
                     }
                     else
                     {
+                        StopShaking();
                         crashTimer = crashTime;
                         crashStartShakingTimer = CrashStartShakingTime;
                     }

--- a/src/Entities/ConnectedBlocks/ConnectedMoveBlock.cs
+++ b/src/Entities/ConnectedBlocks/ConnectedMoveBlock.cs
@@ -343,7 +343,7 @@ public class ConnectedMoveBlock : ConnectedSolid
 
                 if (startingBroken || AnySetEnabled(BreakerFlags))
                 {
-                    moveSfx.Param("arrow_stop", 1f);
+                    moveSfx.Param("arrow_stop", crashTimer > 0.15f ? 0.5f : 1f);
                     crashResetTimer = CrashResetTime;
                     if (crashStartShakingTimer < 0f && shakeOnCollision)
                         StartShaking();

--- a/src/Entities/ConnectedBlocks/ConnectedMoveBlock.cs
+++ b/src/Entities/ConnectedBlocks/ConnectedMoveBlock.cs
@@ -96,6 +96,7 @@ public class ConnectedMoveBlock : ConnectedSolid
     protected const float CrashStartShakingTime = 0.15f;
     protected readonly float crashTime;
     protected readonly float regenTime;
+    protected readonly bool shakeOnCollision;
 
     protected float moveSpeed;
     protected bool triggered;
@@ -212,6 +213,7 @@ public class ConnectedMoveBlock : ConnectedSolid
 
         crashTime = data.Float("crashTime", 0.15f);
         regenTime = data.Float("regenTime", 3f);
+        shakeOnCollision = data.Bool("shakeOnCollision", true);
     }
 
     public ConnectedMoveBlock(Vector2 position, int width, int height, MoveBlock.Directions direction, float moveSpeed)
@@ -343,7 +345,7 @@ public class ConnectedMoveBlock : ConnectedSolid
                 {
                     moveSfx.Param("arrow_stop", 1f);
                     crashResetTimer = CrashResetTime;
-                    if (crashStartShakingTimer < 0f)
+                    if (crashStartShakingTimer < 0f && shakeOnCollision)
                         StartShaking();
                     if (!(crashTimer > 0f))
                     {

--- a/src/Entities/ConnectedBlocks/EquationMoveBlock.cs
+++ b/src/Entities/ConnectedBlocks/EquationMoveBlock.cs
@@ -141,7 +141,7 @@ internal class EquationMoveBlock : ConnectedMoveBlock
 
                 if (startingBroken || AnySetEnabled(BreakerFlags) || targetAngle == double.NaN)
                 {
-                    moveSfx.Param("arrow_stop", 1f);
+                    moveSfx.Param("arrow_stop", crashTimer > 0.15f ? 0.5f : 1f);
                     crashResetTimer = CrashResetTime;
                     if (crashStartShakingTimer < 0f && shakeOnCollision)
                         StartShaking();

--- a/src/Entities/ConnectedBlocks/EquationMoveBlock.cs
+++ b/src/Entities/ConnectedBlocks/EquationMoveBlock.cs
@@ -143,7 +143,7 @@ internal class EquationMoveBlock : ConnectedMoveBlock
                 {
                     moveSfx.Param("arrow_stop", 1f);
                     crashResetTimer = CrashResetTime;
-                    if (crashStartShakingTimer < 0f)
+                    if (crashStartShakingTimer < 0f && shakeOnCollision)
                         StartShaking();
                     if (!(crashTimer > 0f))
                     {

--- a/src/Entities/ConnectedBlocks/EquationMoveBlock.cs
+++ b/src/Entities/ConnectedBlocks/EquationMoveBlock.cs
@@ -82,8 +82,9 @@ internal class EquationMoveBlock : ConnectedMoveBlock
             moveSfx.Play(SFX.game_04_arrowblock_move_loop);
             moveSfx.Param("arrow_stop", 0f);
             StopPlayerRunIntoAnimation = false;
-            float crashTimer = 0.15f;
-            float crashResetTimer = 0.1f;
+            float crashTimer = crashTime;
+            float crashResetTimer = CrashResetTime;
+            float crashStartShakingTimer = CrashStartShakingTime;
             while (true)
             {
                 if (Scene.OnInterval(0.02f))
@@ -141,12 +142,15 @@ internal class EquationMoveBlock : ConnectedMoveBlock
                 if (startingBroken || AnySetEnabled(BreakerFlags) || targetAngle == double.NaN)
                 {
                     moveSfx.Param("arrow_stop", 1f);
-                    crashResetTimer = 0.1f;
+                    crashResetTimer = CrashResetTime;
+                    if (crashStartShakingTimer < 0f)
+                        StartShaking();
                     if (!(crashTimer > 0f))
                     {
                         break;
                     }
                     crashTimer -= Engine.DeltaTime;
+                    crashStartShakingTimer -= Engine.DeltaTime;
                 }
                 else
                 {
@@ -157,7 +161,8 @@ internal class EquationMoveBlock : ConnectedMoveBlock
                     }
                     else
                     {
-                        crashTimer = 0.15f;
+                        crashTimer = crashTime;
+                        crashStartShakingTimer = CrashStartShakingTime;
                     }
                 }
                 Level level = Scene as Level;
@@ -215,6 +220,10 @@ internal class EquationMoveBlock : ConnectedMoveBlock
             Position = startPosition;
             Visible = Collidable = false;
 
+            float waitTime = Calc.Clamp(regenTime - 0.8f, 0, float.MaxValue);
+            float debrisShakeTime = Calc.Clamp(regenTime - 0.6f, 0, 0.2f);
+            float debrisMoveTime = Calc.Clamp(regenTime, 0, 0.6f);
+
             if (shouldProcessBreakFlags)
                 foreach (string flag in OnBreakFlags)
                 {
@@ -233,7 +242,7 @@ internal class EquationMoveBlock : ConnectedMoveBlock
                     }
                 }
             curMoveCheck = false;
-            yield return 2.2f;
+            yield return waitTime;
 
             foreach (MoveBlockDebris item in debris)
             {
@@ -253,13 +262,13 @@ internal class EquationMoveBlock : ConnectedMoveBlock
             {
                 item2.StartShaking();
             }
-            yield return 0.2f;
+            yield return debrisShakeTime;
 
             foreach (MoveBlockDebris item3 in debris)
             {
-                item3.ReturnHome(0.65f);
+                item3.ReturnHome(debrisMoveTime + 0.05f);
             }
-            yield return 0.6f;
+            yield return debrisMoveTime;
 
             routine.RemoveSelf();
             foreach (MoveBlockDebris item4 in debris)

--- a/src/Entities/ConnectedBlocks/EquationMoveBlock.cs
+++ b/src/Entities/ConnectedBlocks/EquationMoveBlock.cs
@@ -161,6 +161,7 @@ internal class EquationMoveBlock : ConnectedMoveBlock
                     }
                     else
                     {
+                        StopShaking();
                         crashTimer = crashTime;
                         crashStartShakingTimer = CrashStartShakingTime;
                     }

--- a/src/Entities/DreamBlocks/DreamMoveBlock.cs
+++ b/src/Entities/DreamBlocks/DreamMoveBlock.cs
@@ -363,6 +363,7 @@ public class DreamMoveBlock : CustomDreamBlock
                     }
                     else
                     {
+                        StopShaking();
                         crashTimer = crashTime;
                         crashStartShakingTimer = CrashStartShakingTime;
                     }

--- a/src/Entities/DreamBlocks/DreamMoveBlock.cs
+++ b/src/Entities/DreamBlocks/DreamMoveBlock.cs
@@ -40,6 +40,7 @@ public class DreamMoveBlock : CustomDreamBlock
     private const float CrashStartShakingTime = 0.15f;
     private readonly float crashTime;
     private readonly float regenTime;
+    private readonly bool shakeOnCollision;
 
     private readonly float moveSpeed;
 
@@ -148,6 +149,7 @@ public class DreamMoveBlock : CustomDreamBlock
 
         crashTime = data.Float("crashTime", 0.15f);
         regenTime = data.Float("regenTime", 3f);
+        shakeOnCollision = data.Bool("shakeOnCollision", true);
 
         if (data.Attr("idleButtonsColor", "FFFFFF") != "FFFFFF")
         {
@@ -345,7 +347,7 @@ public class DreamMoveBlock : CustomDreamBlock
                 {
                     moveSfx.Param("arrow_stop", 1f);
                     crashResetTimer = CrashResetTime;
-                    if (crashStartShakingTimer < 0f)
+                    if (crashStartShakingTimer < 0f && shakeOnCollision)
                         StartShaking();
                     if (!(crashTimer > 0f) && !shattering)
                     {

--- a/src/Entities/DreamBlocks/DreamMoveBlock.cs
+++ b/src/Entities/DreamBlocks/DreamMoveBlock.cs
@@ -345,7 +345,7 @@ public class DreamMoveBlock : CustomDreamBlock
                 }
                 if (hit)
                 {
-                    moveSfx.Param("arrow_stop", 1f);
+                    moveSfx.Param("arrow_stop", crashTimer > 0.15f ? 0.5f : 1f);
                     crashResetTimer = CrashResetTime;
                     if (crashStartShakingTimer < 0f && shakeOnCollision)
                         StartShaking();

--- a/src/Entities/Misc/MoveSwapBlock.cs
+++ b/src/Entities/Misc/MoveSwapBlock.cs
@@ -48,6 +48,9 @@ public class MoveSwapBlock : SwapBlock
     private const float MaxAngle = Calc.EighthCircle;
     private const float NoSteerTime = 0.2f;
     private const float CrashResetTime = 0.1f;
+    private const float CrashStartShakingTime = 0.15f;
+    private readonly float crashTime;
+    private readonly float regenTime;
 
     public enum MovementState
     {
@@ -55,9 +58,6 @@ public class MoveSwapBlock : SwapBlock
         Moving,
         Breaking
     }
-    private const float CrashStartShakingTime = 0.15f;
-    private readonly float crashTime;
-    private readonly float regenTime;
 
     public bool Triggered { get; set; }
 

--- a/src/Entities/Misc/MoveSwapBlock.cs
+++ b/src/Entities/Misc/MoveSwapBlock.cs
@@ -439,7 +439,7 @@ public class MoveSwapBlock : SwapBlock
 
                     if (shouldBreak)
                     {
-                        moveBlockSfx.Param("arrow_stop", 1f);
+                        moveBlockSfx.Param("arrow_stop", crashTimer > 0.15f ? 0.5f : 1f);
                         crashResetTimer = CrashResetTime;
                         if (crashStartShakingTimer < 0f && shakeOnCollision)
                             StartShaking();

--- a/src/Entities/Misc/MoveSwapBlock.cs
+++ b/src/Entities/Misc/MoveSwapBlock.cs
@@ -457,6 +457,7 @@ public class MoveSwapBlock : SwapBlock
                         }
                         else
                         {
+                            StopShaking();
                             crashTimer = crashTime;
                             crashStartShakingTimer = CrashStartShakingTime;
                         }

--- a/src/Entities/Misc/MoveSwapBlock.cs
+++ b/src/Entities/Misc/MoveSwapBlock.cs
@@ -51,6 +51,7 @@ public class MoveSwapBlock : SwapBlock
     private const float CrashStartShakingTime = 0.15f;
     private readonly float crashTime;
     private readonly float regenTime;
+    private readonly bool shakeOnCollision;
 
     public enum MovementState
     {
@@ -167,6 +168,7 @@ public class MoveSwapBlock : SwapBlock
 
         crashTime = data.Float("crashTime", 0.15f);
         regenTime = data.Float("regenTime", 3f);
+        shakeOnCollision = data.Bool("shakeOnCollision", true);
 
         int tilesX = (int) Width / 8;
         int tilesY = (int) Height / 8;
@@ -439,7 +441,7 @@ public class MoveSwapBlock : SwapBlock
                     {
                         moveBlockSfx.Param("arrow_stop", 1f);
                         crashResetTimer = CrashResetTime;
-                        if (crashStartShakingTimer < 0f)
+                        if (crashStartShakingTimer < 0f && shakeOnCollision)
                             StartShaking();
                         if (!(crashTimer > 0f))
                         {


### PR DESCRIPTION
Allows you to specify the time before a move block breaks after it hits a solid and the time it takes the move block to respawn after breaking for all custom move block types (Connected Move Blocks, Equation Move Blocks, Cassette Move Blocks, Dream Move Blocks, and Move Swap Blocks). There is also a toggle for if the move block should start shaking if it has been colliding with a solid for longer than the default break time (0.15s).