### PR TITLE
Use Everest's state-registry API instead of manually creating them

### DIFF
--- a/everest.yaml
+++ b/everest.yaml
@@ -3,4 +3,4 @@
   DLL: src/bin/Debug/net7.0/CommunalHelper.dll
   Dependencies:
     - Name: EverestCore
-      Version: 1.4465.0
+      Version: 1.5052.0

--- a/src/CommunalHelper.csproj
+++ b/src/CommunalHelper.csproj
@@ -32,9 +32,6 @@
 		<Reference Include="$(CelestePrefix)\MMHOOK_Celeste.dll">
 			<Private>false</Private>
 		</Reference>
-		<Reference Include="$(CelestePrefix)\Celeste.dll">
-			<Private>false</Private>
-		</Reference>
 		<Reference Include="$(CelestePrefix)\FNA.dll">
 			<Private>false</Private>
 		</Reference>

--- a/src/CommunalHelper.csproj
+++ b/src/CommunalHelper.csproj
@@ -32,6 +32,9 @@
 		<Reference Include="$(CelestePrefix)\MMHOOK_Celeste.dll">
 			<Private>false</Private>
 		</Reference>
+		<Reference Include="$(CelestePrefix)\Celeste.dll">
+			<Private>false</Private>
+		</Reference>
 		<Reference Include="$(CelestePrefix)\FNA.dll">
 			<Private>false</Private>
 		</Reference>

--- a/src/CommunalHelperModule.cs
+++ b/src/CommunalHelperModule.cs
@@ -13,6 +13,7 @@ using Celeste.Mod.CommunalHelper.States;
 using Celeste.Mod.CommunalHelper.Triggers;
 using Celeste.Mod.CommunalHelper.Triggers.StrawberryJam;
 using MonoMod.ModInterop;
+using DreamTunnelDash = Celeste.Mod.CommunalHelper.DashStates.DreamTunnelDash;
 
 namespace Celeste.Mod.CommunalHelper;
 
@@ -217,7 +218,7 @@ public class CommunalHelperModule : EverestModule
         // We create a static CrystalStaticSpinner which needs to access Tags.TransitionUpdate
         // Which wouldn't be loaded in time for EverestModule.Load
         TimedTriggerSpikes.LoadDelayed();
-        
+
         // Because of StrawberryJam, trying to hook the LaserEmitter codebase breaks the Laser Emitters because both the CommunalHelper and StrawberryJam hooks cannot be cross-compatible
         // (at least until we can update StrawberryJam to fix it)
         // Therefore, we load this hook conditionally dependent on if StrawberryJam has loaded its hooks, and use the same flags it uses to achieve the same effect

--- a/src/DashStates/DreamTunnelDash/DreamTunnelEntry.cs
+++ b/src/DashStates/DreamTunnelDash/DreamTunnelEntry.cs
@@ -1,4 +1,5 @@
-﻿using Mono.Cecil;
+﻿using Celeste.Mod.CommunalHelper.States;
+using Mono.Cecil;
 using Mono.Cecil.Cil;
 using MonoMod.Cil;
 using MonoMod.RuntimeDetour;
@@ -12,7 +13,7 @@ using static Celeste.Mod.CommunalHelper.DashStates.DreamTunnelDash;
 * Slow routine: Particles spray out from each end diagonally, moving inwards
 * Fast routine: Particles spray outwards + diagonally from the ends
 * Try to keep the timing on these the same as for DreamBlocks
-* 
+*
 * Todo:
 * Add Feather particles/functionality
 * Add Dreamblock activate/deactivate routines
@@ -219,7 +220,7 @@ public class DreamTunnelEntry : AbstractPanel
 
         if (changeState)
         {
-            player.StateMachine.State = StDreamTunnelDash;
+            player.StateMachine.State = St.DreamTunnelDash;
         }
 
         return true;
