### PR TITLE
Change state names

### DIFF
--- a/src/States/St.cs
+++ b/src/States/St.cs
@@ -24,7 +24,7 @@ public static class St
 
     private static void RegisterPlayerStates(Player player)
     {
-        DreamTunnelDash = player.AddState("DreamTunnelDash", States.DreamTunnelDash.DreamTunnelDashUpdate, null, States.DreamTunnelDash.DreamTunnelDashBegin, States.DreamTunnelDash.DreamTunnelDashEnd);
-        Elytra = player.AddState("Elytra", States.Elytra.GlideUpdate, States.Elytra.GlideRoutine, States.Elytra.GlideBegin, States.Elytra.GlideEnd);
+        DreamTunnelDash = player.AddState("StDreamTunnelDash", States.DreamTunnelDash.DreamTunnelDashUpdate, null, States.DreamTunnelDash.DreamTunnelDashBegin, States.DreamTunnelDash.DreamTunnelDashEnd);
+        Elytra = player.AddState("StElytra", States.Elytra.GlideUpdate, States.Elytra.GlideRoutine, States.Elytra.GlideBegin, States.Elytra.GlideEnd);
     }
 }


### PR DESCRIPTION
Changed state names from `Elytra` to `StElytra` and `DreamTunnelDash` to `StDreamTunnelDash` to make it clearer that they are states in CelesteTAS.

I do not mod Celeste, so I don't know if there are more references to this that need to be updated to make this fully function. The goal is just to make it easier to differentiate that `Elytra` is a state.