### PR TITLE
Added "No Hole" option to Loop Blocks

### DIFF
--- a/Loenn/entities/strawberry_jam/loop_block.lua
+++ b/Loenn/entities/strawberry_jam/loop_block.lua
@@ -53,13 +53,14 @@ function loopBlock.sprite(room, entity)
     local x, y = entity.x or 0, entity.y or 0
     local width, height = entity.width or 24, entity.height or 24
     local w, h = math.floor(width / 8), math.floor(height / 8)
+    local noHole = entity.noHole or false
 
     math.randomseed(x, y)
 
     local sprites = {}
 
     local tileset = entity.texture or defaultTexture
-    local tiles = generateTorusTiles(w, h, entity.edgeThickness or 1)
+    local tiles = noHole and matrix.filled(true, w, h) or generateTorusTiles(w, h, entity.edgeThickness or 1)
 
     for i = 0, w - 1 do
         for j = 0, h - 1 do

--- a/Loenn/entities/strawberry_jam/loop_block.lua
+++ b/Loenn/entities/strawberry_jam/loop_block.lua
@@ -32,6 +32,7 @@ loopBlock.placements = {
             edgeThickness = 1,
             color = "FFFFFF",
             texture = defaultTexture,
+            noHole = false
         }
     }
 }

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -869,6 +869,7 @@ entities.CommunalHelper/SJ/GrabTempleGate.attributes.description.closed=Whether 
 entities.CommunalHelper/SJ/LoopBlock.placements.name.loop_block=Loop Block [Strawberry Jam]
 entities.CommunalHelper/SJ/LoopBlock.attributes.description.edgeThickness=How thick this loop block's edges are, measured in tiles.
 entities.CommunalHelper/SJ/LoopBlock.attributes.description.color=The hexadecimal color code for this block's tint.
+entities.CommunalHelper/SJ/LoopBlock.attributes.description.noHole=Whether the block should have no hole in the center.
 entities.CommunalHelper/SJ/LoopBlock.attributes.description.texture=The path to this loop block's texture in the Gameplay atlas. Leave at default value or empty for the default texture (original texture from Strawberry Jam).
 
 # [Strawberry Jam] Solar Elevator

--- a/src/Entities/StrawberryJam/LoopBlock.cs
+++ b/src/Entities/StrawberryJam/LoopBlock.cs
@@ -29,6 +29,7 @@ public class LoopBlock : Solid
     private bool canRumble;
     private bool returning, returningDash;
     private bool dashed, scaledSpikes;
+    private bool noHole;
 
     private float respawnTimer;
     private float targetSpeedX;
@@ -40,12 +41,12 @@ public class LoopBlock : Solid
     private const string DEFAULT_TEXTURE = "objects/CommunalHelper/strawberryJam/loopBlock/tiles"; // original sj texture
 
     public LoopBlock(EntityData data, Vector2 offset)
-        : this(data.Position + offset, data.Width, data.Height, data.Int("edgeThickness", 1), data.HexColor("color"), data.Attr("texture", DEFAULT_TEXTURE))
+        : this(data.Position + offset, data.Width, data.Height, data.Int("edgeThickness", 1), data.HexColor("color"), data.Bool("noHole"), data.Attr("texture", DEFAULT_TEXTURE))
     { 
         creatingData = data; 
     }
 
-    public LoopBlock(Vector2 position, int width, int height, int edgeThickness, Color color, string texture = DEFAULT_TEXTURE)
+    public LoopBlock(Vector2 position, int width, int height, int edgeThickness, Color color, bool noHole, string texture = DEFAULT_TEXTURE)
         : base(position, width, height, false)
     {
         Depth = Depths.FGTerrain + 1;
@@ -56,12 +57,13 @@ public class LoopBlock : Solid
         int minEdgeSize = Math.Min(width, height) / 8;
         this.edgeThickness = Calc.Clamp(edgeThickness, 1, (int) ((minEdgeSize - 1) / 2f));
         this.color = color;
-
+        this.noHole = noHole;
+        
         particleType = new(Cloud.P_Cloud)
         {
             Color = color
         };
-
+        
         OnDashCollide = OnDashed;
 
         InitializeTextures(texture);
@@ -78,7 +80,14 @@ public class LoopBlock : Solid
 
         for (int i = 0; i < w; i++)
             for (int j = 0; j < h; j++)
-                tileMap[i, j] = i < edgeThickness || i >= w - edgeThickness || j < edgeThickness || j >= h - edgeThickness;
+                if (!noHole)
+                {
+                    tileMap[i, j] = i < edgeThickness || i >= w - edgeThickness || j < edgeThickness || j >= h - edgeThickness;
+                }
+                else
+                {
+                    tileMap[i, j] = true;
+                }
 
         for (int i = 0; i < w; i++)
         {


### PR DESCRIPTION
Updated the loenn plugin for Loop Blocks to include a boolean option that toggles whether a hole is rendered in the centre of the loop blocks, creating the appearance of one solid block.

![image](https://github.com/user-attachments/assets/f4b545bc-c8d5-4ba2-b1c7-1f97d3b74199)
