### PR TITLE
Flag functionaliy for Manual Cassette controller

### DIFF
--- a/Loenn/entities/cassette_blocks/manual_cassette_controller.lua
+++ b/Loenn/entities/cassette_blocks/manual_cassette_controller.lua
@@ -1,18 +1,22 @@
-local cassetteJumpFixController = {}
+local manualCassetteController = {}
 
-cassetteJumpFixController.name = "CommunalHelper/ManualCassetteController"
-cassetteJumpFixController.depth = -1000000
+manualCassetteController.name = "CommunalHelper/ManualCassetteController"
+manualCassetteController.depth = -1000000
 
-cassetteJumpFixController.placements = {
+manualCassetteController.placements = {
     {
         name = "controller",
         data = {
-            startIndex = 0
+            startIndex = 0,
+            blueFlag = "cas_blue",
+            pinkFlag = "cas_rose",
+            yellowFlag = "cas_brightsun",
+            greenFlag = "cas_malachite",
         }
     }
 }
 
 local alt = math.random(100) == 42
-cassetteJumpFixController.texture = string.format("objects/CommunalHelper/manualCassetteController/icon%s", (alt and "_wacked" or ""))
+manualCassetteController.texture = string.format("objects/CommunalHelper/manualCassetteController/icon%s", (alt and "_wacked" or ""))
 
-return cassetteJumpFixController
+return manualCassetteController

--- a/Loenn/entities/cassette_blocks/manual_cassette_controller.lua
+++ b/Loenn/entities/cassette_blocks/manual_cassette_controller.lua
@@ -8,10 +8,6 @@ manualCassetteController.placements = {
         name = "controller",
         data = {
             startIndex = 0,
-            blueFlag = "cas_blue",
-            pinkFlag = "cas_rose",
-            yellowFlag = "cas_brightsun",
-            greenFlag = "cas_malachite",
         }
     }
 }

--- a/src/Entities/CassetteBlocks/ManualCassetteController.cs
+++ b/src/Entities/CassetteBlocks/ManualCassetteController.cs
@@ -14,20 +14,14 @@ public class ManualCassetteController : AbstractInputController
     private int roomBeats;
     private int currentIndex;
 
-    private string blueFlag;
-    private string pinkFlag;
-    private string yellowFlag;
-    private string greenFlag;
+    private const string blueFlag = "CH_cas_blue";
+    private const string pinkFlag = "CH_cas_rose";
+    private const string yellowFlag = "CH_cas_brightsun";
+    private const string greenFlag = "CH_cas_malachite";
 
     public ManualCassetteController(EntityData data)
     {
         startIndex = data.Int("startIndex", 0);
-              
-        // do not change those flags!
-        blueFlag = "CH_cas_blue";
-        pinkFlag = "CH_cas_rose";
-        yellowFlag = "CH_cas_brightsun";
-        greenFlag = "CH_cas_malachite";
 
         Visible = Collidable = false;
     }
@@ -55,21 +49,15 @@ public class ManualCassetteController : AbstractInputController
 
     public override void Update()
     {
-
         base.Update();
         if (CommunalHelperModule.Settings.CycleCassetteBlocks.Pressed)
-        {
             Tick();
-        }
-
     }
 
     public override void FrozenUpdate()
     {
         if (CommunalHelperModule.Settings.CycleCassetteBlocks.Pressed)
-        {
             Tick();
-        }
     }
 
     public void Tick()
@@ -82,38 +70,14 @@ public class ManualCassetteController : AbstractInputController
         Input.Rumble(RumbleStrength.Medium, RumbleLength.Short);
     }
 
-    public void SetFlag (int index)
+    public void SetFlag(int index)
     {
         Session session = SceneAs<Level>().Session;
-        switch (index)
-        {
-            case 0:
-                session.SetFlag(blueFlag, true);
-                session.SetFlag(pinkFlag, false);
-                session.SetFlag(yellowFlag, false);
-                session.SetFlag(greenFlag, false);
-                break;
-            case 1:
-                session.SetFlag(blueFlag, false);
-                session.SetFlag(pinkFlag, true);
-                session.SetFlag(yellowFlag, false);
-                session.SetFlag(greenFlag, false);
-                break;
-            case 2:
-                session.SetFlag(blueFlag, false);
-                session.SetFlag(pinkFlag, false);
-                session.SetFlag(yellowFlag, true);
-                session.SetFlag(greenFlag, false);
-                break;
-            case 3:
-                session.SetFlag(blueFlag, false);
-                session.SetFlag(pinkFlag, false);
-                session.SetFlag(yellowFlag, false);
-                session.SetFlag(greenFlag, true);
-                break;
-        }
+        session.SetFlag(blueFlag, index == 0);
+        session.SetFlag(pinkFlag, index == 1);
+        session.SetFlag(yellowFlag, index == 2);
+        session.SetFlag(greenFlag, index == 3);
     }
