### PR TITLE
Dream tunnel dash state check overhaul

### DIFF
--- a/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
+++ b/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
@@ -459,7 +459,7 @@ public static class DreamTunnelDash
         ILLabel failedCheck = null;
         Instruction ceqInstr = null;
         
-        if (!cursor.TryGotoNext(MoveType.AfterLabel,
+        if (!cursor.TryGotoNextFirstFitReversed(MoveType.AfterLabel, 0x10,
             instr => instr.MatchLdfld<Player>("StateMachine"),
             instr => instr.MatchCallvirt<StateMachine>("get_State"),
             instr => instr.MatchLdcI4(state),
@@ -476,7 +476,7 @@ public static class DreamTunnelDash
             }))
             return;
         
-        // beq and bne.un work with labels, whereas ceq just leves a bool so we need to deal with them differently
+        // beq and bne.un work with labels, whereas ceq just leaves a bool so we need to deal with them differently
         if (matchedBeqOrBne)
         {
             // labels for cleaning up duplicate player on stack

--- a/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
+++ b/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
@@ -4,6 +4,7 @@ using Mono.Cecil.Cil;
 using MonoMod.Cil;
 using MonoMod.RuntimeDetour;
 using MonoMod.Utils;
+using On.Celeste.Mod;
 using System.Linq;
 using System.Reflection;
 
@@ -126,7 +127,7 @@ public static class DreamTunnelDash
 
         IL.Celeste.FakeWall.Update += State_DreamDashNotEqual;
         IL.Celeste.Spring.OnCollide += State_DreamDashEqual;
-        IL.Celeste.Solid.Update += State_DreamDashNotEqual_And;
+        IL.Celeste.Solid.Update += State_DreamDashNotEqual;
     }
 
     public static void Unload()
@@ -159,7 +160,7 @@ public static class DreamTunnelDash
 
         IL.Celeste.FakeWall.Update -= State_DreamDashNotEqual;
         IL.Celeste.Spring.OnCollide -= State_DreamDashEqual;
-        IL.Celeste.Solid.Update -= State_DreamDashNotEqual_And;
+        IL.Celeste.Solid.Update -= State_DreamDashNotEqual;
     }
 
     public static void InitializeParticles()
@@ -365,7 +366,7 @@ public static class DreamTunnelDash
         if (il.Instrs[0].OpCode == OpCodes.Nop)
             State_DreamDashEqual(il);
         else
-            State_DreamDashNotEqual_And(il);
+            State_DreamDashNotEqual(il);
     }
 
     private static void Player_BeforeUpTransition(ILContext il)
@@ -373,14 +374,14 @@ public static class DreamTunnelDash
         ILCursor cursor = new(il); 
         
         CheckState(cursor, Player.StRedDash, false);
-        CheckState(cursor, Player.StRedDash, false, true);
+        CheckState(cursor, Player.StRedDash, false);
     }
 
     private static void Player_BeforeDownTransition(ILContext il)
     {
         ILCursor cursor = new(il);
         
-        CheckState(cursor, Player.StRedDash, false, true);
+        CheckState(cursor, Player.StRedDash, false);
     }
 
     private static void Player_TransitionTo(ILContext il)
@@ -429,23 +430,16 @@ public static class DreamTunnelDash
         player.NaiveMove(Vector2.UnitY * moveY);
     }
 
-    // Patch any method that checks the player's State
+    // Utilities to patch any method that checks the player's State
     /// <summary>
-    /// Use if decompilation says <c>State==9</c> and NOT followed by <c>&amp;&amp;</c>.
+    /// Use if decompilation says <c>State==9</c>.
     /// </summary>
     private static readonly ILContext.Manipulator State_DreamDashEqual = il => CheckState(new ILCursor(il), Player.StDreamDash, true);
     /// <summary>
-    /// Use if decompilation says <c>State!=9</c> and NOT followed by <c>&amp;&amp;</c>.
+    /// Use if decompilation says <c>State!=9</c>.
     /// </summary>
     private static readonly ILContext.Manipulator State_DreamDashNotEqual = il => CheckState(new ILCursor(il), Player.StDreamDash, false);
-    /// <summary>
-    /// Use if decompilation says <c>State==9</c> and IS followed by <c>&amp;&amp;</c>.
-    /// </summary>
-    private static readonly ILContext.Manipulator State_DreamDashEqual_And = il => CheckState(new ILCursor(il), Player.StDreamDash, true, true);
-    /// <summary>
-    /// Use if decompilation says <c>State!=9</c> and IS followed by <c>&amp;&amp;</c>.
-    /// </summary>
-    private static readonly ILContext.Manipulator State_DreamDashNotEqual_And = il => CheckState(new ILCursor(il), Player.StDreamDash, false, true);
+
     /// <summary>
     /// Patch any method that checks the player's state.
     /// </summary>
@@ -453,50 +447,89 @@ public static class DreamTunnelDash
     /// <param name="cursor">The ILCursor to use</param>
     /// <param name="state">The state to check for</param>
     /// <param name="equal">Whether the decompilation says <c>State == &lt;state&gt;</c></param>
