### PR TITLE
Add Retract Speed Modifier to Chained Kevins

### DIFF
--- a/Loenn/entities/chains/chained_kevin.lua
+++ b/Loenn/entities/chains/chained_kevin.lua
@@ -33,6 +33,7 @@ for _, direction in pairs(directions) do
                 chillout = false,
                 chainLength = 64,
                 direction = direction,
+                retractSpeedModifier = 1.0,
                 chainOutline = true,
                 centeredChain = false,
                 chainTexture = "objects/CommunalHelper/chains/chain"

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -517,7 +517,7 @@ entities.CommunalHelper/ChainedKevin.placements.name.up=Kevin (Chained, Up)
 entities.CommunalHelper/ChainedKevin.placements.name.down=Kevin (Chained, Down)
 entities.CommunalHelper/ChainedKevin.placements.name.left=Kevin (Chained, Left)
 entities.CommunalHelper/ChainedKevin.placements.name.right=Kevin (Chained, Right)
-entities.CommunalHelper/ChainedKevin.attributes.description.chillouts=Whether the block should have the large face and get tired after being hit.
+entities.CommunalHelper/ChainedKevin.attributes.description.chillout=Whether the block should have the large face and get tired after being hit.
 entities.CommunalHelper/ChainedKevin.attributes.description.chainLength=The length of the chain holding the block, which will be unable to go past this distance.
 entities.CommunalHelper/ChainedKevin.attributes.description.direction=The only direction in which this block will travel.
 entities.CommunalHelper/ChainedKevin.attributes.description.retractSpeedModifier=Multiplier for the retract speed of the Kevin (1.0 = normal Kevin retract speed).

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -517,9 +517,10 @@ entities.CommunalHelper/ChainedKevin.placements.name.up=Kevin (Chained, Up)
 entities.CommunalHelper/ChainedKevin.placements.name.down=Kevin (Chained, Down)
 entities.CommunalHelper/ChainedKevin.placements.name.left=Kevin (Chained, Left)
 entities.CommunalHelper/ChainedKevin.placements.name.right=Kevin (Chained, Right)
-entities.CommunalHelper/ChainedKevin.attributes.description.chillout=Whether the block should have the large face and get tired after being hit.
+entities.CommunalHelper/ChainedKevin.attributes.description.chillouts=Whether the block should have the large face and get tired after being hit.
 entities.CommunalHelper/ChainedKevin.attributes.description.chainLength=The length of the chain holding the block, which will be unable to go past this distance.
 entities.CommunalHelper/ChainedKevin.attributes.description.direction=The only direction in which this block will travel.
+entities.CommunalHelper/ChainedKevin.attributes.description.retractSpeedModifier=Multiplier for the retract speed of the Kevin (1.0 = normal Kevin retract speed).
 entities.CommunalHelper/ChainedKevin.attributes.description.centeredChain=Renders only one chain at the horizontal or vertical center of this block, depending on the direction.
 entities.CommunalHelper/ChainedKevin.attributes.description.chainOutline=Whether the chain of this block should have a black outline.
 entities.CommunalHelper/ChainedKevin.attributes.description.chainTexture=The texture for this Chained Kevin's chain.

--- a/src/Entities/Chains/ChainedKevin.cs
+++ b/src/Entities/Chains/ChainedKevin.cs
@@ -14,6 +14,7 @@ internal class ChainedKevin : CrushBlock
     private readonly int chainLength;
     private bool centeredChain;
     private readonly bool chainOutline;
+    private readonly float retractSpeedModifier;
     private readonly MTexture chainTexture;
 
     private DynamicData crushBlockData;
@@ -25,6 +26,12 @@ internal class ChainedKevin : CrushBlock
         start = Position;
         chainLength = data.Int("chainLength", 64);
         chainOutline = data.Bool("chainOutline", true);
+        retractSpeedModifier = data.Float("retractSpeedModifier", 1.0f);
+        if (retractSpeedModifier <= 0)
+        {
+            Logger.Warn("CommunalHelper", "Invalid chained kevin retract speed modifier! Setting to 1.0 (default).");
+            retractSpeedModifier = 1.0f;
+        }
         if (((direction == Directions.Up || direction == Directions.Down) && Width <= 8) ||
             ((direction == Directions.Left || direction == Directions.Right) && Height <= 8))
             centeredChain = true;
@@ -80,6 +87,8 @@ internal class ChainedKevin : CrushBlock
 
         base.Render();
     }
+    
+    
 
     #region Hooks
 
@@ -91,6 +100,8 @@ internal class ChainedKevin : CrushBlock
         On.Celeste.CrushBlock.CanActivate += CrushBlock_CanActivate;
         On.Celeste.CrushBlock.MoveHCheck += CrushBlock_MoveHCheck;
         On.Celeste.CrushBlock.MoveVCheck += CrushBlock_MoveVCheck;
+        On.Celeste.Platform.MoveTowardsX += Platform_MoveTowardsX;
+        On.Celeste.Platform.MoveTowardsY += Platform_MoveTowardsY;
     }
 
     internal static void Unload()
@@ -101,6 +112,33 @@ internal class ChainedKevin : CrushBlock
         On.Celeste.CrushBlock.CanActivate -= CrushBlock_CanActivate;
         On.Celeste.CrushBlock.MoveHCheck -= CrushBlock_MoveHCheck;
         On.Celeste.CrushBlock.MoveVCheck -= CrushBlock_MoveVCheck;