-
 
     public void SetActiveIndex(int index, bool silent = false)
     {

--- a/src/Entities/CassetteBlocks/ManualCassetteController.cs
+++ b/src/Entities/CassetteBlocks/ManualCassetteController.cs
@@ -22,10 +22,10 @@ public class ManualCassetteController : AbstractInputController
     public ManualCassetteController(EntityData data)
     {
         startIndex = data.Int("startIndex", 0);
-        blueFlag = data.Attr("blueFlag", "cas_blue");
-        pinkFlag = data.Attr("pinkFlag", "cas_rose");
-        yellowFlag = data.Attr("yellowFlag", "cas_brightsun");
-        greenFlag = data.Attr("greenFlag", "cas_malachite");
+        blueFlag = "CH_cas_blue";
+        pinkFlag = "CH_cas_rose";
+        yellowFlag = "CH_cas_brightsun";
+        greenFlag = "CH_cas_malachite";
 
         Visible = Collidable = false;
     }

--- a/src/Entities/CassetteBlocks/ManualCassetteController.cs
+++ b/src/Entities/CassetteBlocks/ManualCassetteController.cs
@@ -22,6 +22,8 @@ public class ManualCassetteController : AbstractInputController
     public ManualCassetteController(EntityData data)
     {
         startIndex = data.Int("startIndex", 0);
+              
+        // do not change those flags!
         blueFlag = "CH_cas_blue";
         pinkFlag = "CH_cas_rose";
         yellowFlag = "CH_cas_brightsun";

--- a/src/Entities/CassetteBlocks/ManualCassetteController.cs
+++ b/src/Entities/CassetteBlocks/ManualCassetteController.cs
@@ -1,6 +1,7 @@
-﻿using Mono.Cecil.Cil;
+using Mono.Cecil.Cil;
 using MonoMod.Cil;
 using MonoMod.RuntimeDetour;
+using System;
 using System.Linq;
 using System.Reflection;
 
@@ -13,13 +14,27 @@ public class ManualCassetteController : AbstractInputController
     private int roomBeats;
     private int currentIndex;
 
+    private string blueFlag;
+    private string pinkFlag;
+    private string yellowFlag;
+    private string greenFlag;
+
     public ManualCassetteController(EntityData data)
     {
         startIndex = data.Int("startIndex", 0);
+        blueFlag = data.Attr("blueFlag", "cas_blue");
+        pinkFlag = data.Attr("pinkFlag", "cas_rose");
+        yellowFlag = data.Attr("yellowFlag", "cas_brightsun");
+        greenFlag = data.Attr("greenFlag", "cas_malachite");
 
         Visible = Collidable = false;
     }
 
+    public override void Added(Scene scene)
+    {
+        base.Added(scene);
+        SetFlag(startIndex);
+    }
     public override void Awake(Scene scene)
     {
         base.Awake(scene);
@@ -59,10 +74,44 @@ public class ManualCassetteController : AbstractInputController
     {
         currentIndex++;
         currentIndex %= roomBeats;
+        SetFlag(currentIndex);
         SetActiveIndex(currentIndex);
         Audio.Play("event:/game/general/cassette_block_switch_" + ((currentIndex % 2) + 1));
         Input.Rumble(RumbleStrength.Medium, RumbleLength.Short);
     }
+
+    public void SetFlag (int index)
+    {
+        Session session = SceneAs<Level>().Session;
+        switch (index)
+        {
+            case 0:
+                session.SetFlag(blueFlag, true);
+                session.SetFlag(pinkFlag, false);
+                session.SetFlag(yellowFlag, false);
+                session.SetFlag(greenFlag, false);
+                break;
+            case 1:
+                session.SetFlag(blueFlag, false);
+                session.SetFlag(pinkFlag, true);
+                session.SetFlag(yellowFlag, false);
+                session.SetFlag(greenFlag, false);
+                break;
+            case 2:
+                session.SetFlag(blueFlag, false);
+                session.SetFlag(pinkFlag, false);
+                session.SetFlag(yellowFlag, true);
+                session.SetFlag(greenFlag, false);
+                break;
+            case 3:
+                session.SetFlag(blueFlag, false);
+                session.SetFlag(pinkFlag, false);
+                session.SetFlag(yellowFlag, false);
+                session.SetFlag(greenFlag, true);
+                break;
+        }
+    }
+
 
     public void SetActiveIndex(int index, bool silent = false)
     {


### PR DESCRIPTION
Currently, manual cassette controller (Communal Helper) and cassette flag controller (Crystalline Helper) are incompatible. After raising this issue to Vitellary, we came to the conclusion it would be best to add flag functionality to manual cassette controller.

The PR basically merges the two controllers together. There may be a better way to get the flag names field in loenn, the implementation I used is identical to the one in Crystalline however (and preserves the same names too)

Also the lua file for manual cassette controller referred to it as "jump fix controller" for some reason, so I fixed it on the way.