-    /// <param name="and">Whether the check is followed by <c>&amp;&amp;</c></param>
-    private static void CheckState(ILCursor cursor, int state, bool equal, bool and = false)
+    private static void CheckState(ILCursor cursor, int state, bool equal)
     {
-        if (cursor.TryGotoNext(instr => instr.MatchLdcI4(state) &&
-            instr.Previous != null && instr.Previous.MatchCallvirt<StateMachine>("get_State")))
-        {
-            Instruction idx = cursor.Next;
-            // Duplicate the Player State
-            cursor.Emit(OpCodes.Dup);
-            // Check whether the state matches St.DreamTunnelDash AND we want them to match
-            cursor.EmitDelegate<Func<int, bool>>(st => st == St.DreamTunnelDash == equal ^ and);
-            // If not, skip the rest of the emitted instructions
-            cursor.Emit(OpCodes.Brfalse_S, cursor.Next);
-
-            // Else
-            // Duplicated Player State value will be unused, so it must be trashed
-            cursor.Emit(OpCodes.Pop);
-
-            // Retrieve the next break instruction that checks equality
-            Instruction breakInstr = cursor.Clone().GotoNext(instr => instr.Match(OpCodes.Beq_S) || instr.Match(OpCodes.Bne_Un_S) || instr.Match(OpCodes.Ceq)).Next;
-
-            // For SteamFNA, if there is a check for equality just break to after it after pushing the appropriate value to the stack
-            if (breakInstr.OpCode == OpCodes.Ceq)
+        // essentially, we want to perform these conversions:
+        // `player.StateMachine.State == state` -> `player.StateMachine.State == state || player.StateMachine.State == St.DreamTunnelDash`
+        // `player.StateMachine.State != state` -> `player.StateMachine.State != state && player.StateMachine.State != St.DreamTunnelDash`
+        
+        // variables to grab stuff later
+        Instruction afterMatch = null;
+        
+        bool matchedBeqOrBne = false, matchedCeq = false;
+        ILLabel failedCheck = null;
+        Instruction ceqInstr = null;
+        
+        if (!cursor.TryGotoNext(MoveType.AfterLabel,
+            instr => instr.MatchLdfld<Player>("StateMachine"),
+            instr => instr.MatchCallvirt<StateMachine>("get_State"),
+            instr => instr.MatchLdcI4(state),
+            instr =>
             {
-                cursor.Emit(equal ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0);
-                cursor.Emit(OpCodes.Br_S, breakInstr.Next);
-            }
-            // If our intended behaviour matches what the break instruction is checking for, break to its target
-            else if (breakInstr.OpCode == OpCodes.Beq_S == equal ^ and)
-                cursor.Emit(OpCodes.Br_S, breakInstr.Operand);
-            // Otherwise, break to after the break instruction (skip it)
-            else
-                cursor.Emit(OpCodes.Br_S, breakInstr.Next);
-
-            cursor.Goto(idx, MoveType.After);
+                // we grab a lot of stuff here: the instruction directly after this match, whether we matched a beq/bne.un or a ceq,
+                // the "fail state" label of the beq/bne.un (if we matched one of those) and the actual ceq instruction (if we matched that).
+                
+                afterMatch = instr.Next;
+                // equality checks usually use bne.un (for ==) or beq (for !=) to branch past the block of the if statement if the values don't match
+                matchedBeqOrBne = equal ? instr.MatchBneUn(out failedCheck) : instr.MatchBeq(out failedCheck);
+                matchedCeq = (ceqInstr = instr).MatchCeq();
+                return matchedBeqOrBne || matchedCeq;
+            }))
+            return;
+        
+        // beq and bne.un work with labels, whereas ceq just leves a bool so we need to deal with them differently
+        if (matchedBeqOrBne)
+        {
+            // labels for cleaning up duplicate player on stack
+            ILLabel cleanUpPlayer = cursor.DefineLabel(), pastCleanUpPlayer = cursor.DefineLabel();
+            
+            // duplicate player on stack
+            cursor.Emit(OpCodes.Dup);
+            // check if player is dream tunnel dashing and if so, short-circuit (while also cleaning up the other, now unnecessary duplicate player)
+            cursor.EmitDelegate<Func<Player, bool>>(player => player.StateMachine.State == St.DreamTunnelDash);
+            cursor.Emit(OpCodes.Brtrue, cleanUpPlayer);
+            // else, continue with check as normal
+            
+            // where we short-circuit to depends on whether we check for equality or not.
+            // for equality, we should short-circuit to the "block of the if statement" (past our current condition, whether it be the actual block or another condition),
+            // since our desired behaviour is `player.StateMachine.State == state || player.StateMachine.State == St.DreamTunnelDash` and the first part of that or has been satisfied,
+            // just like how `if (true || condition()) { ... }` should immediately skip checking `condition()` (since `true` or anything is `true`) and run the block inside the if.
+            // for inequality, it's the other way around: we should short-circuit immediately past the rest of the if statement, since our desired behaviour will be
+            // `player.StateMachine.State != state && player.StateMachine.State != St.DreamTunnelDash` and we know the first condition of that and is false, just like how
+            // `if (false && condition()) { ... }` should immediately skip checking `condition()` (since `false` and anything is `false`) and never run the block inside the if.
+            // our `afterMatch` label points to after our current condition, and our `failedCheck` label points to after the rest of the statement.
+            cursor.Goto(equal ? afterMatch : failedCheck.Target);
+            // extra player cleanup, we branch over it in normal behaviour but jump into it if needed (see above)
+            cursor.Emit(OpCodes.Br, pastCleanUpPlayer);
+            cursor.Emit(OpCodes.Pop);
+            cursor.MarkLabel(pastCleanUpPlayer);
+            cursor.Index--;
+            cursor.MarkLabel(cleanUpPlayer);
         }
+        else if (matchedCeq)
+        {
+            // duplicate player on stack
+            cursor.Emit(OpCodes.Dup);
+            // go to the ceq instruction and modify the value it returns
+            cursor.Goto(ceqInstr, MoveType.After);
+            // our desired value for what the ceq instruction returns depends on whether we check equality or not. but we don't control that, the brtrue/brfalse after the ceq does.
+            // to solve this, our desired conditions can be shown equivalent to `player.StateMachine.State == state || player.StateMachine.State == St.DreamTunnelDash` (for equality) and
+            // `!(player.StateMachine.State == state || player.StateMachine.State == St.DreamTunnelDash)` (for inequality). notice how the desired condition for inequality is simply
+            // the inverse of the one for equality. this is great, because the brtrue/brfalse after the ceq will do the required inversion (or lack thereof) for the check, and all
+            // we need to do is calculate the thing on the inside. conveniently, the ceq is already checking for the left term (so that is its return value), and we just need to or it with the right.
+            cursor.EmitDelegate<Func<Player, bool, bool>>((player, orig) => orig || player.StateMachine.State == St.DreamTunnelDash);
+        }
+
+        // go to after the current match to continue with the il hook (no infinite loops!)
+        cursor.Goto(afterMatch, MoveType.After);
     }
 
     private static void Player_orig_Update(ILContext il)
     {
         ILCursor cursor = new(il);
         CheckState(cursor, Player.StDreamDash, true);
-        CheckState(cursor, Player.StDreamDash, false, true);
-        CheckState(cursor, Player.StDreamDash, false, true);
+        CheckState(cursor, Player.StDreamDash, false);
+        CheckState(cursor, Player.StDreamDash, false);
         // Not used because we DO want to enforce Level bounds.
         //Check_State_DreamDash(cursor, false, true);
     }