+        On.Celeste.Platform.MoveTowardsX -= Platform_MoveTowardsX;
+        On.Celeste.Platform.MoveTowardsY -= Platform_MoveTowardsY;
+    }
+    
+    private static void Platform_MoveTowardsX(On.Celeste.Platform.orig_MoveTowardsX orig, Platform self, float x, float amount)
+    {
+        if (self is ChainedKevin chainedKevin)
+        {  
+            if (chainedKevin.crushDir == Vector2.Zero)
+            {
+                amount *= chainedKevin.retractSpeedModifier;
+            }
+        }
+        orig(self, x, amount);
+    }
+    
+    
+    private static void Platform_MoveTowardsY(On.Celeste.Platform.orig_MoveTowardsY orig, Platform self, float y, float amount)
+    {
+        if (self is ChainedKevin chainedKevin)
+        {
+            if (chainedKevin.crushDir == Vector2.Zero)
+            {
+                amount *= chainedKevin.retractSpeedModifier;
+            }
+        }
+        orig(self, y, amount);
     }
 
     private static bool CrushBlock_MoveVCheck(On.Celeste.CrushBlock.orig_MoveVCheck orig, CrushBlock self, float amount)

--- a/src/Entities/Chains/ChainedKevin.cs
+++ b/src/Entities/Chains/ChainedKevin.cs
@@ -1,5 +1,9 @@
-﻿using MonoMod.Utils;
+﻿using Mono.Cecil.Cil;
+using MonoMod.Cil;
+using MonoMod.RuntimeDetour;
+using MonoMod.Utils;
 using System.Collections.Generic;
+using System.Reflection;
 using Directions = Celeste.MoveBlock.Directions;
 
 namespace Celeste.Mod.CommunalHelper.Entities;
@@ -87,10 +91,12 @@ internal class ChainedKevin : CrushBlock
 
         base.Render();
     }
-    
-    
+
+
 
     #region Hooks
+
+    private static ILHook il_CrushBlock_AttackSequence_MoveNext;
 
     internal static void Load()
     {
@@ -100,8 +106,11 @@ internal class ChainedKevin : CrushBlock
         On.Celeste.CrushBlock.CanActivate += CrushBlock_CanActivate;
         On.Celeste.CrushBlock.MoveHCheck += CrushBlock_MoveHCheck;
         On.Celeste.CrushBlock.MoveVCheck += CrushBlock_MoveVCheck;
-        On.Celeste.Platform.MoveTowardsX += Platform_MoveTowardsX;
-        On.Celeste.Platform.MoveTowardsY += Platform_MoveTowardsY;
+
+        il_CrushBlock_AttackSequence_MoveNext = new ILHook(
+            typeof(CrushBlock).GetMethod("AttackSequence", BindingFlags.NonPublic | BindingFlags.Instance).GetStateMachineTarget(),
+            IL_CrushBlock_AttackSequence
+        );
     }
 
     internal static void Unload()
@@ -112,33 +121,21 @@ internal class ChainedKevin : CrushBlock
         On.Celeste.CrushBlock.CanActivate -= CrushBlock_CanActivate;
         On.Celeste.CrushBlock.MoveHCheck -= CrushBlock_MoveHCheck;
         On.Celeste.CrushBlock.MoveVCheck -= CrushBlock_MoveVCheck;
-        On.Celeste.Platform.MoveTowardsX -= Platform_MoveTowardsX;
-        On.Celeste.Platform.MoveTowardsY -= Platform_MoveTowardsY;
+
+        il_CrushBlock_AttackSequence_MoveNext.Dispose(); il_CrushBlock_AttackSequence_MoveNext = null;
     }
-    
-    private static void Platform_MoveTowardsX(On.Celeste.Platform.orig_MoveTowardsX orig, Platform self, float x, float amount)
+
+    private static void IL_CrushBlock_AttackSequence(ILContext il)
     {
-        if (self is ChainedKevin chainedKevin)
-        {  
-            if (chainedKevin.crushDir == Vector2.Zero)
-            {
-                amount *= chainedKevin.retractSpeedModifier;
-            }
-        }
-        orig(self, x, amount);
-    }
-    
-    
-    private static void Platform_MoveTowardsY(On.Celeste.Platform.orig_MoveTowardsY orig, Platform self, float y, float amount)
-    {
-        if (self is ChainedKevin chainedKevin)
-        {
-            if (chainedKevin.crushDir == Vector2.Zero)
-            {
-                amount *= chainedKevin.retractSpeedModifier;
-            }
-        }
-        orig(self, y, amount);
+        ILCursor cursor = new(il);
+
+        cursor.GotoNext(instr => instr.MatchLdstr(SFX.game_06_crushblock_return_loop));
+        cursor.GotoNext(MoveType.After, instr => instr.MatchLdcR4(60.0f));
+
+        cursor.Emit(OpCodes.Ldloc_1);
+        cursor.EmitDelegate((float speed, CrushBlock e) => e is ChainedKevin block ? block.retractSpeedModifier * speed : speed);
+
+        System.Console.WriteLine(cursor);
     }
 
     private static bool CrushBlock_MoveVCheck(On.Celeste.CrushBlock.orig_MoveVCheck orig, CrushBlock self, float amount)


### PR DESCRIPTION
Add retract speed modifier to chained kevins.
Implementation creates two new hooks, which isn't ideal, but there didn't seem to be a cleaner way to do it and the hooked methods (MoveTowardsX/MoveTowardsY) aren't actually used that often (MoveTowardsX only for Kevins, in fact).
Per request for a collab.