### PR TITLE
Kosei/new attributes

### DIFF
--- a/Loenn/entities/misc/hint_controller.lua
+++ b/Loenn/entities/misc/hint_controller.lua
@@ -13,8 +13,9 @@ hintController.placements = {
             singleUses = "",
             selectorCounter = "",
             selectNextHint = false,
-        },
-    },
+			flagWhileReading = ""
+        }
+    }
 }
 
 return hintController

--- a/Loenn/entities/misc/hint_controller.lua
+++ b/Loenn/entities/misc/hint_controller.lua
@@ -14,6 +14,7 @@ hintController.placements = {
             selectorCounter = "",
             selectNextHint = false,
 			flagWhileReading = ""
+            flagWhileReading = "",
         }
     }
 }

--- a/Loenn/entities/station_blocks/track_switch_box.lua
+++ b/Loenn/entities/station_blocks/track_switch_box.lua
@@ -15,7 +15,7 @@ trackSwitchBox.placements = {
             floaty = true,
             bouncy = true,
             reverse = false,
-			switchFlag = ""
+            switchFlag = "",
         }
     },
     {

--- a/Loenn/entities/station_blocks/track_switch_box.lua
+++ b/Loenn/entities/station_blocks/track_switch_box.lua
@@ -14,7 +14,8 @@ trackSwitchBox.placements = {
             globalSwitch = false,
             floaty = true,
             bouncy = true,
-            reverse = false
+            reverse = false,
+			switchFlag = ""
         }
     },
     {
@@ -23,7 +24,8 @@ trackSwitchBox.placements = {
             globalSwitch = true,
             floaty = true,
             bouncy = true,
-            reverse = false
+            reverse = false,
+			switchFlag = ""
         }
     }
 }

--- a/Loenn/entities/station_blocks/track_switch_box.lua
+++ b/Loenn/entities/station_blocks/track_switch_box.lua
@@ -25,7 +25,7 @@ trackSwitchBox.placements = {
             floaty = true,
             bouncy = true,
             reverse = false,
-			switchFlag = ""
+           switchFlag = "",
         }
     }
 }

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -138,6 +138,7 @@ entities.CommunalHelper/TrackSwitchBox.attributes.description.globalSwitch=Wheth
 entities.CommunalHelper/TrackSwitchBox.attributes.description.floaty=Whether the box should float up and down; this also causes the box to sink down if the player stands on it. If unticked, the box will stay in its place.
 entities.CommunalHelper/TrackSwitchBox.attributes.description.bouncy=Whether the box should bounce away from the player when dashed into.
 entities.CommunalHelper/TrackSwitchBox.attributes.description.reverse=Whether the box should reverse one-way/force directions instead of toggling on/off
+entities.CommunalHelper/TrackSwitchBox.attributes.description.switchFlag=This flag will be set to true while the tracks are ON and false while the tracks are OFF.
 
 # Custom Cassette Block
 entities.CommunalHelper/CustomCassetteBlock.placements.name.cassette_block_0=Custom Cassette Block (0 - Blue)

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -563,6 +563,7 @@ entities.CommunalHelper/HintController.attributes.description.dialogIds=A comma 
 entities.CommunalHelper/HintController.attributes.description.singleUses=A comma separated list of numbers, where 0 means the corresponding hint entry can be used multiple times, and anything else means it can only be used once.\nDefaults to empty string, which means all entries can be used multiple times.
 entities.CommunalHelper/HintController.attributes.description.selectorCounter=The name of the session counter that selects the current dialog.\nDefaults to empty string, which means that there is no counter and only the first hint will be available.
 entities.CommunalHelper/HintController.attributes.description.selectNextHint=If true, the selector defined in selectorCounter will be automatically incremented when a hint is shown. Defaults to false.
+entities.CommunalHelper/HintController.attributes.description.flagWhileReading=This flag will be true while a hint is being read.
 
 # Input Flag Controller
 entities.CommunalHelper/InputFlagController.placements.name.controller=Input Flag Controller

--- a/src/Entities/Misc/HintController.cs
+++ b/src/Entities/Misc/HintController.cs
@@ -12,6 +12,7 @@ public class HintController : Entity
     public bool[] SingleUses { get; }
     public string SelectorCounter { get; }
     public bool SelectNextHint { get; }