--- a/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
+++ b/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
@@ -429,7 +429,7 @@ public static class DreamTunnelDash
         player.NaiveMove(Vector2.UnitY * moveY);
     }
 
-    // Utilities to patch any method that checks the player's State
+    // Utilities to patch any method that checks the player's State.
     /// <summary>
     /// Use if decompilation says <c>State==9</c>.
     /// </summary>
@@ -440,17 +440,19 @@ public static class DreamTunnelDash
     private static readonly ILContext.Manipulator State_DreamDashNotEqual = il => CheckState(new ILCursor(il), Player.StDreamDash, false);
 
     /// <summary>
-    /// Patch any method that checks the player's state.
+    /// Patch any method that checks the player's State.
     /// </summary>
-    /// <remarks>Checks for <c>ldc.i4.s &lt;state&gt;</c></remarks>
+    /// <remarks>Checks for <c>ldc.i4.s &lt;state&gt;</c>.</remarks>
     /// <param name="cursor">The ILCursor to use</param>
     /// <param name="state">The state to check for</param>
-    /// <param name="equal">Whether the decompilation says <c>State == &lt;state&gt;</c></param>
+    /// <param name="equal">Whether to check for <c>== &lt;state&gt;</c> or <c>!= &lt;state&gt;</c></param>
     private static void CheckState(ILCursor cursor, int state, bool equal)
     {
         // essentially, we want to perform these conversions:
-        // `player.StateMachine.State == state` -> `player.StateMachine.State == state || player.StateMachine.State == St.DreamTunnelDash`
-        // `player.StateMachine.State != state` -> `player.StateMachine.State != state && player.StateMachine.State != St.DreamTunnelDash`
+        //  - `player.StateMachine.State == <state>` -> `player.StateMachine.State == St.DreamTunnelDash || player.StateMachine.State == <state>`
+        //  - `player.StateMachine.State != <state>` -> `player.StateMachine.State != St.DreamTunnelDash && player.StateMachine.State != <state>`
+        // the dream tunnel dash check comes before the normal check because 1. it's more predictable to implement and 2. vanilla has no state checks
+        // that cause side effects and would thus be broken by our short-circuiting method.
         
         // go to before the state check
         if (!cursor.TryGotoNextFirstFitReversed(MoveType.AfterLabel, 0x10,
@@ -459,48 +461,50 @@ public static class DreamTunnelDash
             instr => instr.MatchLdcI4(state)))
             return;
         
-        // variables to grab various things
         bool matchedBeqOrBne = false, matchedCeq = false;
         ILLabel failedCheck = null;
         Instruction ceqInstr = null;
         
-        // retrieve the instruction after the current check
+        // retrieve info about the current check
         ILCursor cloned = cursor.Clone();
         if (!cloned.TryGotoNext(MoveType.After, instr =>
             {
                 // we grab a lot of stuff here: whether we matched a beq/bne.un or a ceq, the "fail state" label of the beq/bne.un
                 // (if we matched one of those) and the actual ceq instruction (if we matched that).
 
-                // equality checks usually use bne.un (for ==) or beq (for !=) in order to branch past the block of the if statement if the values don't match
+                // equality checks usually use bne.un (for ==) or beq (for !=) to branch past the block of the if statement when the values don't match
                 matchedBeqOrBne = equal ? instr.MatchBneUn(out failedCheck) : instr.MatchBeq(out failedCheck);
+                // alternatively they could use ceq and then a brtrue/brfalse to do the same, though i don't think there are any for this purpose in vanilla
                 matchedCeq = (ceqInstr = instr).MatchCeq();
+                
                 return matchedBeqOrBne || matchedCeq;
             })) return;
+        // and the instruction after the current check
         Instruction afterMatch = cloned.Next!;
         
         // beq and bne.un work with labels, whereas ceq just leaves a bool so we need to deal with them differently
         if (matchedBeqOrBne)
         {
-            // labels for cleaning up duplicate player on stack
+            // labels for cleaning up duplicate player left on stack
             ILLabel cleanUpPlayer = cursor.DefineLabel(), pastCleanUpPlayer = cursor.DefineLabel();
             
             // duplicate player on stack
             cursor.Emit(OpCodes.Dup);
-            // check if player is dream tunnel dashing and if so, short-circuit (while also cleaning up the other, now unnecessary duplicate player)
+            // check if player is dream tunnel dashing and if so, short-circuit (while also popping the other, now unnecessary duplicate player off the stack)
             cursor.EmitDelegate<Func<Player, bool>>(player => player.StateMachine.State == St.DreamTunnelDash);
             cursor.Emit(OpCodes.Brtrue, cleanUpPlayer);
             // else, continue with check as normal
             
             // where we short-circuit to depends on whether we check for equality or not.
-            // for equality, we should short-circuit to the "block of the if statement" (past our current condition, whether it be the actual block or another condition),
-            // since our desired behaviour is `player.StateMachine.State == state || player.StateMachine.State == St.DreamTunnelDash` and the first part of that or has been satisfied,
+            // for equality, we should short-circuit to the "block" of the if statement (past our current condition, whether it be the actual block or another condition),
+            // since our desired behaviour is `player.StateMachine.State == state || player.StateMachine.State == St.DreamTunnelDash` and the first term of that or has been satisfied,
             // just like how `if (true || condition()) { ... }` should immediately skip checking `condition()` (since `true` or anything is `true`) and run the block inside the if.
-            // for inequality, it's the other way around: we should short-circuit immediately past the rest of the if statement, since our desired behaviour will be
+            // for inequality, it's the other way around: we should short-circuit past the rest of the if statement (skipping the block), since our desired behaviour will be
             // `player.StateMachine.State != state && player.StateMachine.State != St.DreamTunnelDash` and we know the first condition of that and is false, just like how
             // `if (false && condition()) { ... }` should immediately skip checking `condition()` (since `false` and anything is `false`) and never run the block inside the if.
             // our `afterMatch` label points to after our current condition, and our `failedCheck` label points to after the rest of the statement.
             cursor.Goto(equal ? afterMatch : failedCheck.Target);
-            // extra player cleanup, we branch over it in normal behaviour but jump into it if needed (see above)
+            // extra player cleanup, we skip over it in normal behaviour but jump into it if needed (see above)
             cursor.Emit(OpCodes.Br, pastCleanUpPlayer);
             cursor.Emit(OpCodes.Pop);
             cursor.MarkLabel(pastCleanUpPlayer);
@@ -515,10 +519,10 @@ public static class DreamTunnelDash
             // go to the ceq instruction and modify the value it returns
             cursor.Goto(ceqInstr, MoveType.After);
             // our desired value for what the ceq instruction returns depends on whether we check equality or not. but we don't control that, the brtrue/brfalse after the ceq does.
-            // to solve this, our desired conditions can be shown equivalent to `player.StateMachine.State == state || player.StateMachine.State == St.DreamTunnelDash` (for equality) and
-            // `!(player.StateMachine.State == state || player.StateMachine.State == St.DreamTunnelDash)` (for inequality). notice how the desired condition for inequality is simply
-            // the inverse of the one for equality. this is great, because the brtrue/brfalse after the ceq will do the required inversion (or lack thereof) for the check, and all
-            // we need to do is calculate the thing on the inside. conveniently, the ceq is already checking for the left term, and we just need to or it with the right.
+            // to solve this, our desired conditions can be shown equivalent to `player.StateMachine.State == state || player.StateMachine.State == St.DreamTunnelDash` (for equality)
+            // and `!(player.StateMachine.State == state || player.StateMachine.State == St.DreamTunnelDash)` (for inequality). notice how the desired condition for inequality is
+            // simplythe inverse of the one for equality. this is great, because the brtrue/brfalse after the ceq will do the required inversion (or lack thereof) for the check, and
+            // all we need to do is calculate the thing on the inside. conveniently, the ceq is already checking for the left term, and we just need to or it with the right.
             cursor.EmitDelegate<Func<Player, bool, bool>>((player, orig) => orig || player.StateMachine.State == St.DreamTunnelDash);
         }
 

--- a/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
+++ b/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
@@ -100,10 +100,10 @@ public static class DreamTunnelDash
         On.Celeste.Player.DreamDashCheck += Player_DreamDashCheck;
         On.Celeste.Player.Update += Player_Update;
         On.Celeste.Player.Die += Player_Die;
+        
         hook_Player_DashCoroutine = new ILHook(
             typeof(Player).GetMethod("DashCoroutine", BindingFlags.NonPublic | BindingFlags.Instance).GetStateMachineTarget(),
             Player_DashCoroutine);
-
         IL.Celeste.Player.IsRiding_Solid += State_DreamDashEqual;
         IL.Celeste.Player.IsRiding_JumpThru += Player_IsRiding_JumpThru;
         IL.Celeste.Player.OnCollideH += State_DreamDashEqual;

--- a/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
+++ b/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
@@ -4,7 +4,6 @@ using Mono.Cecil.Cil;
 using MonoMod.Cil;
 using MonoMod.RuntimeDetour;
 using MonoMod.Utils;
-using On.Celeste.Mod;
 using System.Linq;
 using System.Reflection;
 

--- a/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
+++ b/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
@@ -429,7 +429,7 @@ public static class DreamTunnelDash
         player.NaiveMove(Vector2.UnitY * moveY);
     }
 
