### PR TITLE
Add 'Slow' option for Dash Zip Movers + Double On. hook fix

### DIFF
--- a/Loenn/entities/strawberry_jam/dash_zip_mover.lua
+++ b/Loenn/entities/strawberry_jam/dash_zip_mover.lua
@@ -39,6 +39,7 @@ dashZipMover.placements = {
         ropeLightColor = "329415",
         ropeShadowColor = "003622",
         soundEvent = "event:/CommunalHelperEvents/game/strawberryJam/game/dash_zip_mover/zip_mover",
+        slow = false,
     }
 }
 

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -837,6 +837,7 @@ entities.CommunalHelper/SJ/DashZipMover.attributes.description.ropeColor=The rop
 entities.CommunalHelper/SJ/DashZipMover.attributes.description.ropeLightColor=The rope's highlight color.
 entities.CommunalHelper/SJ/DashZipMover.attributes.description.ropeShadowColor=The rope's shadow color.
 entities.CommunalHelper/SJ/DashZipMover.attributes.description.soundEvent=The sound event that plays when the Zip Mover is activated.
+entities.CommunalHelper/SJ/DashZipMover.attributes.description.slow=Makes the Zip Mover slower.\nTo make up for the slower speed, it slams harder, allowing for more liftspeed.
 
 # [Strawberry Jam] Flag Breaker Box 
 entities.CommunalHelper/SJ/FlagBreakerBox.placements.name.breaker_box=Flag Breaker Box [Strawberry Jam]