+    public string FlagWhileReading { get; private set; }
 
     private int CurrentSelector
     {
@@ -50,6 +51,8 @@ public class HintController : Entity
     {
         TitleDialog = data.Attr("titleDialog", "");
         if (string.IsNullOrWhiteSpace(TitleDialog)) TitleDialog = "communalhelper_entities_hint_controller_menu";
+
+        FlagWhileReading = data.Attr("flagWhileReading", "");
 
         DialogIds = data.Attr("dialogIds")
             .Split(CommaSeparator, StringSplitOptions.RemoveEmptyEntries)
@@ -147,9 +150,12 @@ public class HintController : Entity
 
     private IEnumerator ShowHintSequence()
     {
+        Level lvl = SceneAs<Level>();
+        lvl.Session.SetFlag(FlagWhileReading, true);
         showingHint = true;
         yield return Textbox.Say(CurrentDialogId);
         showingHint = false;
+        lvl.Session.SetFlag(FlagWhileReading, false);
 
         if (SelectNextHint && DialogIds.Length > 0 && !string.IsNullOrWhiteSpace(SelectorCounter))
         {

--- a/src/Entities/StationBlocks/TrackSwitchBox.cs
+++ b/src/Entities/StationBlocks/TrackSwitchBox.cs
@@ -86,10 +86,19 @@ public class TrackSwitchBox : Solid
     public override void Awake(Scene scene)
     {
         base.Awake(scene);
+        Level level = SceneAs<Level>();
         spikesUp = CollideCheck<Spikes>(Position - Vector2.UnitY);
         spikesDown = CollideCheck<Spikes>(Position + Vector2.UnitY);
         spikesLeft = CollideCheck<Spikes>(Position - Vector2.UnitX);
         spikesRight = CollideCheck<Spikes>(Position + Vector2.UnitX);
+        if (LocalTrackSwitchState == TrackSwitchState.On)
+        {
+            level.Session.SetFlag(switchFlag, true);
+        }
+        if (LocalTrackSwitchState == TrackSwitchState.Off)
+        {
+            level.Session.SetFlag(switchFlag, false);
+        }
     }
 
     public DashCollisionResults Dashed(Player player, Vector2 dir)

--- a/src/Entities/StationBlocks/TrackSwitchBox.cs
+++ b/src/Entities/StationBlocks/TrackSwitchBox.cs
@@ -21,6 +21,7 @@ public class TrackSwitchBox : Solid
     private readonly bool canFloat = true;
     private readonly bool canBounce = true;
     private readonly bool reverse = false;
+    private readonly string switchFlag = "";
 
     private float shakeCounter;
     private bool smashParticles = false;
@@ -43,7 +44,7 @@ public class TrackSwitchBox : Solid
 
     private bool spikesLeft, spikesRight, spikesUp, spikesDown;
 
-    public TrackSwitchBox(Vector2 position, bool global, bool canFloat, bool canBounce, bool reverse)
+    public TrackSwitchBox(Vector2 position, bool global, bool canFloat, bool canBounce, bool reverse, string flag)
         : base(position, 32f, 32f, safe: true)
     {
 
@@ -53,6 +54,7 @@ public class TrackSwitchBox : Solid
         this.canFloat = canFloat;
         this.canBounce = canBounce;
         this.reverse = reverse;
+        this.switchFlag = flag;
 
         SurfaceSoundIndex = SurfaceIndex.ZipMover;
         start = Position;
@@ -79,7 +81,7 @@ public class TrackSwitchBox : Solid
     }
 
     public TrackSwitchBox(EntityData e, Vector2 levelOffset)
-        : this(e.Position + levelOffset, e.Bool("globalSwitch"), e.Bool("floaty"), e.Bool("bounce"), e.Bool("reverse")) { }
+        : this(e.Position + levelOffset, e.Bool("globalSwitch"), e.Bool("floaty"), e.Bool("bouncy"), e.Bool("reverse"), e.Attr("switchFlag")) { }
 
     public override void Awake(Scene scene)
     {
@@ -199,6 +201,7 @@ public class TrackSwitchBox : Solid
     public override void Update()
     {
         base.Update();
+        Level level = SceneAs<Level>();
         if (Scene.OnInterval(0.1f))
         {
             Seed++;
@@ -216,6 +219,14 @@ public class TrackSwitchBox : Solid
                 shaker.On = false;
                 sprite.Scale = Vector2.One * 1.2f;
                 sprite.Play("switch");
+                if (LocalTrackSwitchState == TrackSwitchState.On)
+                {
+                    level.Session.SetFlag(switchFlag, true);
+                }
+                if (LocalTrackSwitchState == TrackSwitchState.Off)
+                {
+                    level.Session.SetFlag(switchFlag, false);
+                }
             }
         }
         if (Collidable)


### PR DESCRIPTION
This PR sets a flag to true while a textbox from the Hints controller is being read.

It also adds a flag that is toggled when a track swap box is dashed, and fixes the "bouncy" attribute not doing anything (it was called "bounce" internally).