-    // Utilities to patch any method that checks the player's State
+    // Utilities to patch any method that checks the player's State.
     /// <summary>
     /// Use if decompilation says <c>State==9</c>.
     /// </summary>
@@ -440,17 +440,19 @@ public static class DreamTunnelDash
     private static readonly ILContext.Manipulator State_DreamDashNotEqual = il => CheckState(new ILCursor(il), Player.StDreamDash, false);
 
     /// <summary>
-    /// Patch any method that checks the player's state.
+    /// Patch any method that checks the player's State.
     /// </summary>
-    /// <remarks>Checks for <c>ldc.i4.s &lt;state&gt;</c></remarks>
+    /// <remarks>Checks for <c>ldc.i4.s &lt;state&gt;</c>.</remarks>
     /// <param name="cursor">The ILCursor to use</param>
     /// <param name="state">The state to check for</param>
-    /// <param name="equal">Whether the decompilation says <c>State == &lt;state&gt;</c></param>
+    /// <param name="equal">Whether to check for <c>== &lt;state&gt;</c> or <c>!= &lt;state&gt;</c></param>
     private static void CheckState(ILCursor cursor, int state, bool equal)
     {
         // essentially, we want to perform these conversions:
-        // `player.StateMachine.State == state` -> `player.StateMachine.State == state || player.StateMachine.State == St.DreamTunnelDash`
-        // `player.StateMachine.State != state` -> `player.StateMachine.State != state && player.StateMachine.State != St.DreamTunnelDash`
+        //  - `player.StateMachine.State == <state>` -> `player.StateMachine.State == St.DreamTunnelDash || player.StateMachine.State == <state>`
+        //  - `player.StateMachine.State != <state>` -> `player.StateMachine.State != St.DreamTunnelDash && player.StateMachine.State != <state>`
+        // the dream tunnel dash check comes before the normal check because 1. it's more predictable to implement and 2. vanilla has no state checks
+        // that cause side effects and would thus be broken by our short-circuiting method.
         
         // go to before the state check
         if (!cursor.TryGotoNextFirstFitReversed(MoveType.AfterLabel, 0x10,
@@ -459,48 +461,50 @@ public static class DreamTunnelDash
             instr => instr.MatchLdcI4(state)))
             return;
         
-        // variables to grab various things
         bool matchedBeqOrBne = false, matchedCeq = false;
         ILLabel failedCheck = null;
         Instruction ceqInstr = null;
         
-        // retrieve the instruction after the current check
+        // retrieve info about the current check
         ILCursor cloned = cursor.Clone();
         if (!cloned.TryGotoNext(MoveType.After, instr =>
             {
                 // we grab a lot of stuff here: whether we matched a beq/bne.un or a ceq, the "fail state" label of the beq/bne.un
                 // (if we matched one of those) and the actual ceq instruction (if we matched that).
 
-                // equality checks usually use bne.un (for ==) or beq (for !=) in order to branch past the block of the if statement if the values don't match
+                // equality checks usually use bne.un (for ==) or beq (for !=) to branch past the block of the if statement when the values don't match
                 matchedBeqOrBne = equal ? instr.MatchBneUn(out failedCheck) : instr.MatchBeq(out failedCheck);
+                // alternatively they could use ceq and then a brtrue/brfalse to do the same, though i don't think there are any for this purpose in vanilla
                 matchedCeq = (ceqInstr = instr).MatchCeq();
+                
                 return matchedBeqOrBne || matchedCeq;
             })) return;
+        // and the instruction after the current check
         Instruction afterMatch = cloned.Next!;
         
         // beq and bne.un work with labels, whereas ceq just leaves a bool so we need to deal with them differently
         if (matchedBeqOrBne)
         {
-            // labels for cleaning up duplicate player on stack
+            // labels for cleaning up duplicate player left on stack
             ILLabel cleanUpPlayer = cursor.DefineLabel(), pastCleanUpPlayer = cursor.DefineLabel();
             
             // duplicate player on stack
             cursor.Emit(OpCodes.Dup);
-            // check if player is dream tunnel dashing and if so, short-circuit (while also cleaning up the other, now unnecessary duplicate player)
+            // check if player is dream tunnel dashing and if so, short-circuit (while also popping the other, now unnecessary duplicate player off the stack)
             cursor.EmitDelegate<Func<Player, bool>>(player => player.StateMachine.State == St.DreamTunnelDash);
             cursor.Emit(OpCodes.Brtrue, cleanUpPlayer);
             // else, continue with check as normal
             
             // where we short-circuit to depends on whether we check for equality or not.
-            // for equality, we should short-circuit to the "block of the if statement" (past our current condition, whether it be the actual block or another condition),
-            // since our desired behaviour is `player.StateMachine.State == state || player.StateMachine.State == St.DreamTunnelDash` and the first part of that or has been satisfied,
+            // for equality, we should short-circuit to the "block" of the if statement (past our current condition, whether it be the actual block or another condition),
+            // since our desired behaviour is `player.StateMachine.State == state || player.StateMachine.State == St.DreamTunnelDash` and the first term of that or has been satisfied,
             // just like how `if (true || condition()) { ... }` should immediately skip checking `condition()` (since `true` or anything is `true`) and run the block inside the if.
-            // for inequality, it's the other way around: we should short-circuit immediately past the rest of the if statement, since our desired behaviour will be
+            // for inequality, it's the other way around: we should short-circuit past the rest of the if statement (skipping the block), since our desired behaviour will be
             // `player.StateMachine.State != state && player.StateMachine.State != St.DreamTunnelDash` and we know the first condition of that and is false, just like how
             // `if (false && condition()) { ... }` should immediately skip checking `condition()` (since `false` and anything is `false`) and never run the block inside the if.
             // our `afterMatch` label points to after our current condition, and our `failedCheck` label points to after the rest of the statement.
             cursor.Goto(equal ? afterMatch : failedCheck.Target);
-            // extra player cleanup, we branch over it in normal behaviour but jump into it if needed (see above)
+            // extra player cleanup, we skip over it in normal behaviour but jump into it if needed (see above)
             cursor.Emit(OpCodes.Br, pastCleanUpPlayer);
             cursor.Emit(OpCodes.Pop);
             cursor.MarkLabel(pastCleanUpPlayer);

--- a/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
+++ b/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
@@ -474,20 +474,22 @@ public static class DreamTunnelDash
         
         bool matchedBeqOrBne = false, matchedCeq = false;
         ILLabel failedCheck = null;
-        Instruction ceqInstr = null;
+        Instruction checkInstr = null;
         
         // retrieve info about the current check
         ILCursor cloned = cursor.Clone();
         if (!cloned.TryGotoNext(MoveType.After, instr =>
             {
-                // we grab a lot of stuff here: whether we matched a beq/bne.un or a ceq, the "fail state" label of the beq/bne.un
-                // (if we matched one of those) and the actual ceq instruction (if we matched that).
-
-                // equality checks usually use bne.un (for ==) or beq (for !=) to branch past the block of the if statement when the values don't match
+                // we grab a lot of stuff here: whether we matched a beq/bne.un or a ceq, the "fail state" label of the beq/bne.un (if we matched one of those)
+                // and the check instruction itself.
+            
+                // equality checks usually use bne.un (for `==`) or beq (for `!=`) in order to branch past the block of the if statement when the values don't match
                 matchedBeqOrBne = equal ? instr.MatchBneUn(out failedCheck) : instr.MatchBeq(out failedCheck);
                 // alternatively they could use ceq and then a brtrue/brfalse to do the same, though i don't think there are any for this purpose in vanilla
-                matchedCeq = (ceqInstr = instr).MatchCeq();
-                
+                matchedCeq = instr.MatchCeq();
+                // the instruction we're testing is the one doing the check; grab it
+                checkInstr = instr;
+            
                 return matchedBeqOrBne || matchedCeq;
             })) return;
         // and the instruction after the current check
@@ -528,7 +530,7 @@ public static class DreamTunnelDash
             // duplicate player on stack
             cursor.Emit(OpCodes.Dup);
             // go to the ceq instruction and modify the value it returns
-            cursor.Goto(ceqInstr, MoveType.After);
+            cursor.Goto(checkInstr, MoveType.After);
             // our desired value for what the ceq instruction returns depends on whether we check equality or not. but we don't control that, the brtrue/brfalse after the ceq does.
             // to solve this, our desired conditions can be shown equivalent to `player.StateMachine.State == state || player.StateMachine.State == St.DreamTunnelDash` (for equality)
             // and `!(player.StateMachine.State == state || player.StateMachine.State == St.DreamTunnelDash)` (for inequality). notice how the desired condition for inequality is

--- a/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
+++ b/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
@@ -536,7 +536,7 @@ public static class DreamTunnelDash
             // our desired value for what the ceq instruction returns depends on whether we check equality or not. but we don't control that, the brtrue/brfalse after the ceq does.
             // to solve this, our desired conditions can be shown equivalent to `player.StateMachine.State == state || player.StateMachine.State == St.DreamTunnelDash` (for equality)
             // and `!(player.StateMachine.State == state || player.StateMachine.State == St.DreamTunnelDash)` (for inequality). notice how the desired condition for inequality is
-            // simplythe inverse of the one for equality. this is great, because the brtrue/brfalse after the ceq will do the required inversion (or lack thereof) for the check, and
+            // simply the inverse of the one for equality. this is great, because the brtrue/brfalse after the ceq will do the required inversion (or lack thereof) for the check, and
             // all we need to do is calculate the thing on the inside. conveniently, the ceq is already checking for the left term, and we just need to or it with the right.
             cursor.EmitDelegate<Func<Player, bool, bool>>((player, orig) => orig || player.StateMachine.State == St.DreamTunnelDash);
         }

--- a/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
+++ b/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
@@ -452,29 +452,31 @@ public static class DreamTunnelDash
         // `player.StateMachine.State == state` -> `player.StateMachine.State == state || player.StateMachine.State == St.DreamTunnelDash`
         // `player.StateMachine.State != state` -> `player.StateMachine.State != state && player.StateMachine.State != St.DreamTunnelDash`
         
-        // variables to grab stuff later
-        Instruction afterMatch = null;
+        // go to before the state check
+        if (!cursor.TryGotoNextFirstFitReversed(MoveType.AfterLabel, 0x10,
+            instr => instr.MatchLdfld<Player>("StateMachine"),
+            instr => instr.MatchCallvirt<StateMachine>("get_State"),
+            instr => instr.MatchLdcI4(state)))
+            return;
         
+        // variables to grab various things
         bool matchedBeqOrBne = false, matchedCeq = false;
         ILLabel failedCheck = null;
         Instruction ceqInstr = null;
         
-        if (!cursor.TryGotoNextFirstFitReversed(MoveType.AfterLabel, 0x10,
-            instr => instr.MatchLdfld<Player>("StateMachine"),
-            instr => instr.MatchCallvirt<StateMachine>("get_State"),
-            instr => instr.MatchLdcI4(state),
-            instr =>
+        // retrieve the instruction after the current check
+        ILCursor cloned = cursor.Clone();
+        if (!cloned.TryGotoNext(MoveType.After, instr =>
             {
-                // we grab a lot of stuff here: the instruction directly after this match, whether we matched a beq/bne.un or a ceq,
-                // the "fail state" label of the beq/bne.un (if we matched one of those) and the actual ceq instruction (if we matched that).
-                
-                afterMatch = instr.Next;
-                // equality checks usually use bne.un (for ==) or beq (for !=) to branch past the block of the if statement if the values don't match
+                // we grab a lot of stuff here: whether we matched a beq/bne.un or a ceq, the "fail state" label of the beq/bne.un
+                // (if we matched one of those) and the actual ceq instruction (if we matched that).
+
+                // equality checks usually use bne.un (for ==) or beq (for !=) in order to branch past the block of the if statement if the values don't match
                 matchedBeqOrBne = equal ? instr.MatchBneUn(out failedCheck) : instr.MatchBeq(out failedCheck);
                 matchedCeq = (ceqInstr = instr).MatchCeq();
                 return matchedBeqOrBne || matchedCeq;
-            }))
-            return;
+            })) return;
+        Instruction afterMatch = cloned.Next!;
         
         // beq and bne.un work with labels, whereas ceq just leaves a bool so we need to deal with them differently
         if (matchedBeqOrBne)
