### PR TITLE
Implement Dream Tunnel Blockers

### DIFF
--- a/Loenn/entities/misc/dream_tunnel_blocker.lua
+++ b/Loenn/entities/misc/dream_tunnel_blocker.lua
@@ -1,0 +1,43 @@
+﻿local triggers = require("triggers")
+local depths = require("consts.object_depths")
+local drawableRectangle = require("structs.drawable_rectangle")
+local drawableText = require("structs.drawable_text")
+local colors = require("consts.colors")
+
+local dreamTunnelBlocker = {}
+
+dreamTunnelBlocker.name = "CommunalHelper/DreamTunnelBlocker"
+dreamTunnelBlocker.depth = depths.fakeWalls + 2000;
+
+dreamTunnelBlocker.placements = {
+    name = "normal",
+    data = {
+        width = 16,
+        height = 16,
+        blockDreamTunnelDashes = true,
+        blockDreamDashes = false
+    }
+}
+
+-- adapted from triggers.getDrawable
+function dreamTunnelBlocker.sprite(room, entity)
+    local displayName = triggers.triggerText(room, entity)
+
+    local x = entity.x or 0
+    local y = entity.y or 0
+
+    local width = entity.width or 16
+    local height = entity.height or 16
+
+    local borderedRectangle = drawableRectangle.fromRectangle("bordered", x, y, width, height, colors.triggerColor, colors.triggerBorderColor)
+    local textDrawable = drawableText.fromText(displayName, x, y, width, height, nil, triggers.triggerFontSize, colors.triggerTextColor)
+
+    local drawables = borderedRectangle:getDrawableSprite()
+    table.insert(drawables, textDrawable)
+
+    textDrawable.depth = dreamTunnelBlocker.depth - 1
+
+    return drawables
+end
+
+return dreamTunnelBlocker

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -979,6 +979,10 @@ entities.CommunalHelper/SJ/PelletEmitter.attributes.description.wiggleFrequency=
 entities.CommunalHelper/SJ/PelletEmitter.attributes.description.wiggleAmount=The amplitude of the wiggle. Defaults to 2. Set to 0 to disable wiggling, causing pellets to travel in a straight line.
 entities.CommunalHelper/SJ/PelletEmitter.attributes.description.wiggleHitbox=Whether or not the pellet hitbox should move following the wiggle.
 
+entities.CommunalHelper/DreamTunnelBlocker.placements.name.normal=Dream Tunnel Blocker
+entities.CommunalHelper/DreamTunnelBlocker.attributes.description.blockDreamTunnelDashes=Whether to prevent dream tunneling when dashing into a solid covered by this entity.
+entities.CommunalHelper/DreamTunnelBlocker.attributes.description.blockDreamDashes=Whether to prevent dream dashing when dashing into a dream block covered by this entity.
+
 # ---------------------- TRIGGERS --------------------------
 
 # [Strawberry Jam] Show Hitbox Trigger

--- a/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
+++ b/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
@@ -1,9 +1,11 @@
 ﻿using Celeste.Mod.CommunalHelper.Components;
+using Celeste.Mod.CommunalHelper.Entities;
 using Celeste.Mod.CommunalHelper.States;
 using Mono.Cecil.Cil;
 using MonoMod.Cil;
 using MonoMod.RuntimeDetour;
 using MonoMod.Utils;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
@@ -50,6 +52,8 @@ public static class DreamTunnelDash
     public static Color[] DreamTrailColors;
     public static int DreamTrailColorIndex = 0;
 
+    // Keep a List<Entity> around to not allocate a new one every CollideAll<T>() call
+    private static List<Entity> dreamTunnelBlockers = new();
 
     private static IDetour hook_Player_DashCoroutine;
     private static IDetour hook_Player_orig_Update;
