### PR TITLE
Use new photosensitivity options

### DIFF
--- a/everest.yaml
+++ b/everest.yaml
@@ -3,4 +3,4 @@
   DLL: src/bin/Debug/net7.0/CommunalHelper.dll
   Dependencies:
     - Name: EverestCore
-      Version: 1.5052.0
+      Version: 1.5184.0

--- a/src/Backdrops/Cloudscape/Cloudscape.cs
+++ b/src/Backdrops/Cloudscape/Cloudscape.cs
@@ -1,5 +1,6 @@
 ﻿using Celeste.Mod.Backdrops;
 using Celeste.Mod.CommunalHelper.Utils;
+using Celeste.Mod.Core;
 using Microsoft.Xna.Framework.Graphics;
 using System.Collections.Generic;
 using System.Linq;
@@ -167,7 +168,7 @@ public class Cloudscape : Backdrop
                     timer = Calc.Random.Range(parent.lightningMinDelay, parent.lightningMaxDelay);
                     flashColor = parent.lightningFlashColor;
                     flashTimer = flashDuration = Calc.Random.Range(parent.lightningMinDuration, parent.lightningMaxDuration);
-                    intensity = Settings.Instance.DisableFlashes ? 0 : parent.lightningIntensity * Ease.CubeIn(Calc.Random.NextFloat());
+                    intensity = CoreModule.Settings.AllowLightning ? parent.lightningIntensity * Ease.CubeIn(Calc.Random.NextFloat()) : 0;
                     targetColorA = Util.ColorArrayLerp(Calc.Random.NextFloat() * (parent.lightningColors.Length - 1), parent.lightningColors);
                     targetColorB = Util.ColorArrayLerp(Calc.Random.NextFloat() * (parent.lightningColors.Length - 1), parent.lightningColors);
                 }

--- a/src/Entities/Misc/LightningController.cs
+++ b/src/Entities/Misc/LightningController.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using Celeste.Mod.Core;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace Celeste.Mod.CommunalHelper.Entities;
@@ -77,7 +78,7 @@ public class LightningController : Entity
         Level level = Scene as Level;
         Camera cam = level.Camera;
 
-        bool flashes = flashDuration > 0 && flash > 0 && !Settings.Instance.DisableFlashes;
+        bool flashes = flashDuration > 0 && flash > 0 && CoreModule.Settings.AllowLightning;
 
         while (true)
         {


### PR DESCRIPTION
Update to use the new Everest photosensitivity sub-options. Requires latest stable

There are a couple entities (HeldBooster and SJ/MomentumBlock) that use the default option that I did not change since the effects are minor and don't really fall under the suboptions