@@ -503,6 +505,7 @@ public static class DreamTunnelDash
             cursor.Emit(OpCodes.Pop);
             cursor.MarkLabel(pastCleanUpPlayer);
             cursor.Index--;
+            // mark label to short-circuit to
             cursor.MarkLabel(cleanUpPlayer);
         }
         else if (matchedCeq)
@@ -515,7 +518,7 @@ public static class DreamTunnelDash
             // to solve this, our desired conditions can be shown equivalent to `player.StateMachine.State == state || player.StateMachine.State == St.DreamTunnelDash` (for equality) and
             // `!(player.StateMachine.State == state || player.StateMachine.State == St.DreamTunnelDash)` (for inequality). notice how the desired condition for inequality is simply
             // the inverse of the one for equality. this is great, because the brtrue/brfalse after the ceq will do the required inversion (or lack thereof) for the check, and all
-            // we need to do is calculate the thing on the inside. conveniently, the ceq is already checking for the left term (so that is its return value), and we just need to or it with the right.
+            // we need to do is calculate the thing on the inside. conveniently, the ceq is already checking for the left term, and we just need to or it with the right.
             cursor.EmitDelegate<Func<Player, bool, bool>>((player, orig) => orig || player.StateMachine.State == St.DreamTunnelDash);
         }
 