@@ -507,7 +508,7 @@ public class DreamTunnelEntry : AbstractPanel
     {
         /*
          * adds a check for !player.CollideCheck<DreamTunnelEntry>(player.Position + Vector2.UnitY) to
-         * if (player.onGround && player.DashDir.X != 0f && player.DashDir.Y > 0f && player.Speed.Y > 0f && 
+         * if (player.onGround && player.DashDir.X != 0f && player.DashDir.Y > 0f && player.Speed.Y > 0f &&
          *  (!player.Inventory.DreamDash || !player.CollideCheck<DreamBlock>(player.Position + Vector2.UnitY)))
          */
         ILCursor cursor = new(il);

--- a/src/Exports.cs
+++ b/src/Exports.cs
@@ -1,6 +1,8 @@
 using Celeste.Mod.CommunalHelper.Components;
 using Celeste.Mod.CommunalHelper.DashStates;
+using Celeste.Mod.CommunalHelper.States;
 using MonoMod.ModInterop;
+using DreamTunnelDash = Celeste.Mod.CommunalHelper.DashStates.DreamTunnelDash;
 
 namespace Celeste.Mod.CommunalHelper;
 
@@ -18,7 +20,7 @@ public static class ModExports
 
         public static int GetDreamTunnelDashState()
         {
-            return DreamTunnelDash.StDreamTunnelDash;
+            return St.DreamTunnelDash;
         }
 
         public static bool HasDreamTunnelDash()

--- a/src/Imports/SpeedrunTool.cs
+++ b/src/Imports/SpeedrunTool.cs
@@ -9,7 +9,7 @@ public static class SpeedrunTool
         typeof(SaveLoadImports).ModInterop();
 
         SaveLoadImports.RegisterStaticTypes?.Invoke(typeof(DreamTunnelDash), new string[9] {
-            "StDreamTunnelDash",
+            "St.DreamTunnelDash",
             "hasDreamTunnelDash",
             "dreamTunnelDashCount",
             "dreamTunnelDashAttacking",

--- a/src/OptionalDependencies.cs
+++ b/src/OptionalDependencies.cs
@@ -43,15 +43,6 @@ internal static class OptionalDependencies
             Extensions.CollabUtils_MiniHeart = module.GetType().Module.GetType("Celeste.Mod.CollabUtils2.Entities.MiniHeart", ignoreCase: false, throwOnError: true);
             Extensions.CollabUtilsLoaded = true;
         };
-        // Used for registering custom playerstates for display in CelesteTAS
-        meta = new EverestModuleMetadata { Name = "CelesteTAS", VersionString = "3.4.5" };
-        optionalDepLoaders[meta] = module =>
-        {
-            Type t_PlayerStates = module.GetType().Module.GetType("TAS.PlayerStates", ignoreCase: false, throwOnError: true);
-            Extensions.CelesteTAS_PlayerStates_Register = t_PlayerStates.GetMethod("Register", BindingFlags.Public | BindingFlags.Static, throwOnNull: true);
-            Extensions.CelesteTAS_PlayerStates_Unregister = t_PlayerStates.GetMethod("Unregister", BindingFlags.Public | BindingFlags.Static, throwOnNull: true);
-            Extensions.CelesteTASLoaded = true;
-        };
         meta = new EverestModuleMetadata { Name = "MaxHelpingHand", VersionString = "1.9.3" };
         optionalDepLoaders[meta] = module => MaxHelpingHandLoaded = true;
         meta = new EverestModuleMetadata { Name = "VivHelper", VersionString = "1.0.28" };

--- a/src/States/DreamTunnelDash.cs
+++ b/src/States/DreamTunnelDash.cs
@@ -1,0 +1,181 @@
+using Celeste.Mod.CommunalHelper.Components;
+using Celeste.Mod.CommunalHelper.DashStates;
+using MonoMod.Utils;
+using System.Linq;
+
+namespace Celeste.Mod.CommunalHelper.States;
+
+public static class DreamTunnelDash
+{
+    public static void DreamTunnelDashBegin(this Player player)
+    {
+        DynamicData playerData = player.GetData();
+
+        player.StartedDashing = false;
+
+        if (player.dreamSfxLoop == null)
+        {
+            player.dreamSfxLoop = new SoundSource();
+            player.Add(player.dreamSfxLoop);
+        }
+
+        // Extra correction for fast moving solids, this does not cause issues with dashdir leniency
+        Vector2 dir = player.DashDir.Sign();
+        if (!player.CollideCheck<Solid, DreamBlock>() && player.CollideCheck<Solid, DreamBlock>(player.Position + dir))
+        {
+            player.NaiveMove(dir);
+        }
+
+        // Hackfix to unduck when downdiagonal dashing next to solid, caused by forcing the player into the solid as part of fast-moving solid correction
+        if (player.DashDir.Y > 0)
+            player.Ducking = false;
+
+        player.Speed = player.DashDir * Player.DashSpeed;
+        player.TreatNaive = true;
+        player.Depth = Depths.PlayerDreamDashing;
+        playerData.Set(DashStates.DreamTunnelDash.Player_dreamTunnelDashCanEndTimer, 0.1f);
+        player.Stamina = Player.ClimbMaxStamina;
+        playerData.Set("dreamJump", false);
+        player.Play(SFX.char_mad_dreamblock_enter, null, 0f);
+        if (DashStates.DreamTunnelDash.FeatherMode)
+            player.Loop(player.dreamSfxLoop, CustomSFX.game_connectedDreamBlock_dreamblock_fly_travel);
+        else
+            player.Loop(player.dreamSfxLoop, SFX.char_mad_dreamblock_travel);
+
+        // Allows DreamDashListener to also work from here, as this is basically a dream block, right?
+        foreach (DreamDashListener component in player.Scene.Tracker.GetComponents<DreamDashListener>())
+        {
+            component.OnDreamDash?.Invoke(player.DashDir);
+        }
+    }
+
+    public static void DreamTunnelDashEnd(this Player player)
+    {
+        DynamicData playerData = player.GetData();
+
+        player.Depth = Depths.Player;
+        if (!player.dreamJump)
+        {
+            player.AutoJump = true;
+            player.AutoJumpTimer = 0f;
+        }
+        if (!player.Inventory.NoRefills)
+        {
+            player.RefillDash();
+        }
+        player.RefillStamina();
+        player.TreatNaive = false;
+        Solid solid = playerData.Get<Solid>(DashStates.DreamTunnelDash.Player_solid);
+        if (solid != null)
+        {
+            if (player.DashDir.X != 0f)
+            {
+                player.jumpGraceTimer = 0.1f;
+                player.dreamJump = true;
+            }
+            else
+            {
+                player.jumpGraceTimer = 0f;
+            }
+            solid.Components.GetAll<DreamTunnelInteraction>().ToList().ForEach(i => i.OnPlayerExit(player));
+            solid = null;
+        }
+        player.Stop(player.dreamSfxLoop);
+        player.Play(SFX.char_mad_dreamblock_exit, null, 0f);
+        Input.Rumble(RumbleStrength.Medium, RumbleLength.Short);
+    }
+
+    public static int DreamTunnelDashUpdate(this Player player)
+    {
+        DynamicData playerData = player.GetData();
+
+        if (DashStates.DreamTunnelDash.FeatherMode)
+        {
+            Vector2 input = Input.Aim.Value.SafeNormalize();
+            if (input != Vector2.Zero)
+            {
+                Vector2 vector = player.Speed.SafeNormalize();
+                if (vector != Vector2.Zero)
+                {
+                    vector = Vector2.Dot(input, vector) != -0.8f ? vector.RotateTowards(input.Angle(), 5f * Engine.DeltaTime) : vector;
+                    vector = vector.CorrectJoystickPrecision();
+                    player.DashDir = vector;
+                    player.Speed = vector * 240f;
+                }
+            }
+        }
+
+        Input.Rumble(RumbleStrength.Light, RumbleLength.Medium);
+        Vector2 position = player.Position;
+
+        Vector2 factor = Vector2.One;
+        if (player.IsInverted())
+            factor.Y = -1;
+        player.NaiveMove(player.Speed * factor * Engine.DeltaTime);
+
+        float dreamDashCanEndTimer = playerData.Get<float>(DashStates.DreamTunnelDash.Player_dreamTunnelDashCanEndTimer);
+        if (dreamDashCanEndTimer > 0f)
+        {
+            playerData.Set(DashStates.DreamTunnelDash.Player_dreamTunnelDashCanEndTimer, dreamDashCanEndTimer - Engine.DeltaTime);
+        }
+        Solid solid = player.CollideFirst<Solid, DreamBlock>();
+        if (solid == null)
+        {
+            if (player.DreamTunneledIntoDeath())
+            {
+                player.DreamDashDie(position);
+            }
+            else if (playerData.Get<float>(DashStates.DreamTunnelDash.Player_dreamTunnelDashCanEndTimer) <= 0f)
+            {
+                Celeste.Freeze(0.05f);
+                if (Input.Jump.Pressed && player.DashDir.X != 0f)
+                {
+                    player.dreamJump = true;
+                    player.Jump(true, true);
+                }
+                else if (player.DashDir.Y >= 0f || player.DashDir.X != 0f)
+                {
+                    if (player.DashDir.X > 0f && player.CollideCheck<DreamBlock>(player.Position - (Vector2.UnitX * 5f)))
+                    {
+                        player.MoveHExact(-5, null, null);
+                    }
+                    else if (player.DashDir.X < 0f && player.CollideCheck<DreamBlock>(player.Position + (Vector2.UnitX * 5f)))
+                    {
+                        player.MoveHExact(5, null, null);
+                    }
+                    bool flag = player.ClimbCheck(-1, 0);
+                    bool flag2 = player.ClimbCheck(1, 0);
+                    int moveX = player.moveX;
+                    if (Input.GrabCheck && ((moveX == 1 && flag2) || (moveX == -1 && flag)))
+                    {
+                        player.Facing = (Facings) moveX;
+                        if (!SaveData.Instance.Assists.NoGrabbing)
+                        {
+                            return Player.StClimb;
+                        }
+                        player.ClimbTrigger(moveX);
+                        player.Speed.X = 0f;
+                    }
+                }
+                return Player.StNormal;
+            }
+        }
+        else
+        {
+            playerData.Set(DashStates.DreamTunnelDash.Player_solid, solid);
+            if (player.Scene.OnInterval(0.1f))
+            {
+                player.CreateDreamTrail();
+            }
+            Level level = player.level;
+            if (level.OnInterval(0.04f))
+            {
+                DisplacementRenderer.Burst burst = level.Displacement.AddBurst(player.Center, 0.3f, 0f, 40f, 1f, null, null);
+                burst.WorldClipCollider = solid.Collider;
+                burst.WorldClipPadding = 2;
+            }
+        }
+
+        return St.DreamTunnelDash;
+    }
+}

--- a/src/States/St.cs
+++ b/src/States/St.cs
@@ -2,6 +2,7 @@
 
 public static class St
 {
+    public static int DreamTunnelDash { get; private set; } = -1;
     public static int Elytra { get; private set; } = -1;
 
     internal static void Initialize()
@@ -11,32 +12,19 @@ public static class St
 
     internal static void Load()
     {
-        On.Celeste.Player.ctor += Mod_Player_ctor;
+        Everest.Events.Player.OnRegisterStates += RegisterPlayerStates;
 
         States.Elytra.Load();
     }
 
     internal static void Unload()
     {
-        On.Celeste.Player.ctor -= Mod_Player_ctor;
-
         States.Elytra.Unload();
-        if (Elytra is not -1)
-            Extensions.UnregisterState(Elytra);
     }
 
-    private static void Mod_Player_ctor(On.Celeste.Player.orig_ctor orig, Player self, Vector2 position, PlayerSpriteMode spriteMode)
+    private static void RegisterPlayerStates(Player player)
     {
-        orig(self, position, spriteMode);
-
-        // for each custom state:
-        // * unregister previous state ID
-        // * initialize new state ID
-        // * register new state ID
-
-        if (Elytra is not -1)
-            Extensions.UnregisterState(Elytra);
-        Elytra = self.StateMachine.AddState(self.GlideUpdate, self.GlideRoutine, self.GlideBegin, self.GlideEnd);
-        Extensions.RegisterState(Elytra, "Elytra");
+        DreamTunnelDash = player.AddState("DreamTunnelDash", States.DreamTunnelDash.DreamTunnelDashUpdate, null, States.DreamTunnelDash.DreamTunnelDashBegin, States.DreamTunnelDash.DreamTunnelDashEnd);
+        Elytra = player.AddState("Elytra", States.Elytra.GlideUpdate, States.Elytra.GlideRoutine, States.Elytra.GlideBegin, States.Elytra.GlideEnd);
     }
 }

--- a/src/Utils/Extensions.cs
+++ b/src/Utils/Extensions.cs
@@ -222,22 +222,6 @@ public static class Extensions
 
     // Dream Tunnel Dash related extension methods located in DreamTunnelDash.cs
 
-    internal static bool CelesteTASLoaded;
-    internal static MethodInfo CelesteTAS_PlayerStates_Register;
-    internal static MethodInfo CelesteTAS_PlayerStates_Unregister;
-
-    public static void RegisterState(int state, string stateName)
-    {
-        if (CelesteTASLoaded)
-            CelesteTAS_PlayerStates_Register.Invoke(null, new object[] { state, stateName });
-    }
-
-    public static void UnregisterState(int state)
-    {
-        if (CelesteTASLoaded)
-            CelesteTAS_PlayerStates_Unregister.Invoke(null, new object[] { state });
-    }
-
     internal static bool MoreDashelineLoaded;
     internal static MethodInfo MoreDasheline_GetHairColor;
 
@@ -494,41 +478,6 @@ public static class Extensions
                 entity.Awake(scene);
         }
     }