@@ -348,7 +352,14 @@ public static class DreamTunnelDash
 
     private static bool Player_DreamDashCheck(On.Celeste.Player.orig_DreamDashCheck orig, Player self, Vector2 dir)
     {
-        return overrideDreamDashCheck ? (overrideDreamDashCheck = false) : orig(self, dir);
+        if (overrideDreamDashCheck)
+            return overrideDreamDashCheck = false;
+
+        // Don't enter StDreamDash if there's a blocker
+        if (self.IsDreamDashBlocked(self.Position + dir))
+            return false;
+
+        return orig(self, dir);
     }
 
     // Fixes bug with dreamSfx soundsource not being stopped
@@ -659,6 +670,10 @@ public static class DreamTunnelDash
             if (player.Left + dir.X < bounds.Left || player.Right + dir.X > bounds.Right || player.Top + dir.Y < bounds.Top || player.Bottom + dir.Y > bounds.Bottom)
                 return false;
 
+            // Check if we're colliding with a DreamTunnelBlocker
+            if (player.IsDreamTunnelDashBlocked(player.Position + dir))
+                return false;
+
             Solid solid = null;
 
             // Check for dream blocks first, then for solids
@@ -738,6 +753,37 @@ public static class DreamTunnelDash
             }
         }
         return false;
+    }
+
+    private static (bool blockDreamTunnelDashes, bool blockDreamDashes) GetBlockerConfiguration(this Player player, Vector2 position)
+    {
+        bool blockDreamTunnelDashes = false;
+        bool blockDreamDashes = false;
+
+        foreach (Entity e in player.CollideAll<DreamTunnelBlocker>(position, dreamTunnelBlockers))
+        {
+            if (e is DreamTunnelBlocker { BlockDreamTunnelDashes: true })
+                blockDreamTunnelDashes = true;
+            if (e is DreamTunnelBlocker { BlockDreamDashes: true })
+                blockDreamDashes = true;
+
+            if (blockDreamTunnelDashes && blockDreamDashes)
+                break;
+        }
+
+        return (blockDreamTunnelDashes, blockDreamDashes);
+    }
+
+    private static bool IsDreamTunnelDashBlocked(this Player player, Vector2 position)
+    {
+        return player.CollideAll<DreamTunnelBlocker>(position, dreamTunnelBlockers)
+            .Any(e => e is DreamTunnelBlocker { BlockDreamTunnelDashes: true });
+    }
+
+    private static bool IsDreamDashBlocked(this Player player, Vector2 position)
+    {
+        return player.CollideAll<DreamTunnelBlocker>(position, dreamTunnelBlockers)
+            .Any(e => e is DreamTunnelBlocker { BlockDreamDashes: true });
     }
 
     #endregion

--- a/src/Entities/Misc/DreamTunnelBlocker.cs
+++ b/src/Entities/Misc/DreamTunnelBlocker.cs
@@ -1,0 +1,20 @@
+﻿namespace Celeste.Mod.CommunalHelper.Entities;
+
+[Tracked]
+[CustomEntity("CommunalHelper/DreamTunnelBlocker")]
+public class DreamTunnelBlocker : Entity
+{
+    public bool BlockDreamTunnelDashes;
+    public bool BlockDreamDashes;
+
+    /// Blocking behavior handled in <see cref="DashStates.DreamTunnelDash.DreamTunnelDashCheck" />
+    /// and <see cref="DashStates.DreamTunnelDash.Player_DreamDashCheck"/>
+    public DreamTunnelBlocker(EntityData data, Vector2 offset) : base(data.Position + offset)
+    {
+        Collider = new Hitbox(data.Width, data.Height);
+        Depth = Depths.FakeWalls + 2000;
+
+        BlockDreamTunnelDashes = data.Bool("blockDreamTunnelDashes", true);
+        BlockDreamDashes = data.Bool("blockDreamDashes", false);
+    }
+}


### PR DESCRIPTION
Allows the mapper to prevent entering a dream tunnel/dream dash when colliding with solids/dream blocks covered by this entity.

> [!NOTE]
> If the player is already in the dream dash/dream tunnel state, this entity has no effect.