--- a/src/Utils/Extensions.cs
+++ b/src/Utils/Extensions.cs
@@ -3,6 +3,8 @@ using Celeste.Mod.CommunalHelper.Imports;
 using Celeste.Mod.Helpers;
 using FMOD.Studio;
 using Microsoft.Xna.Framework.Graphics;
+using Mono.Cecil.Cil;
+using MonoMod.Cil;
 using MonoMod.Utils;
 using System.Collections;
 using System.Collections.Generic;
@@ -784,4 +786,296 @@ public static class Extensions
         return el.Attributes.TryGetValue(name, out object value)
                && Enum.TryParse(value.ToString(), true, out T result) ? result : defaultValue;
     }
+    
+    #region ILCursor extensions
+    
+    /// <summary>
+    /// Go to the next match of a given IL sequence, allowing up to <paramref name="maxInstructionSpread"/> instructions of tolerance if the instructions are not sequential.<br/>
+    /// (i.e. if something else hooks the same sequence)
+    /// </summary>
+    /// <param name="cursor">The IL cursor to look for a match in.</param>
+    /// <param name="moveType">The move type to use.</param>
+    /// <param name="maxInstructionSpread">The amount of instructions between predicate matches to still consider as a successful match.</param>
+    /// <param name="predicates">The IL instructions to match against.</param>
+    /// <remarks>
+    /// This function picks the first match, which might not have the least possible instruction spread.<br/>
+    /// For that, see <see cref="Helpers.ILCursorExtensions.TryGotoNextBestFit(ILCursor,MoveType,int,Func&lt;Instruction,bool&gt;[])"/>.
+    /// </remarks>
+    /// <returns>Whether a match has been found, and the cursor has been moved.</returns>
+    public static bool TryGotoNextFirstFit(this ILCursor cursor, MoveType moveType, int maxInstructionSpread, params Func<Instruction, bool>[] predicates)
+    {
+        if (predicates.Length == 0)
+        {
+            throw new ArgumentException("No predicates given.");
+        }
+
+        if (predicates.Length == 1)
+        {
+            return cursor.TryGotoNext(moveType, predicates[0]);
+        }
+
+        int matchFrom = -1, matchTo = -1;
+        while (cursor.TryGotoNext(MoveType.Before, predicates[0]))
+        {
+            matchFrom = cursor.Index++;
+            bool flag = true;
+            for (int i = 1; i < predicates.Length; i++)
+            {
+                Func<Instruction, bool> func = predicates[i];
+                int index = cursor.Index;
+                if (!cursor.TryGotoNext(MoveType.After, func))
+                {
+                    flag = false;
+                    break;
+                }
+
+                int instructionSpread = cursor.Index - index;
+                if (instructionSpread > maxInstructionSpread)
+                {
+                    flag = false;
+                    break;
+                }
+            }
+
+            if (flag)
+            {
+                matchTo = cursor.Index;
+                break;
+            }
+
+            cursor.Index = matchFrom + 1;
+        }
+
+        if (matchFrom == -1 || matchTo == -1)
+        {
+            return false;
+        }
+
+        cursor.Index = moveType != MoveType.After ? matchFrom : matchTo;
+        if (moveType == MoveType.AfterLabel)
+        {
+            cursor.MoveAfterLabels();
+        }
+
+        return true;
+    }
+    
+    /// <summary>
+    /// Go to the previous match of a given IL sequence, allowing up to <paramref name="maxInstructionSpread"/> instructions of tolerance if the instructions are not sequential.<br/>
+    /// (i.e. if something else hooks the same sequence)
+    /// </summary>
+    /// <param name="cursor">The IL cursor to look for a match in.</param>
+    /// <param name="moveType">The move type to use.</param>
+    /// <param name="maxInstructionSpread">The amount of instructions between predicate matches to still consider as a successful match.</param>
+    /// <param name="predicates">The IL instructions to match against.</param>
+    /// <remarks>
+    /// This function picks the first match, which might not have the least possible instruction spread.<br/>
+    /// For that, see <see cref="Helpers.ILCursorExtensions.TryGotoPrevBestFit(ILCursor,MoveType,int,Func&lt;Instruction,bool&gt;[])"/>.
+    /// </remarks>
+    /// <returns>Whether a match has been found, and the cursor has been moved.</returns>
+    public static bool TryGotoPrevFirstFit(this ILCursor cursor, MoveType moveType, int maxInstructionSpread, params Func<Instruction, bool>[] predicates)
+    {
+        if (predicates.Length == 0)
+        {
+            throw new ArgumentException("No predicates given.");
+        }
+
+        if (predicates.Length == 1)
+        {
+            return cursor.TryGotoNext(moveType, predicates[0]);
+        }
+
+        int matchFrom = -1, matchTo = -1;
+        while (cursor.TryGotoPrev(MoveType.Before, predicates[0]))
+        {
+            matchFrom = cursor.Index++;
+            bool flag = true;
+            for (int i = 1; i < predicates.Length; i++)
+            {
+                Func<Instruction, bool> func = predicates[i];
+                int index = cursor.Index;
+                if (!cursor.TryGotoNext(MoveType.After, func))
+                {
+                    flag = false;
+                    break;
+                }
+
+                int instructionSpread = cursor.Index - index;
+                if (instructionSpread > maxInstructionSpread)
+                {
+                    flag = false;
+                    break;
+                }
+            }
+
+            if (flag)
+            {
+                matchTo = cursor.Index;
+                break;
+            }
+
+            cursor.Index = matchFrom;
+        }
+
+        if (matchFrom == -1 || matchTo == -1)
+        {
+            return false;
+        }
+
+        cursor.Index = moveType != MoveType.After ? matchFrom : matchTo;
+        if (moveType == MoveType.AfterLabel)
+        {
+            cursor.MoveAfterLabels();
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Go to the next match of a given IL sequence, allowing up to <paramref name="maxInstructionSpread"/> instructions of tolerance if the instructions are not sequential, checking the match in reverse order.<br/>
+    /// (i.e. if something else hooks the same sequence)
+    /// </summary>
+    /// <param name="cursor">The IL cursor to look for a match in.</param>
+    /// <param name="moveType">The move type to use.</param>
+    /// <param name="maxInstructionSpread">The amount of instructions between predicate matches to still consider as a successful match.</param>
+    /// <param name="predicates">The IL instructions to match against.</param>
+    /// <remarks>
+    /// This function picks the first match, which might not have the least possible instruction spread.<br/>
+    /// For that, see <see cref="Helpers.ILCursorExtensions.TryGotoNextBestFit(ILCursor,MoveType,int,Func&lt;Instruction,bool&gt;[])"/>.<br/>
+    /// This function also checks its match predicates in reverse order, starting from the last.<br/>
+    /// If you do not want this behavior, see <see cref="TryGotoNextFirstFit"/>.
+    /// </remarks>
+    /// <returns>Whether a match has been found, and the cursor has been moved.</returns>
+    public static bool TryGotoNextFirstFitReversed(this ILCursor cursor, MoveType moveType, int maxInstructionSpread, params Func<Instruction, bool>[] predicates)
+    {
+        if (predicates.Length == 0)
+        {
+            throw new ArgumentException("No predicates given.");
+        }
+
+        if (predicates.Length == 1)
+        {
+            return cursor.TryGotoNext(moveType, predicates[0]);
+        }
+
+        int matchFrom = -1, matchTo = -1;
+        while (cursor.TryGotoNext(MoveType.Before, predicates[^1]))
+        {
+            matchTo = cursor.Index + 1;
+            bool flag = true;
+            for (int i = predicates.Length - 2; i >= 0; i--)
+            {
+                Func<Instruction, bool> func = predicates[i];
+                int index = cursor.Index;
+                if (!cursor.TryGotoPrev(MoveType.Before, func))
+                {
+                    flag = false;
+                    break;
+                }
+
+                int instructionSpread = index - cursor.Index;
+                if (instructionSpread > maxInstructionSpread)
+                {
+                    flag = false;
+                    break;
+                }
+            }
+
+            if (flag)
+            {
+                matchFrom = cursor.Index;
+                break;
+            }
+
+            cursor.Index = matchTo + 1;
+        }
+
+        if (matchFrom == -1 || matchTo == -1)
+        {
+            return false;
+        }
+
+        cursor.Index = moveType != MoveType.After ? matchFrom : matchTo;
+        if (moveType == MoveType.AfterLabel)
+        {
+            cursor.MoveAfterLabels();
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Go to the previous match of a given IL sequence, allowing up to <paramref name="maxInstructionSpread"/> instructions of tolerance if the instructions are not sequential, checking the match in reverse order.<br/>
+    /// (i.e. if something else hooks the same sequence)
+    /// </summary>
+    /// <param name="cursor">The IL cursor to look for a match in.</param>
+    /// <param name="moveType">The move type to use.</param>
+    /// <param name="maxInstructionSpread">The amount of instructions between predicate matches to still consider as a successful match.</param>
+    /// <param name="predicates">The IL instructions to match against.</param>
+    /// <remarks>
+    /// This function picks the first match, which might not have the least possible instruction spread.<br/>
+    /// For that, see <see cref="Helpers.ILCursorExtensions.TryGotoPrevBestFit(ILCursor,MoveType,int,Func&lt;Instruction,bool&gt;[])"/>.<br/>
+    /// This function also checks its match predicates in reverse order, starting from the last.<br/>
+    /// If you do not want this behavior, see <see cref="TryGotoNextFirstFit"/>.
+    /// </remarks>
+    /// <returns>Whether a match has been found, and the cursor has been moved.</returns>
+    public static bool TryGotoPrevFirstFitReversed(this ILCursor cursor, MoveType moveType, int maxInstructionSpread, params Func<Instruction, bool>[] predicates)
+    {
+        if (predicates.Length == 0)
+        {
+            throw new ArgumentException("No predicates given.");
+        }
+
+        if (predicates.Length == 1)
+        {
+            return cursor.TryGotoNext(moveType, predicates[0]);
+        }
+
+        int matchFrom = -1, matchTo = -1;
+        while (cursor.TryGotoPrev(MoveType.Before, predicates[^1]))
+        {
+            matchTo = cursor.Index + 1;
+            bool flag = true;
+            for (int i = predicates.Length - 2; i >= 0; i--)
+            {
+                Func<Instruction, bool> func = predicates[i];
+                int index = cursor.Index;
+                if (!cursor.TryGotoPrev(MoveType.Before, func))
+                {
+                    flag = false;
+                    break;
+                }
+
+                int instructionSpread = index - cursor.Index;
+                if (instructionSpread > maxInstructionSpread)
+                {
+                    flag = false;
+                    break;
+                }
+            }
+
+            if (flag)
+            {
+                matchFrom = cursor.Index;
+                break;
+            }
+
+            cursor.Index = matchFrom;
+        }
+
+        if (matchFrom == -1 || matchTo == -1)
+        {
+            return false;
+        }
+
+        cursor.Index = moveType != MoveType.After ? matchFrom : matchTo;
+        if (moveType == MoveType.AfterLabel)
+        {
+            cursor.MoveAfterLabels();
+        }
+
+        return true;
+    }
+    
+    #endregion
 }

--- a/src/Utils/Extensions.cs
+++ b/src/Utils/Extensions.cs
@@ -790,8 +790,7 @@ public static class Extensions
     #region ILCursor extensions
     
     /// <summary>
-    /// Go to the next match of a given IL sequence, allowing up to <paramref name="maxInstructionSpread"/> instructions of tolerance if the instructions are not sequential.<br/>
-    /// (i.e. if something else hooks the same sequence)
+    /// Go to the next match of a given IL sequence, allowing up to <paramref name="maxInstructionSpread"/> instructions of tolerance if the instructions are not sequential (i.e. if something else hooks the same sequence).
     /// </summary>
     /// <param name="cursor">The IL cursor to look for a match in.</param>
     /// <param name="moveType">The move type to use.</param>
@@ -861,8 +860,7 @@ public static class Extensions
     }
     
     /// <summary>
-    /// Go to the previous match of a given IL sequence, allowing up to <paramref name="maxInstructionSpread"/> instructions of tolerance if the instructions are not sequential.<br/>
-    /// (i.e. if something else hooks the same sequence)
+    /// Go to the previous match of a given IL sequence, allowing up to <paramref name="maxInstructionSpread"/> instructions of tolerance if the instructions are not sequential (i.e. if something else hooks the same sequence).
     /// </summary>
     /// <param name="cursor">The IL cursor to look for a match in.</param>
     /// <param name="moveType">The move type to use.</param>
@@ -932,8 +930,7 @@ public static class Extensions
     }
 
     /// <summary>
-    /// Go to the next match of a given IL sequence, allowing up to <paramref name="maxInstructionSpread"/> instructions of tolerance if the instructions are not sequential, checking the match in reverse order.<br/>
-    /// (i.e. if something else hooks the same sequence)
+    /// Go to the next match of a given IL sequence, allowing up to <paramref name="maxInstructionSpread"/> instructions of tolerance if the instructions are not sequential (i.e. if something else hooks the same sequence), checking the match in reverse order.
     /// </summary>
     /// <param name="cursor">The IL cursor to look for a match in.</param>
     /// <param name="moveType">The move type to use.</param>
@@ -1005,8 +1002,7 @@ public static class Extensions
     }
 
     /// <summary>
-    /// Go to the previous match of a given IL sequence, allowing up to <paramref name="maxInstructionSpread"/> instructions of tolerance if the instructions are not sequential, checking the match in reverse order.<br/>
-    /// (i.e. if something else hooks the same sequence)
+    /// Go to the previous match of a given IL sequence, allowing up to <paramref name="maxInstructionSpread"/> instructions of tolerance if the instructions are not sequential (i.e. if something else hooks the same sequence), checking the match in reverse order.
     /// </summary>
     /// <param name="cursor">The IL cursor to look for a match in.</param>
     /// <param name="moveType">The move type to use.</param>


### PR DESCRIPTION
Overhauls the dream tunnel dash IL hook state check logic to no longer use an unnecessary, bug inducing `and` parameter and to have more comprehensive documentation. Also adds new ILCursor extensions (which are most of the diff, sorry) that can be used to make this kind of hooking more resilient to other mods inserting instructions.
This also fixes https://github.com/CommunalHelper/CommunalHelper/issues/240.