--- a/src/Components/DreamHoldable.cs
+++ b/src/Components/DreamHoldable.cs
@@ -116,7 +116,7 @@ internal class DreamHoldable : Holdable
     internal static void Unload()
     {
         On.Celeste.Holdable.Check -= Holdable_Check;
-        On.Celeste.Holdable.HitSpring += Holdable_HitSpring;
+        On.Celeste.Holdable.HitSpring -= Holdable_HitSpring;
 
         On.Celeste.Player.NormalUpdate -= Player_NormalUpdate;
         On.Celeste.Player.StartDash -= Player_StartDash;

--- a/src/Entities/StrawberryJam/DashZipMover.cs
+++ b/src/Entities/StrawberryJam/DashZipMover.cs
@@ -149,12 +149,15 @@ namespace Celeste.Mod.CommunalHelper.Entities.StrawberryJam
 
         private string soundEvent;
 
-        public DashZipMover(Vector2 position, int width, int height, Vector2 target, string spritePath, bool drawBlackBorder, Color ropeColor, Color ropeLightColor, Color ropeShadowColor, string sound)
+        private readonly bool slow;
+
+        public DashZipMover(Vector2 position, int width, int height, Vector2 target, string spritePath, bool drawBlackBorder, Color ropeColor, Color ropeLightColor, Color ropeShadowColor, string sound, bool slow)
             : base(position, width, height, safe: false)
         {
             Depth = Depths.FGTerrain + 1;
             start = Position;
             this.target = target;
+            this.slow = slow;
 
             Add(new Coroutine(Sequence()));
             Add(new LightOcclude());
@@ -194,7 +197,7 @@ namespace Celeste.Mod.CommunalHelper.Entities.StrawberryJam
         }
 
         public DashZipMover(EntityData data, Vector2 offset)
-            : this(data.Position + offset, data.Width, data.Height, data.Nodes[0] + offset, data.Attr("spritePath", "objects/CommunalHelper/strawberryJam/dashZipMover/"), data.Bool("drawBlackBorder", false), Calc.HexToColor(data.Attr("ropeColor", "046e19")), Calc.HexToColor(data.Attr("ropeLightColor", "329415")), Calc.HexToColor(data.Attr("ropeShadowColor", "003622")), data.Attr("soundEvent", "event:/CommunalHelperEvents/game/strawberryJam/game/dash_zip_mover/zip_mover"))
+            : this(data.Position + offset, data.Width, data.Height, data.Nodes[0] + offset, data.Attr("spritePath", "objects/CommunalHelper/strawberryJam/dashZipMover/"), data.Bool("drawBlackBorder", false), Calc.HexToColor(data.Attr("ropeColor", "046e19")), Calc.HexToColor(data.Attr("ropeLightColor", "329415")), Calc.HexToColor(data.Attr("ropeShadowColor", "003622")), data.Attr("soundEvent", "event:/CommunalHelperEvents/game/strawberryJam/game/dash_zip_mover/zip_mover"), data.Bool("slow", false))
         {
         }
 
@@ -374,6 +377,8 @@ namespace Celeste.Mod.CommunalHelper.Entities.StrawberryJam
         {
             Vector2 start = Position;
 
+            float factor = slow ? 1.75f : 1f;
+
             while (true)
             {
                 if (!triggered)
@@ -383,10 +388,11 @@ namespace Celeste.Mod.CommunalHelper.Entities.StrawberryJam
                 }
 
                 sfx.Play(soundEvent);
+                //sfx.instance.setPitch(1 / factor); //let them handle the sound event manually
 
                 Input.Rumble(RumbleStrength.Medium, RumbleLength.Short);
-                StartShaking(0.1f);
-                yield return 0.1f;
+                StartShaking(0.1f * factor);
+                yield return 0.1f * factor;
 
                 streetlight.SetAnimationFrame(3);
                 StopPlayerRunIntoAnimation = false;
@@ -396,8 +402,8 @@ namespace Celeste.Mod.CommunalHelper.Entities.StrawberryJam
                 while (at2 < 1f)
                 {
                     yield return null;
-                    at2 = Calc.Approach(at2, 1f, 2f * Engine.DeltaTime);
-                    percent = Ease.SineIn(at2);
+                    at2 = Calc.Approach(at2, 1f, 2f * Engine.DeltaTime * (1/factor));
+                    percent = slow ? Ease.CubeIn(at2) : Ease.SineIn(at2);
                     Vector2 vector = Vector2.Lerp(start, target, percent);
                     ScrapeParticlesCheck(vector);
                     if (Scene.OnInterval(0.1f))
@@ -405,12 +411,12 @@ namespace Celeste.Mod.CommunalHelper.Entities.StrawberryJam
                     MoveTo(vector);
                 }
 
-                StartShaking(0.2f);
+                StartShaking(0.2f * factor);
                 Input.Rumble(RumbleStrength.Strong, RumbleLength.Medium);
                 streetlight.SetAnimationFrame(2);
                 SceneAs<Level>().Shake();
                 StopPlayerRunIntoAnimation = true;
-                yield return 0.5f;
+                yield return 0.5f * factor;
 
                 StopPlayerRunIntoAnimation = false;
                 streetlight.SetAnimationFrame(1);

--- a/src/Entities/StrawberryJam/DashZipMover.cs
+++ b/src/Entities/StrawberryJam/DashZipMover.cs
@@ -1,7 +1,6 @@
 ﻿using Celeste.Mod.CommunalHelper;
 using System.Collections;
 using System.Collections.Generic;
-using static MonoMod.Cil.RuntimeILReferenceBag;
 
 namespace Celeste.Mod.CommunalHelper.Entities.StrawberryJam
 {
@@ -150,6 +149,8 @@ namespace Celeste.Mod.CommunalHelper.Entities.StrawberryJam
         private string soundEvent;
 
         private readonly bool slow;
+
+        private static Ease.Easer EaseSevenHalves = Util.MakeCustomEaser(3.5f);
 
         public DashZipMover(Vector2 position, int width, int height, Vector2 target, string spritePath, bool drawBlackBorder, Color ropeColor, Color ropeLightColor, Color ropeShadowColor, string sound, bool slow)
             : base(position, width, height, safe: false)
@@ -403,7 +404,7 @@ namespace Celeste.Mod.CommunalHelper.Entities.StrawberryJam
                 {
                     yield return null;
                     at2 = Calc.Approach(at2, 1f, 2f * Engine.DeltaTime * (1/factor));
-                    percent = slow ? Ease.CubeIn(at2) : Ease.SineIn(at2);
+                    percent = slow ? EaseSevenHalves(at2) : Ease.SineIn(at2);
                     Vector2 vector = Vector2.Lerp(start, target, percent);
                     ScrapeParticlesCheck(vector);
                     if (Scene.OnInterval(0.1f))

--- a/src/Entities/StrawberryJam/DashZipMover.cs
+++ b/src/Entities/StrawberryJam/DashZipMover.cs
@@ -388,7 +388,7 @@ namespace Celeste.Mod.CommunalHelper.Entities.StrawberryJam
                 }
 
                 sfx.Play(soundEvent);
-                //sfx.instance.setPitch(1 / factor); //let them handle the sound event manually
+                sfx.instance.setPitch(1 / factor);
 
                 Input.Rumble(RumbleStrength.Medium, RumbleLength.Short);
                 StartShaking(0.1f * factor);

--- a/src/Utils/Util.cs
+++ b/src/Utils/Util.cs
@@ -86,6 +86,10 @@ public static class Util
                 return Color.White;
         }
     }
+    public static Ease.Easer MakeCustomEaser(float factor)
+    {
+        return (t) => MathF.Pow(t, factor);
+    }
 
     public static int ToInt(bool b)
     {


### PR DESCRIPTION
Adds a 'Slow' field for Dash Zip Movers that make them 1.75x slower. Also fixes a double On. hook from the Dream Theo implementation