-
-
-    #region JaThePlayer's state machine extension code
-
-    /// <summary>
-    /// Adds a state to a StateMachine
-    /// </summary>
-    /// <returns>The index of the new state</returns>
-    public static int AddState(this StateMachine machine, Func<int> onUpdate, Func<IEnumerator> coroutine = null, Action begin = null, Action end = null)
-    {
-        Action[] begins = (Action[]) StateMachine_begins.GetValue(machine);
-        Func<int>[] updates = (Func<int>[]) StateMachine_updates.GetValue(machine);
-        Action[] ends = (Action[]) StateMachine_ends.GetValue(machine);
-        Func<IEnumerator>[] coroutines = (Func<IEnumerator>[]) StateMachine_coroutines.GetValue(machine);
-        int nextIndex = begins.Length;
-        // Now let's expand the arrays
-        Array.Resize(ref begins, begins.Length + 1);
-        Array.Resize(ref updates, begins.Length + 1);
-        Array.Resize(ref ends, begins.Length + 1);
-        Array.Resize(ref coroutines, coroutines.Length + 1);
-        // Store the resized arrays back into the machine
-        StateMachine_begins.SetValue(machine, begins);
-        StateMachine_updates.SetValue(machine, updates);
-        StateMachine_ends.SetValue(machine, ends);
-        StateMachine_coroutines.SetValue(machine, coroutines);
-        // And now we add the new functions
-        machine.SetCallbacks(nextIndex, onUpdate, coroutine, begin, end);
-        return nextIndex;
-    }
-    private static readonly FieldInfo StateMachine_begins = typeof(StateMachine).GetField("begins", BindingFlags.Instance | BindingFlags.NonPublic);
-    private static readonly FieldInfo StateMachine_updates = typeof(StateMachine).GetField("updates", BindingFlags.Instance | BindingFlags.NonPublic);
-    private static readonly FieldInfo StateMachine_ends = typeof(StateMachine).GetField("ends", BindingFlags.Instance | BindingFlags.NonPublic);
-    private static readonly FieldInfo StateMachine_coroutines = typeof(StateMachine).GetField("coroutines", BindingFlags.Instance | BindingFlags.NonPublic);
-
-    #endregion
 
     public static Vector2 PutInside(this Entity entity, Vector2 pos)
     {


### PR DESCRIPTION
This reduces potential conflict with other mods which register states in the legacy way, and also allows dropping the CelesteTAS dependency to provide state information to the Info HUD.
I'm not sure which Everest version introduced that API, so just to be safe, depend on the latest stable.