### PR TITLE
Add `noCollideSteer` option to Dream Move Blocks

### DIFF
--- a/Ahorn/entities/dreamBlocks/DreamMoveBlock.jl
+++ b/Ahorn/entities/dreamBlocks/DreamMoveBlock.jl
@@ -8,6 +8,7 @@ const entityData = appendkwargs(CustomDreamBlockData, :(
     direction::String="Right",
     moveSpeed::Number=60.0,
     noCollide::Bool=false,
+    noCollideSteer::Bool=false,
 ))
 @mapdefdata Entity "CommunalHelper/DreamMoveBlock" DreamMoveBlock entityData
 

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -122,6 +122,7 @@ placements.entities.CommunalHelper/DreamMoveBlock.tooltips.direction=The directi
 placements.entities.CommunalHelper/DreamMoveBlock.tooltips.refillCount=Number of dashes the Dream Move Block should refill (-1 for default).
 placements.entities.CommunalHelper/DreamMoveBlock.tooltips.moveSpeed=The speed at which the Dream Move Block moves (accepts any number).
 placements.entities.CommunalHelper/DreamMoveBlock.tooltips.noCollide=Whether the Dream Move Block should go through solids.
+placements.entities.CommunalHelper/DreamMoveBlock.tooltips.noCollideSteer=Force-allow this block to go through solids when it is steerable.
 placements.entities.CommunalHelper/DreamMoveBlock.tooltips.featherMode=Whether the Dream Move Block has the Dream Block Feather controls enabled.
 placements.entities.CommunalHelper/DreamMoveBlock.tooltips.oneUse=Whether the Dream Move Block should shatter upon exit.
 placements.entities.CommunalHelper/DreamMoveBlock.tooltips.quickDestroy=Makes this Dream Move Block shatter a little faster.

--- a/Loenn/entities/dream_blocks/dream_move_block.lua
+++ b/Loenn/entities/dream_blocks/dream_move_block.lua
@@ -69,6 +69,7 @@ dreamMoveBlock.placements = {
             direction = "Right",
             moveSpeed = 60.0,
             noCollide = false,
+            noCollideSteer = false,
             canSteer = false,
             crashTime = 0.15,
             regenTime = 3.0,

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -269,7 +269,7 @@ entities.CommunalHelper/SolidExtension.attributes.description.collidable=Whether
 
 # Dream Zip Mover
 entities.CommunalHelper/DreamZipMover.placements.name.dream_zip_mover=Dream Zip Mover
-entities.CommunalHelper/DreamZipMover.attributes.description.below=Determines whether the Dream Move Block should render below foreground tiles.
+entities.CommunalHelper/DreamZipMover.attributes.description.below=Determines whether the Dream Zip Mover should render below foreground tiles.
 entities.CommunalHelper/DreamZipMover.attributes.description.noReturn=Whether the Dream Zip Mover should return to its starting point or not.
 entities.CommunalHelper/DreamZipMover.attributes.description.dreamAesthetic=Optional look for this entity, mostly unused, but left there.
 entities.CommunalHelper/DreamZipMover.attributes.description.featherMode=Whether the Dream Zip Mover has the Dream Block Feather controls enabled.
@@ -310,6 +310,7 @@ entities.CommunalHelper/DreamMoveBlock.attributes.description.direction=The dire
 entities.CommunalHelper/DreamMoveBlock.attributes.description.refillCount=Number of dashes the Dream Move Block should refill (-1 for default).
 entities.CommunalHelper/DreamMoveBlock.attributes.description.moveSpeed=The speed at which the Dream Move Block moves (accepts any number).
 entities.CommunalHelper/DreamMoveBlock.attributes.description.noCollide=Whether the Dream Move Block should go through solids.
+entities.CommunalHelper/DreamMoveBlock.attributes.description.noCollideSteer=Force-allow this block to go through solids when it is steerable.
 entities.CommunalHelper/DreamMoveBlock.attributes.description.featherMode=Whether the Dream Move Block has the Dream Block Feather controls enabled.
 entities.CommunalHelper/DreamMoveBlock.attributes.description.oneUse=Whether the Dream Move Block should shatter upon exit.
 entities.CommunalHelper/DreamMoveBlock.attributes.description.quickDestroy=Makes this Dream Move Block shatter a little faster.

--- a/src/Entities/DreamBlocks/DreamMoveBlock.cs
+++ b/src/Entities/DreamBlocks/DreamMoveBlock.cs
@@ -89,7 +89,10 @@ public class DreamMoveBlock : CustomDreamBlock
 
     private readonly Coroutine controller;
     private readonly bool noCollide;
+    private readonly bool noCollideSteer;
     private readonly bool canSteer;
+
+    private bool IsNoCollide => noCollide || noCollideSteer;
 
     private bool oneUseBroken;
 
@@ -123,6 +126,7 @@ public class DreamMoveBlock : CustomDreamBlock
         // Backwards Compatibility
         moveSpeed = data.Bool("fast") ? FastMoveSpeed : data.Float("moveSpeed", MoveSpeed);
         noCollide = data.Bool("noCollide");
+        noCollideSteer = data.Bool("noCollideSteer", false);
 
         canSteer = data.Bool("canSteer");
 
@@ -322,7 +326,12 @@ public class DreamMoveBlock : CustomDreamBlock
                 {
                     hit = MoveCheck(move.XComp());
                     noSquish = Scene.Tracker.GetEntity<Player>();
-                    MoveVCollideSolids(move.Y, thruDashBlocks: false);
+
+                    if (canSteer || noCollideSteer)
+                        MoveV(move.Y);
+                    else
+                        MoveVCollideSolids(move.Y, thruDashBlocks: false);
+
                     noSquish = null;
                     if (Scene.OnInterval(0.03f))
                     {
@@ -340,7 +349,12 @@ public class DreamMoveBlock : CustomDreamBlock
                 {
                     hit = MoveCheck(move.YComp());
                     noSquish = Scene.Tracker.GetEntity<Player>();
-                    MoveHCollideSolids(move.X, thruDashBlocks: false);
+
+                    if (canSteer || noCollideSteer)
+                        MoveH(move.X);
+                    else
+                        MoveHCollideSolids(move.X, thruDashBlocks: false);
+
                     noSquish = null;
                     if (Scene.OnInterval(0.03f))
                     {
@@ -447,7 +461,7 @@ public class DreamMoveBlock : CustomDreamBlock
                 yield break;
             }
 
-            while (CollideCheck<Actor>() || (noCollide ? CollideCheck<DreamBlock>() : CollideCheck<Solid>()))
+            while (CollideCheck<Actor>() || (IsNoCollide ? CollideCheck<DreamBlock>() : CollideCheck<Solid>()))
             {
                 yield return null;
             }
@@ -626,7 +640,7 @@ public class DreamMoveBlock : CustomDreamBlock
     {
         if (speed.X != 0f)
         {
-            if (!noCollide || CollideCheck<DreamBlock>(Position + speed.XComp()))
+            if (!IsNoCollide || CollideCheck<DreamBlock>(Position + speed.XComp()))
             {
                 if (MoveHCollideSolids(speed.X, thruDashBlocks: false))
                 {
@@ -654,7 +668,7 @@ public class DreamMoveBlock : CustomDreamBlock
         }
         if (speed.Y != 0f)
         {
-            if (!noCollide || CollideCheck<DreamBlock>(Position + speed.YComp()))
+            if (!IsNoCollide || CollideCheck<DreamBlock>(Position + speed.YComp()))
             {
                 if (MoveVCollideSolids(speed.Y, thruDashBlocks: false))
                 {
@@ -921,7 +935,7 @@ public class DreamMoveBlock : CustomDreamBlock
 
     private void ScrapeParticles(Vector2 dir)
     {
-        if (noCollide)
+        if (IsNoCollide)
             return;
 
         Collidable = false;

--- a/src/Entities/DreamBlocks/DreamMoveBlock.cs
+++ b/src/Entities/DreamBlocks/DreamMoveBlock.cs
@@ -328,7 +328,7 @@ public class DreamMoveBlock : CustomDreamBlock
                     noSquish = Scene.Tracker.GetEntity<Player>();
 
                     if (canSteer || noCollideSteer)
-                        MoveV(move.Y);
+                        MoveCheck(move.YComp());
                     else
                         MoveVCollideSolids(move.Y, thruDashBlocks: false);
 
@@ -351,7 +351,7 @@ public class DreamMoveBlock : CustomDreamBlock
                     noSquish = Scene.Tracker.GetEntity<Player>();
 
                     if (canSteer || noCollideSteer)
-                        MoveH(move.X);
+                        MoveCheck(move.XComp());
                     else
                         MoveHCollideSolids(move.X, thruDashBlocks: false);
 


### PR DESCRIPTION
Allows steerable dream move blocks to be steered into solids (by ticking the corresponding new option).

https://github.com/user-attachments/assets/6e0b4e9a-a4df-4e29-832a-7301415ef48c

