### PR TITLE
Add Bounce On Collision, Revert On Death and Revert On Leave options to Configure Dream Tunnel Dash triggers

### DIFF
--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -1070,6 +1070,11 @@ triggers.CommunalHelper/ConfigureElytraTrigger.placements.name.no=Disable Elytra
 triggers.CommunalHelper/ConfigureElytraTrigger.attributes.description.allow=Whether the player can deploy its elytra after going through the trigger.\nThe elytra is deployed with a keybind configured in mod settings.\nDefault is W on keyboard, and Left Shoulder on controller.
 triggers.CommunalHelper/ConfigureElytraTrigger.attributes.description.infinite=If this trigger enables the elytra, this option will make it so that deploying the elytra does not consume a dash. Note that this can potentially be used to build infinite height (over long distances).
 triggers.CommunalHelper/ConfigureElytraTrigger.attributes.description.disableReverseVerticalMomentum=Disables the vertical boost the player gets when deploying the elytra facing the opposite direction they are moving.
+triggers.CommunalHelper/ConfigureElytraTrigger.attributes.description.revertOnLeave=Whether to revert this trigger's effects when the player leaves it.
+triggers.CommunalHelper/ConfigureElytraTrigger.attributes.description.revertOnDeath=Whether to revert this trigger's effects when the player dies.
+triggers.CommunalHelper/ConfigureElytraTrigger.attributes.description.onlyOnce=Whether this trigger should only activate once per room load.
+triggers.CommunalHelper/ConfigureElytraTrigger.attributes.description.flag=The flag this trigger should react to. Leave empty for this trigger to not be affected by flags.
+triggers.CommunalHelper/ConfigureElytraTrigger.attributes.description.flagInverted=If checked, the trigger will be disabled when the flag is active.\nIf unchecked, the trigger will be enabled when the flag is active.
 
 # Configure Dream Tunnel Dash Trigger
 triggers.CommunalHelper/ConfigureDreamTunnelDashTrigger.placements.name.trigger=Configure Dream Tunnel Dash
@@ -1082,6 +1087,12 @@ triggers.CommunalHelper/ConfigureDreamTunnelDashTrigger.attributes.description.c
 triggers.CommunalHelper/ConfigureDreamTunnelDashTrigger.attributes.description.allowDashCancels=Allows the dream tunnel dash to be cancelled before tunnelling through solids. Replicates vanilla behavior of being able to instant hyper, for example, on dream blocks.
 triggers.CommunalHelper/ConfigureDreamTunnelDashTrigger.attributes.description.redirectConsumesNormalDash=Whether dream tunnel dash redirects should consume the player's normal dashes instead of their dream tunnel dashes.
 triggers.CommunalHelper/ConfigureDreamTunnelDashTrigger.attributes.description.allowTransitions=Whether to allow screen transitions while dream tunnel dashing.
+triggers.CommunalHelper/ConfigureDreamTunnelDashTrigger.attributes.description.bounceOnCollision=Whether the player should bounce on collision with a dream block while dream tunnel dashing.
+triggers.CommunalHelper/ConfigureDreamTunnelDashTrigger.attributes.description.revertOnLeave=Whether to revert this trigger's effects when the player leaves it.
+triggers.CommunalHelper/ConfigureDreamTunnelDashTrigger.attributes.description.revertOnDeath=Whether to revert this trigger's effects when the player dies.
+triggers.CommunalHelper/ConfigureDreamTunnelDashTrigger.attributes.description.onlyOnce=Whether this trigger should only activate once per room load.
+triggers.CommunalHelper/ConfigureDreamTunnelDashTrigger.attributes.description.flag=The flag this trigger should react to. Leave empty for this trigger to not be affected by flags.
+triggers.CommunalHelper/ConfigureDreamTunnelDashTrigger.attributes.description.flagInverted=If checked, the trigger will be disabled when the flag is active.\nIf unchecked, the trigger will be enabled when the flag is active.
 
 # Follow Shapeshifter Path Trigger
 triggers.CommunalHelper/FollowShapeshifterPathTrigger.placements.name.follow_path=Follow Shapeshifter Path

--- a/Loenn/triggers/configure_dream_tunnel_dash.lua
+++ b/Loenn/triggers/configure_dream_tunnel_dash.lua
@@ -13,6 +13,12 @@ return {
                 allowDashCancels = false,
                 redirectConsumesNormalDash = false,
                 allowTransitions = false,
+                bounceOnCollision = false,
+                revertOnLeave = false,
+                revertOnDeath = false,
+                onlyOnce = false,
+                flag = "",
+                flagInverted = false,
             }
         }
     },
@@ -25,5 +31,13 @@ return {
             },
             editable = false,
         }
-    }
+    },
+    fieldOrder = {
+        "x", "y", "width", "height",
+        "allowRedirect", "allowSameDirectionRedirect", "sameDirectionSpeedMultiplier", "redirectConsumesNormalDash",
+        "useEntryDirection", "speedConfiguration", "customSpeed",
+        "allowDashCancels", "allowTransitions", "bounceOnCollision",
+        "revertOnLeave", "revertOnDeath", "onlyOnce",
+        "flag", "flagInverted",
+    },
 }

--- a/Loenn/triggers/configure_elytra.lua
+++ b/Loenn/triggers/configure_elytra.lua
@@ -1,7 +1,7 @@
 return {
     name = "CommunalHelper/ConfigureElytraTrigger",
     ignoredFields = {
-        "_name", "_id", "_type", "infinite"
+        "_name", "_id", "_type", "infinite",
     },
     placements = {
         {
@@ -10,6 +10,11 @@ return {
                 allow = true,
                 infinite = false,
                 disableReverseVerticalMomentum = false,
+                revertOnLeave = false,
+                revertOnDeath = false,
+                onlyOnce = false,
+                flag = "",
+                flagInverted = false,
             }
         },
         {
@@ -18,6 +23,11 @@ return {
                 allow = true,
                 infinite = true,
                 disableReverseVerticalMomentum = false,
+                revertOnLeave = false,
+                revertOnDeath = false,
+                onlyOnce = false,
+                flag = "",
+                flagInverted = false,
             }
         },
         {
@@ -26,7 +36,18 @@ return {
                 allow = false,
                 infinite = false,
                 disableReverseVerticalMomentum = false,
+                revertOnLeave = false,
+                revertOnDeath = false,
+                onlyOnce = false,
+                flag = "",
+                flagInverted = false,
             }
         }
-    }
+    },
+    fieldOrder = {
+        "x", "y", "width", "height",
+        "allow", "infinite", "disableReverseVerticalMomentum",
+        "revertOnLeave", "revertOnDeath", "onlyOnce",
+        "flag", "flagInverted",
+    },
 }

--- a/everest.yaml
+++ b/everest.yaml
@@ -1,6 +1,6 @@
 - Name: CommunalHelper
-  Version: 1.23.0
-  DLL: src/bin/Debug/net7.0/CommunalHelper.dll
+  Version: 0.0.0-dev
+  DLL: src/bin/Debug/net8.0/CommunalHelper.dll
   Dependencies:
     - Name: EverestCore
-      Version: 1.5184.0
+      Version: 1.5474.0 # latest beta as of writing, todo: remember to update this when it hits stable!

--- a/everest.yaml
+++ b/everest.yaml
@@ -1,6 +1,6 @@
 - Name: CommunalHelper
   Version: 0.0.0-dev
-  DLL: src/bin/Debug/net8.0/CommunalHelper.dll
+  DLL: src/bin/Debug/net7.0/CommunalHelper.dll
   Dependencies:
     - Name: EverestCore
       Version: 1.5509.0

--- a/everest.yaml
+++ b/everest.yaml
@@ -1,5 +1,5 @@
 - Name: CommunalHelper
-  Version: 1.22.0
+  Version: 1.23.0
   DLL: src/bin/Debug/net7.0/CommunalHelper.dll
   Dependencies:
     - Name: EverestCore

--- a/everest.yaml
+++ b/everest.yaml
@@ -1,6 +1,6 @@
 - Name: CommunalHelper
-  Version: 1.23.0
+  Version: 0.0.0-dev
   DLL: src/bin/Debug/net7.0/CommunalHelper.dll
   Dependencies:
     - Name: EverestCore
-      Version: 1.5184.0
+      Version: 1.5474.0 # latest beta as of writing, todo: remember to update this when it hits stable!

--- a/everest.yaml
+++ b/everest.yaml
@@ -3,4 +3,4 @@
   DLL: src/bin/Debug/net8.0/CommunalHelper.dll
   Dependencies:
     - Name: EverestCore
-      Version: 1.5474.0 # latest beta as of writing, todo: remember to update this when it hits stable!
+      Version: 1.5509.0

--- a/everest.yaml
+++ b/everest.yaml
@@ -1,5 +1,5 @@
 - Name: CommunalHelper
-  Version: 0.0.0-dev
+  Version: 1.22.0
   DLL: src/bin/Debug/net7.0/CommunalHelper.dll
   Dependencies:
     - Name: EverestCore

--- a/src/CommunalHelper.csproj
+++ b/src/CommunalHelper.csproj
@@ -2,7 +2,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0</TargetFrameworks>
+		<TargetFrameworks>net7.0</TargetFrameworks>
 		<AssemblyName>CommunalHelper</AssemblyName>
 		<RootNamespace>Celeste.Mod.CommunalHelper</RootNamespace>
 		<LangVersion>latest</LangVersion>

--- a/src/CommunalHelper.csproj
+++ b/src/CommunalHelper.csproj
@@ -2,7 +2,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net7.0</TargetFrameworks>
+		<TargetFrameworks>net8.0</TargetFrameworks>
 		<AssemblyName>CommunalHelper</AssemblyName>
 		<RootNamespace>Celeste.Mod.CommunalHelper</RootNamespace>
 		<LangVersion>latest</LangVersion>

--- a/src/CommunalHelperModule.cs
+++ b/src/CommunalHelperModule.cs
@@ -101,6 +101,9 @@ public class CommunalHelperModule : EverestModule
         WormholeBooster.Load();
         OshiroAttackTimeTrigger.Load();
         PlayerVisualModifier.Load();
+        
+        ConfigureDreamTunnelDashTrigger.Load();
+        ConfigureElytraTrigger.Load();
 
         AeroBlockCharged.Load();
 
@@ -192,6 +195,9 @@ public class CommunalHelperModule : EverestModule
         WormholeBooster.Unload();
         OshiroAttackTimeTrigger.Unload();
         PlayerVisualModifier.Unload();
+        
+        ConfigureDreamTunnelDashTrigger.Unload();
+        ConfigureElytraTrigger.Unload();
 
         AeroBlockCharged.Unload();
 

--- a/src/Components/FlagToggleComponent.cs
+++ b/src/Components/FlagToggleComponent.cs
@@ -1,0 +1,53 @@
+namespace Celeste.Mod.CommunalHelper.Components;
+
+public class FlagToggleComponent : Component
+{
+    public bool Enabled = true;
+    
+    private readonly string flag;
+    private readonly Action onDisable;
+    private readonly Action onEnable;
+    private readonly bool inverted;
+
+    public FlagToggleComponent(string flag, bool inverted, Action onDisable = null, Action onEnable = null) : base(true, false)
+    {
+        this.flag = flag;
+        this.inverted = inverted;
+        this.onDisable = onDisable;
+        this.onEnable = onEnable;
+    }
+
+    public override void EntityAdded(Scene scene)
+    {
+        base.EntityAdded(scene);
+        UpdateFlag();
+    }
+
+    public override void Update()
+    {
+        base.Update();
+        UpdateFlag();
+    }
+
+    private void UpdateFlag()
+    {
+        if ((inverted || SceneAs<Level>().Session.GetFlag(flag) == Enabled)
+            && (!inverted || SceneAs<Level>().Session.GetFlag(flag) != Enabled))
+            return;
+        
+        if (Enabled)
+        {
+            // disable the entity.
+            Entity.Visible = Entity.Collidable = false;
+            onDisable?.Invoke();
+            Enabled = false;
+        }
+        else
+        {
+            // enable the entity.
+            Entity.Visible = Entity.Collidable = true;
+            onEnable?.Invoke();
+            Enabled = true;
+        }
+    }
+}

--- a/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
+++ b/src/DashStates/DreamTunnelDash/DreamTunnelDash.cs
@@ -78,6 +78,7 @@ public static class DreamTunnelDash
         public bool AllowDashCancels;
         public bool RedirectConsumesNormalDash;
         public bool AllowTransitions;
+        public bool BounceOnCollision;
     }
 
     public static readonly DreamTunnelDashConfiguration DefaultDreamTunnelDashConfiguration = new()
@@ -91,6 +92,7 @@ public static class DreamTunnelDash
         AllowDashCancels = false,
         RedirectConsumesNormalDash = false,
         AllowTransitions = false,
+        BounceOnCollision = false
     };
 
 

--- a/src/States/DreamTunnelDash.cs
+++ b/src/States/DreamTunnelDash.cs
@@ -102,37 +102,40 @@ public static class DreamTunnelDash
     {
         DreamTunnelDashConfiguration config = CommunalHelperModule.Session.CurrentDreamTunnelDashConfiguration;
 
-        if (config.RedirectConsumesNormalDash ? player.Dashes > 0 : DreamTunnelDashCount > 0)
+        if (config.RedirectConsumesNormalDash ? player.Dashes <= 0 : DreamTunnelDashCount <= 0)
+            return;
+
+        bool flag = Input.GetAimVector().Sign() == player.Speed.Sign();
+        if ((!config.AllowRedirect || flag) && (!config.AllowSameDirectionRedirect || !flag))
+            return;
+        
+        if (config.RedirectConsumesNormalDash)
+            player.Dashes = Math.Max(0, player.Dashes - 1);
+        else
+            DreamTunnelDashCount = Math.Max(0, DreamTunnelDashCount - 1);
+                
+        Audio.Play("event:/char/madeline/dreamblock_enter");
+        if (Engine.TimeRate > 0.25f)
         {
-            bool flag = Input.GetAimVector() == player.DashDir;
-            if ((config.AllowRedirect && !flag) || (config.AllowSameDirectionRedirect && flag))
-            {
-                if (config.RedirectConsumesNormalDash)
-                    player.Dashes = Math.Max(0, player.Dashes - 1);
-                else
-                    DreamTunnelDashCount = Math.Max(0, DreamTunnelDashCount - 1);
-                Audio.Play("event:/char/madeline/dreamblock_enter");
-                if (Engine.TimeRate > 0.25f)
-                {
-                    Celeste.Freeze(0.05f);
-                }
-                if (flag)
-                {
-                    player.Speed *= config.SameDirectionSpeedMultiplier;
-                    player.DashDir *= Math.Sign(config.SameDirectionSpeedMultiplier);
-                }
-                else
-                {
-                    player.DashDir = Input.GetAimVector();
-                    player.Speed = player.DashDir * player.Speed.Length();
-                }
-                Input.Dash.ConsumeBuffer();
-            }
+            Celeste.Freeze(0.05f);
         }
+                
+        if (flag)
+        {
+            player.Speed *= config.SameDirectionSpeedMultiplier;
+            player.DashDir *= Math.Sign(config.SameDirectionSpeedMultiplier);
+        }
+        else
+        {
+            player.DashDir = Input.GetAimVector();
+            player.Speed = player.DashDir * player.Speed.Length();
+        }
+                
+        Input.Dash.ConsumeBuffer();
     }
     
     // Do a bounce check and bounce if possible
-    public static bool AttemptBounce(this Player player)
+    private static bool AttemptBounce(this Player player)
     { 
         if (!CommunalHelperModule.Session.CurrentDreamTunnelDashConfiguration.BounceOnCollision)
             return false;

--- a/src/States/DreamTunnelDash.cs
+++ b/src/States/DreamTunnelDash.cs
@@ -18,7 +18,7 @@ public static class DreamTunnelDash
         if (player.dreamSfxLoop == null)
         {
             player.dreamSfxLoop = new SoundSource();
-            player.dreamSfxLoop.DisposeOnTransition = !CommunalHelperModule.Session.CurrentDreamTunnelDashConfiguration.AllowTransitions;
+            player.dreamSfxLoop.DisposeOnTransition = !config.AllowTransitions;
             player.Add(player.dreamSfxLoop);
         }
 
@@ -130,15 +130,70 @@ public static class DreamTunnelDash
             }
         }
     }
+    
+    // Do a bounce check and bounce if possible
+    public static bool AttemptBounce(this Player player)
+    { 
+        if (!CommunalHelperModule.Session.CurrentDreamTunnelDashConfiguration.BounceOnCollision)
+            return false;
+        
+        Vector2 moveCheckVector = player.Speed * Engine.DeltaTime;
+        player.NaiveMove(moveCheckVector);
+
+        Solid solid = player.CollideFirst<Solid, DreamBlock>();
+        if (solid == null && player.DreamTunneledIntoDeath())
+        {
+            // Move the player out of the wall properly, then bounce
+            player.NaiveMove(-moveCheckVector);
+            player.DreamDashBounce();
+            return true;
+        }
+
+        // Make sure we undo the check movement
+        player.NaiveMove(-moveCheckVector);
+        return false;
+    }
+
+    private static void DreamDashBounce(this Player player)
+    {
+        Vector2 horizontalMoveCheckVector = new(player.Speed.X * Engine.DeltaTime, 0f);
+        Vector2 verticalMoveCheckVector = new(0f, player.Speed.Y * Engine.DeltaTime);
+
+        bool horizontal = player.OutsideAfterMove(horizontalMoveCheckVector);
+        bool vertical = player.OutsideAfterMove(verticalMoveCheckVector);
+
+        if (horizontal)
+        {
+            player.Speed.X *= -1;
+        }
+        if (vertical)
+        {
+            player.Speed.Y *= -1;
+        }
+    }
+
+    private static bool OutsideAfterMove(this Player player, Vector2 offset)
+    {
+        player.NaiveMove(offset);
+        bool outside = player.CollideFirst<Solid, DreamBlock>() == null;
+        player.NaiveMove(-offset);
+
+        return outside;
+    }
 
     public static int DreamTunnelDashUpdate(this Player player)
     {
         DynamicData playerData = player.GetData();
         DreamTunnelDashConfiguration config = CommunalHelperModule.Session.CurrentDreamTunnelDashConfiguration;
-
+        
         if (Input.Dash.Pressed && Input.Aim.Value != Vector2.Zero)
         {
             player.DreamTunnelDashRedirect();
+        }
+        
+        if (player.AttemptBounce())
+        {
+            return St.DreamTunnelDash;
         }
 
         if (FeatherMode)

--- a/src/States/Elytra.cs
+++ b/src/States/Elytra.cs
@@ -52,12 +52,12 @@ public static class Elytra
 
     public struct ElytraConfiguration
     {
-        public bool disableReverseVerticalMomentum;
+        public bool DisableReverseVerticalMomentum;
     }
 
     public static readonly ElytraConfiguration DefaultElytraConfiguration = new()
     {
-        disableReverseVerticalMomentum = false,
+        DisableReverseVerticalMomentum = false,
     };
 
     /// <summary>
@@ -73,6 +73,9 @@ public static class Elytra
 
     public static void SetInfiniteElytra(this Player player, bool enabled)
         => DynamicData.For(player).Set(f_Player_elytraIsInfinite, enabled);
+    
+    public static bool HasInfiniteElytra(this Player player)
+        => DynamicData.For(player).Get<bool>(f_Player_elytraIsInfinite);
 
     private static void PlayElytraRefillSound(this Player player)
     {
@@ -98,7 +101,7 @@ public static class Elytra
 
         ElytraConfiguration config = CommunalHelperModule.Session.CurrentElytraConfiguration;
         Vector2 speed;
-        if (config.disableReverseVerticalMomentum)
+        if (config.DisableReverseVerticalMomentum)
         {
             speed = new(MathF.Abs(player.Speed.X), player.Speed.Y);
         }

--- a/src/Triggers/AbstractConfigureStateTrigger.cs
+++ b/src/Triggers/AbstractConfigureStateTrigger.cs
@@ -1,0 +1,82 @@
+using Celeste.Mod.CommunalHelper.Components;
+using System.Linq;
+
+namespace Celeste.Mod.CommunalHelper.Triggers;
+
+// todo: tracking is borked
+[Tracked(true)]
+public abstract class AbstractConfigureStateTrigger<TOptions, TChanges> : Trigger
+    where TOptions : struct where TChanges : struct
+{
+    private readonly TOptions options;
+    private TChanges? changesNeededToRevert;
+    
+    private readonly bool revertOnLeave;
+    private readonly bool revertOnDeath;
+    private readonly bool onlyOnce;
+
+    public AbstractConfigureStateTrigger(EntityData data, Vector2 offset)
+        : base(data, offset)
+    {
+        revertOnLeave = data.Bool("revertOnLeave", false);
+        revertOnDeath = data.Bool("revertOnDeath", true);
+        onlyOnce = data.Bool("onlyOnce", false);
+
+        options = GetConfiguredOptions(data);
+        
+        string flag = data.Attr("flag");
+        if (!string.IsNullOrEmpty(flag)) {
+            Add(new FlagToggleComponent(flag, data.Bool("flagInverted")));
+        }
+    }
+
+    protected abstract TOptions GetConfiguredOptions(EntityData data);
+    protected abstract TOptions GetCurrentOptions(Player player);
+    protected abstract void SaveOptions(Player player, TOptions options);
+
+    protected abstract TChanges CalculateChangesNeededToRevert(TOptions from, TOptions to);
+    protected abstract TOptions RevertChanges(TOptions current, TChanges? changesNeededToRevert);
+
+    public override void OnEnter(Player player)
+    {
+        changesNeededToRevert = CalculateChangesNeededToRevert(GetCurrentOptions(player), options);
+        SaveOptions(player, options);
+
+        if (onlyOnce)
+        {
+            RemoveSelf();
+        }
+    }
+
+    public override void OnLeave(Player player)
+    {
+        if (revertOnLeave && !player.Dead)
+        {
+            SaveOptions(player, RevertChanges(options, changesNeededToRevert));
+        }
+    }
+    
+    #region Hooks
+
+    internal static void Load()
+    {
+        Everest.Events.Player.OnDie += OnDie;
+    }
+
+    internal static void Unload()
+    {
+        Everest.Events.Player.OnDie -= OnDie;
+    }
+
+    private static void OnDie(Player player)
+    {
+        foreach (AbstractConfigureStateTrigger<TOptions, TChanges> trigger in player.SceneAs<Level>().Tracker.GetEntities<AbstractConfigureStateTrigger<TOptions, TChanges>>()
+                                                         .Cast<AbstractConfigureStateTrigger<TOptions, TChanges>>()
+                                                         .Where(trigger => trigger.revertOnDeath && trigger.changesNeededToRevert is not null))
+        {
+            trigger.SaveOptions(player, trigger.RevertChanges(trigger.options, trigger.changesNeededToRevert));
+        }
+    }
+    
+    #endregion
+}

--- a/src/Triggers/AbstractConfigureStateTrigger.cs
+++ b/src/Triggers/AbstractConfigureStateTrigger.cs
@@ -3,7 +3,8 @@ using System.Linq;
 
 namespace Celeste.Mod.CommunalHelper.Triggers;
 
-// todo: tracking is borked
+// unfortunately, due to this class being generic, `[Tracked(true)]` doesn't really do anything here. we include it anyway as it signifies our intent
+// all children of this class need to be marked as `[TrackedAs(typeof(AbstractConfigureStateTrigger<TOptions, TChanges>))]` in order to be tracked properly
 [Tracked(true)]
 public abstract class AbstractConfigureStateTrigger<TOptions, TChanges> : Trigger
     where TOptions : struct where TChanges : struct

--- a/src/Triggers/AbstractConfigureStateTrigger.cs
+++ b/src/Triggers/AbstractConfigureStateTrigger.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace Celeste.Mod.CommunalHelper.Triggers;
 
-// unfortunately, due to this class being generic, `[Tracked(true)]` doesn't really do anything here. we include it anyway as it signifies our intent
+// unfortunately, due to this class being generic, `[Tracked(true)]` doesn't really do anything here
 // all children of this class need to be marked as `[TrackedAs(typeof(AbstractConfigureStateTrigger<TOptions, TChanges>))]` in order to be tracked properly
 [Tracked(true)]
 public abstract class AbstractConfigureStateTrigger<TOptions, TChanges> : Trigger

--- a/src/Triggers/ConfigureDreamTunnelDashTrigger.cs
+++ b/src/Triggers/ConfigureDreamTunnelDashTrigger.cs
@@ -32,43 +32,43 @@ public class ConfigureDreamTunnelDashTrigger : AbstractConfigureStateTrigger<Dre
     protected override DreamTunnelDashConfigurationChanges CalculateChangesNeededToRevert(DreamTunnelDashConfiguration from, DreamTunnelDashConfiguration to)
         => new()
         {
-            AllowRedirect = to.AllowRedirect == from.AllowRedirect ? null : from.AllowRedirect,
-            AllowSameDirectionRedirect = to.AllowSameDirectionRedirect == from.AllowSameDirectionRedirect ? null : from.AllowSameDirectionRedirect,
-            SameDirectionSpeedMultiplier = to.SameDirectionSpeedMultiplier == from.SameDirectionSpeedMultiplier ? null : from.SameDirectionSpeedMultiplier,
-            UseEntryDirection = to.UseEntryDirection == from.UseEntryDirection ? null : from.UseEntryDirection,
-            SpeedConfiguration = to.SpeedConfiguration == from.SpeedConfiguration ? null : from.SpeedConfiguration,
-            CustomSpeed = to.CustomSpeed == from.CustomSpeed ? null : from.CustomSpeed,
-            AllowDashCancels = to.AllowDashCancels == from.AllowDashCancels ? null : from.AllowDashCancels,
-            RedirectConsumesNormalDash = to.RedirectConsumesNormalDash == from.RedirectConsumesNormalDash ? null : from.RedirectConsumesNormalDash,
-            AllowTransitions = to.AllowTransitions == from.AllowTransitions ? null : from.AllowTransitions,
-            BounceOnCollision = to.BounceOnCollision == from.BounceOnCollision ? null : from.BounceOnCollision
+            NewAllowRedirect = to.AllowRedirect == from.AllowRedirect ? null : from.AllowRedirect,
+            NewAllowSameDirectionRedirect = to.AllowSameDirectionRedirect == from.AllowSameDirectionRedirect ? null : from.AllowSameDirectionRedirect,
+            NewSameDirectionSpeedMultiplier = to.SameDirectionSpeedMultiplier == from.SameDirectionSpeedMultiplier ? null : from.SameDirectionSpeedMultiplier,
+            NewUseEntryDirection = to.UseEntryDirection == from.UseEntryDirection ? null : from.UseEntryDirection,
+            NewSpeedConfiguration = to.SpeedConfiguration == from.SpeedConfiguration ? null : from.SpeedConfiguration,
+            NewCustomSpeed = to.CustomSpeed == from.CustomSpeed ? null : from.CustomSpeed,
+            NewAllowDashCancels = to.AllowDashCancels == from.AllowDashCancels ? null : from.AllowDashCancels,
+            NewRedirectConsumesNormalDash = to.RedirectConsumesNormalDash == from.RedirectConsumesNormalDash ? null : from.RedirectConsumesNormalDash,
+            NewAllowTransitions = to.AllowTransitions == from.AllowTransitions ? null : from.AllowTransitions,
+            NewBounceOnCollision = to.BounceOnCollision == from.BounceOnCollision ? null : from.BounceOnCollision
         };
     protected override DreamTunnelDashConfiguration RevertChanges(DreamTunnelDashConfiguration current, DreamTunnelDashConfigurationChanges? changesNeededToRevert)
         => new()
         {
-            AllowRedirect = changesNeededToRevert?.AllowRedirect ?? current.AllowRedirect,
-            AllowSameDirectionRedirect = changesNeededToRevert?.AllowSameDirectionRedirect ?? current.AllowSameDirectionRedirect,
-            SameDirectionSpeedMultiplier = changesNeededToRevert?.SameDirectionSpeedMultiplier ?? current.SameDirectionSpeedMultiplier,
-            UseEntryDirection = changesNeededToRevert?.UseEntryDirection ?? current.UseEntryDirection,
-            SpeedConfiguration = changesNeededToRevert?.SpeedConfiguration ?? current.SpeedConfiguration,
-            CustomSpeed = changesNeededToRevert?.CustomSpeed ?? current.CustomSpeed,
-            AllowDashCancels = changesNeededToRevert?.AllowDashCancels ?? current.AllowDashCancels,
-            RedirectConsumesNormalDash = changesNeededToRevert?.RedirectConsumesNormalDash ?? current.RedirectConsumesNormalDash,
-            AllowTransitions = changesNeededToRevert?.AllowTransitions ?? current.AllowTransitions,
-            BounceOnCollision = changesNeededToRevert?.BounceOnCollision ?? current.BounceOnCollision
+            AllowRedirect = changesNeededToRevert?.NewAllowRedirect ?? current.AllowRedirect,
+            AllowSameDirectionRedirect = changesNeededToRevert?.NewAllowSameDirectionRedirect ?? current.AllowSameDirectionRedirect,
+            SameDirectionSpeedMultiplier = changesNeededToRevert?.NewSameDirectionSpeedMultiplier ?? current.SameDirectionSpeedMultiplier,
+            UseEntryDirection = changesNeededToRevert?.NewUseEntryDirection ?? current.UseEntryDirection,
+            SpeedConfiguration = changesNeededToRevert?.NewSpeedConfiguration ?? current.SpeedConfiguration,
+            CustomSpeed = changesNeededToRevert?.NewCustomSpeed ?? current.CustomSpeed,
+            AllowDashCancels = changesNeededToRevert?.NewAllowDashCancels ?? current.AllowDashCancels,
+            RedirectConsumesNormalDash = changesNeededToRevert?.NewRedirectConsumesNormalDash ?? current.RedirectConsumesNormalDash,
+            AllowTransitions = changesNeededToRevert?.NewAllowTransitions ?? current.AllowTransitions,
+            BounceOnCollision = changesNeededToRevert?.NewBounceOnCollision ?? current.BounceOnCollision
         };
 }
 
 public struct DreamTunnelDashConfigurationChanges
 {
-    public bool? AllowRedirect;
-    public bool? AllowSameDirectionRedirect;
-    public float? SameDirectionSpeedMultiplier;
-    public bool? UseEntryDirection;
-    public SpeedConfiguration? SpeedConfiguration;
-    public float? CustomSpeed;
-    public bool? AllowDashCancels;
-    public bool? RedirectConsumesNormalDash;
-    public bool? AllowTransitions;
-    public bool? BounceOnCollision;
+    public bool? NewAllowRedirect;
+    public bool? NewAllowSameDirectionRedirect;
+    public float? NewSameDirectionSpeedMultiplier;
+    public bool? NewUseEntryDirection;
+    public SpeedConfiguration? NewSpeedConfiguration;
+    public float? NewCustomSpeed;
+    public bool? NewAllowDashCancels;
+    public bool? NewRedirectConsumesNormalDash;
+    public bool? NewAllowTransitions;
+    public bool? NewBounceOnCollision;
 }

--- a/src/Triggers/ConfigureDreamTunnelDashTrigger.cs
+++ b/src/Triggers/ConfigureDreamTunnelDashTrigger.cs
@@ -1,15 +1,42 @@
+using Celeste.Mod.CommunalHelper.Components;
+using System.Linq;
 using static Celeste.Mod.CommunalHelper.DashStates.DreamTunnelDash;
 
 namespace Celeste.Mod.CommunalHelper.Triggers;
 
 [CustomEntity("CommunalHelper/ConfigureDreamTunnelDashTrigger")]
+[Tracked]
 public class ConfigureDreamTunnelDashTrigger : Trigger
-{
+{ 
     private readonly DreamTunnelDashConfiguration options;
+    
+    private readonly bool revertOnLeave;
+    private readonly bool revertOnDeath;
+    private readonly bool onlyOnce;
+
+    private struct DreamTunnelDashConfigurationChanges
+    {
+        public bool? AllowRedirect;
+        public bool? AllowSameDirectionRedirect;
+        public float? SameDirectionSpeedMultiplier;
+        public bool? UseEntryDirection;
+        public SpeedConfiguration? SpeedConfiguration;
+        public float? CustomSpeed;
+        public bool? AllowDashCancels;
+        public bool? RedirectConsumesNormalDash;
+        public bool? AllowTransitions;
+        public bool? BounceOnCollision;
+    }
+    
+    private DreamTunnelDashConfigurationChanges? changesNeededToRevert;
 
     public ConfigureDreamTunnelDashTrigger(EntityData data, Vector2 offset)
         : base(data, offset)
     {
+        revertOnLeave = data.Bool("revertOnLeave", false);
+        revertOnDeath = data.Bool("revertOnDeath", true);
+        onlyOnce = data.Bool("onlyOnce", false);
+        
         options = new DreamTunnelDashConfiguration()
         {
             AllowRedirect = data.Bool("allowRedirect", false),
@@ -21,11 +48,84 @@ public class ConfigureDreamTunnelDashTrigger : Trigger
             AllowDashCancels = data.Bool("allowDashCancels", false),
             RedirectConsumesNormalDash = data.Bool("redirectConsumesNormalDash", false),
             AllowTransitions = data.Bool("allowTransitions", false),
+            BounceOnCollision = data.Bool("bounceOnCollision", false)
         };
+
+        string flag = data.Attr("flag");
+        if (!string.IsNullOrEmpty(flag)) {
+            Add(new FlagToggleComponent(flag, data.Bool("flagInverted")));
+        }
     }
+    
+    private static DreamTunnelDashConfigurationChanges CalculateChangesNeededToRevert(DreamTunnelDashConfiguration from, DreamTunnelDashConfiguration to)
+        => new()
+        {
+            AllowRedirect = to.AllowRedirect == from.AllowRedirect ? null : from.AllowRedirect,
+            AllowSameDirectionRedirect = to.AllowSameDirectionRedirect == from.AllowSameDirectionRedirect ? null : from.AllowSameDirectionRedirect,
+            SameDirectionSpeedMultiplier = to.SameDirectionSpeedMultiplier == from.SameDirectionSpeedMultiplier ? null : from.SameDirectionSpeedMultiplier,
+            UseEntryDirection = to.UseEntryDirection == from.UseEntryDirection ? null : from.UseEntryDirection,
+            SpeedConfiguration = to.SpeedConfiguration == from.SpeedConfiguration ? null : from.SpeedConfiguration,
+            CustomSpeed = to.CustomSpeed == from.CustomSpeed ? null : from.CustomSpeed,
+            AllowDashCancels = to.AllowDashCancels == from.AllowDashCancels ? null : from.AllowDashCancels,
+            RedirectConsumesNormalDash = to.RedirectConsumesNormalDash == from.RedirectConsumesNormalDash ? null : from.RedirectConsumesNormalDash,
+            AllowTransitions = to.AllowTransitions == from.AllowTransitions ? null : from.AllowTransitions,
+            BounceOnCollision = to.BounceOnCollision == from.BounceOnCollision ? null : from.BounceOnCollision
+        };
+
+    private static DreamTunnelDashConfiguration RevertChanges(DreamTunnelDashConfiguration current, DreamTunnelDashConfigurationChanges? changesNeededToRevert)
+        => new()
+        {
+            AllowRedirect = changesNeededToRevert?.AllowRedirect ?? current.AllowRedirect,
+            AllowSameDirectionRedirect = changesNeededToRevert?.AllowSameDirectionRedirect ?? current.AllowSameDirectionRedirect,
+            SameDirectionSpeedMultiplier = changesNeededToRevert?.SameDirectionSpeedMultiplier ?? current.SameDirectionSpeedMultiplier,
+            UseEntryDirection = changesNeededToRevert?.UseEntryDirection ?? current.UseEntryDirection,
+            SpeedConfiguration = changesNeededToRevert?.SpeedConfiguration ?? current.SpeedConfiguration,
+            CustomSpeed = changesNeededToRevert?.CustomSpeed ?? current.CustomSpeed,
+            AllowDashCancels = changesNeededToRevert?.AllowDashCancels ?? current.AllowDashCancels,
+            RedirectConsumesNormalDash = changesNeededToRevert?.RedirectConsumesNormalDash ?? current.RedirectConsumesNormalDash,
+            AllowTransitions = changesNeededToRevert?.AllowTransitions ?? current.AllowTransitions,
+            BounceOnCollision = changesNeededToRevert?.BounceOnCollision ?? current.BounceOnCollision
+        };
 
     public override void OnEnter(Player player)
     {
+        changesNeededToRevert = CalculateChangesNeededToRevert(CommunalHelperModule.Session.CurrentDreamTunnelDashConfiguration, options);
         CommunalHelperModule.Session.CurrentDreamTunnelDashConfiguration = options;
+        
+        if (onlyOnce) {
+            RemoveSelf();
+        }
     }
+
+    public override void OnLeave(Player player)
+    {
+        if (revertOnLeave && !player.Dead)
+        {
+            CommunalHelperModule.Session.CurrentDreamTunnelDashConfiguration = RevertChanges(CommunalHelperModule.Session.CurrentDreamTunnelDashConfiguration, changesNeededToRevert);
+        }
+    }
+    
+    #region Hooks
+
+    internal static void Load()
+    {
+        Everest.Events.Player.OnDie += OnDie;
+    }
+
+    internal static void Unload()
+    {
+        Everest.Events.Player.OnDie -= OnDie;
+    }
+
+    private static void OnDie(Player player)
+    {
+        foreach (ConfigureDreamTunnelDashTrigger trigger in player.SceneAs<Level>().Tracker.GetEntities<ConfigureDreamTunnelDashTrigger>()
+                                                                  .Cast<ConfigureDreamTunnelDashTrigger>()
+                                                                  .Where(trigger => trigger.revertOnDeath && trigger.changesNeededToRevert is not null))
+        {
+            CommunalHelperModule.Session.CurrentDreamTunnelDashConfiguration = RevertChanges(CommunalHelperModule.Session.CurrentDreamTunnelDashConfiguration, trigger.changesNeededToRevert);
+        }
+    }
+    
+    #endregion
 }

--- a/src/Triggers/ConfigureDreamTunnelDashTrigger.cs
+++ b/src/Triggers/ConfigureDreamTunnelDashTrigger.cs
@@ -1,43 +1,17 @@
-using Celeste.Mod.CommunalHelper.Components;
-using System.Linq;
 using static Celeste.Mod.CommunalHelper.DashStates.DreamTunnelDash;
 
 namespace Celeste.Mod.CommunalHelper.Triggers;
 
 [CustomEntity("CommunalHelper/ConfigureDreamTunnelDashTrigger")]
-[Tracked]
-public class ConfigureDreamTunnelDashTrigger : Trigger
+[TrackedAs(typeof(AbstractConfigureStateTrigger<DreamTunnelDashConfiguration, DreamTunnelDashConfigurationChanges>))]
+public class ConfigureDreamTunnelDashTrigger : AbstractConfigureStateTrigger<DreamTunnelDashConfiguration, DreamTunnelDashConfigurationChanges>
 { 
-    private readonly DreamTunnelDashConfiguration options;
-    
-    private readonly bool revertOnLeave;
-    private readonly bool revertOnDeath;
-    private readonly bool onlyOnce;
-
-    private struct DreamTunnelDashConfigurationChanges
-    {
-        public bool? AllowRedirect;
-        public bool? AllowSameDirectionRedirect;
-        public float? SameDirectionSpeedMultiplier;
-        public bool? UseEntryDirection;
-        public SpeedConfiguration? SpeedConfiguration;
-        public float? CustomSpeed;
-        public bool? AllowDashCancels;
-        public bool? RedirectConsumesNormalDash;
-        public bool? AllowTransitions;
-        public bool? BounceOnCollision;
-    }
-    
-    private DreamTunnelDashConfigurationChanges? changesNeededToRevert;
-
     public ConfigureDreamTunnelDashTrigger(EntityData data, Vector2 offset)
         : base(data, offset)
-    {
-        revertOnLeave = data.Bool("revertOnLeave", false);
-        revertOnDeath = data.Bool("revertOnDeath", true);
-        onlyOnce = data.Bool("onlyOnce", false);
-        
-        options = new DreamTunnelDashConfiguration()
+    { }
+
+    protected override DreamTunnelDashConfiguration GetConfiguredOptions(EntityData data)
+        => new()
         {
             AllowRedirect = data.Bool("allowRedirect", false),
             AllowSameDirectionRedirect = data.Bool("allowSameDirectionRedirect", false),
@@ -50,14 +24,12 @@ public class ConfigureDreamTunnelDashTrigger : Trigger
             AllowTransitions = data.Bool("allowTransitions", false),
             BounceOnCollision = data.Bool("bounceOnCollision", false)
         };
-
-        string flag = data.Attr("flag");
-        if (!string.IsNullOrEmpty(flag)) {
-            Add(new FlagToggleComponent(flag, data.Bool("flagInverted")));
-        }
-    }
+    protected override DreamTunnelDashConfiguration GetCurrentOptions(Player player)
+        => CommunalHelperModule.Session.CurrentDreamTunnelDashConfiguration;
+    protected override void SaveOptions(Player player, DreamTunnelDashConfiguration options)
+        => CommunalHelperModule.Session.CurrentDreamTunnelDashConfiguration = options;
     
-    private static DreamTunnelDashConfigurationChanges CalculateChangesNeededToRevert(DreamTunnelDashConfiguration from, DreamTunnelDashConfiguration to)
+    protected override DreamTunnelDashConfigurationChanges CalculateChangesNeededToRevert(DreamTunnelDashConfiguration from, DreamTunnelDashConfiguration to)
         => new()
         {
             AllowRedirect = to.AllowRedirect == from.AllowRedirect ? null : from.AllowRedirect,
@@ -71,8 +43,7 @@ public class ConfigureDreamTunnelDashTrigger : Trigger
             AllowTransitions = to.AllowTransitions == from.AllowTransitions ? null : from.AllowTransitions,
             BounceOnCollision = to.BounceOnCollision == from.BounceOnCollision ? null : from.BounceOnCollision
         };
-
-    private static DreamTunnelDashConfiguration RevertChanges(DreamTunnelDashConfiguration current, DreamTunnelDashConfigurationChanges? changesNeededToRevert)
+    protected override DreamTunnelDashConfiguration RevertChanges(DreamTunnelDashConfiguration current, DreamTunnelDashConfigurationChanges? changesNeededToRevert)
         => new()
         {
             AllowRedirect = changesNeededToRevert?.AllowRedirect ?? current.AllowRedirect,
@@ -86,46 +57,18 @@ public class ConfigureDreamTunnelDashTrigger : Trigger
             AllowTransitions = changesNeededToRevert?.AllowTransitions ?? current.AllowTransitions,
             BounceOnCollision = changesNeededToRevert?.BounceOnCollision ?? current.BounceOnCollision
         };
+}
 
-    public override void OnEnter(Player player)
-    {
-        changesNeededToRevert = CalculateChangesNeededToRevert(CommunalHelperModule.Session.CurrentDreamTunnelDashConfiguration, options);
-        CommunalHelperModule.Session.CurrentDreamTunnelDashConfiguration = options;
-        
-        if (onlyOnce) {
-            RemoveSelf();
-        }
-    }
-
-    public override void OnLeave(Player player)
-    {
-        if (revertOnLeave && !player.Dead)
-        {
-            CommunalHelperModule.Session.CurrentDreamTunnelDashConfiguration = RevertChanges(CommunalHelperModule.Session.CurrentDreamTunnelDashConfiguration, changesNeededToRevert);
-        }
-    }
-    
-    #region Hooks
-
-    internal static void Load()
-    {
-        Everest.Events.Player.OnDie += OnDie;
-    }
-
-    internal static void Unload()
-    {
-        Everest.Events.Player.OnDie -= OnDie;
-    }
-
-    private static void OnDie(Player player)
-    {
-        foreach (ConfigureDreamTunnelDashTrigger trigger in player.SceneAs<Level>().Tracker.GetEntities<ConfigureDreamTunnelDashTrigger>()
-                                                                  .Cast<ConfigureDreamTunnelDashTrigger>()
-                                                                  .Where(trigger => trigger.revertOnDeath && trigger.changesNeededToRevert is not null))
-        {
-            CommunalHelperModule.Session.CurrentDreamTunnelDashConfiguration = RevertChanges(CommunalHelperModule.Session.CurrentDreamTunnelDashConfiguration, trigger.changesNeededToRevert);
-        }
-    }
-    
-    #endregion
+public struct DreamTunnelDashConfigurationChanges
+{
+    public bool? AllowRedirect;
+    public bool? AllowSameDirectionRedirect;
+    public float? SameDirectionSpeedMultiplier;
+    public bool? UseEntryDirection;
+    public SpeedConfiguration? SpeedConfiguration;
+    public float? CustomSpeed;
+    public bool? AllowDashCancels;
+    public bool? RedirectConsumesNormalDash;
+    public bool? AllowTransitions;
+    public bool? BounceOnCollision;
 }

--- a/src/Triggers/ConfigureElytraTrigger.cs
+++ b/src/Triggers/ConfigureElytraTrigger.cs
@@ -1,115 +1,77 @@
-﻿using Celeste.Mod.CommunalHelper.Components;
-using Celeste.Mod.CommunalHelper.States;
-using System.Linq;
+﻿using Celeste.Mod.CommunalHelper.States;
 using static Celeste.Mod.CommunalHelper.States.Elytra;
 
 namespace Celeste.Mod.CommunalHelper.Triggers;
 
 [CustomEntity("CommunalHelper/ConfigureElytraTrigger")]
-[Tracked]
-public class ConfigureElytraTrigger : Trigger
+[TrackedAs(typeof(AbstractConfigureStateTrigger<ElytraOptions, ElytraOptionsChanges>))]
+public class ConfigureElytraTrigger : AbstractConfigureStateTrigger<ElytraOptions, ElytraOptionsChanges>
 {
-    private readonly bool allow, infinite;
-    private readonly ElytraConfiguration options;
-    
-    private readonly bool revertOnLeave;
-    private readonly bool revertOnDeath;
-    private readonly bool onlyOnce;
-    
-    private struct ElytraConfigurationChanges
+    public ConfigureElytraTrigger(EntityData data, Vector2 offset)
+        : base(data, offset)
+    { }
+
+    protected override ElytraOptions GetConfiguredOptions(EntityData data)
+        => new()
+        {
+            Allow = data.Bool("allow", false),
+            Infinite = data.Bool("infinite", false),
+            Configuration = new ElytraConfiguration()
+            {
+                DisableReverseVerticalMomentum = data.Bool("disableReverseVerticalMomentum"),
+            },
+        };
+    protected override ElytraOptions GetCurrentOptions(Player player)
+        => new()
+        {
+            Allow = CommunalHelperModule.Session.CanDeployElytra,
+            Infinite = player.HasInfiniteElytra(),
+            Configuration = CommunalHelperModule.Session.CurrentElytraConfiguration,
+        };
+    protected override void SaveOptions(Player player, ElytraOptions options)
     {
-        public bool? Allow;
-        public bool? Infinite;
+        CommunalHelperModule.Session.CanDeployElytra = options.Allow;
+        player.SetInfiniteElytra(options.Infinite);
+        CommunalHelperModule.Session.CurrentElytraConfiguration = options.Configuration;
+    }
+    
+    protected override ElytraOptionsChanges CalculateChangesNeededToRevert(ElytraOptions from, ElytraOptions to)
+        => new()
+        {
+            Allow = to.Allow == from.Allow ? null : from.Allow,
+            Infinite = to.Infinite == from.Infinite ? null : from.Infinite,
+            Configuration = new ElytraOptionsChanges.ElytraConfigurationChanges()
+            {
+                DisableReverseVerticalMomentum = to.Configuration.DisableReverseVerticalMomentum == from.Configuration.DisableReverseVerticalMomentum ? null : from.Configuration.DisableReverseVerticalMomentum
+            }
+        };
+    protected override ElytraOptions RevertChanges(ElytraOptions current, ElytraOptionsChanges? changesNeededToRevert)
+        => new()
+        {
+            Allow = changesNeededToRevert?.Allow ?? current.Allow,
+            Infinite = changesNeededToRevert?.Infinite ?? current.Infinite,
+            Configuration = new ElytraConfiguration()
+            {
+                DisableReverseVerticalMomentum = changesNeededToRevert?.Configuration.DisableReverseVerticalMomentum ?? current.Configuration.DisableReverseVerticalMomentum
+            }
+        };
+}
+
+public struct ElytraOptions
+{
+    public bool Allow;
+    public bool Infinite;
+    public ElytraConfiguration Configuration;
+}
+
+public struct ElytraOptionsChanges
+{
+    public struct ElytraConfigurationChanges
+    {
         public bool? DisableReverseVerticalMomentum;
     }
     
-    private ElytraConfigurationChanges? changesNeededToRevert;
-
-    public ConfigureElytraTrigger(EntityData data, Vector2 offset)
-        : base(data, offset)
-    {
-        revertOnLeave = data.Bool("revertOnLeave", false);
-        revertOnDeath = data.Bool("revertOnDeath", true);
-        onlyOnce = data.Bool("onlyOnce", false);
-        
-        allow = data.Bool("allow", false);
-        infinite = data.Bool("infinite", false);
-
-        options = new ElytraConfiguration()
-        {
-            DisableReverseVerticalMomentum = data.Bool("disableReverseVerticalMomentum"),
-        };
-        
-        string flag = data.Attr("flag");
-        if (!string.IsNullOrEmpty(flag)) {
-            Add(new FlagToggleComponent(flag, data.Bool("flagInverted")));
-        }
-    }
-    
-    private static ElytraConfigurationChanges CalculateChangesNeededToRevert((bool allow, bool infinite, ElytraConfiguration options) from, (bool allow, bool infinite, ElytraConfiguration options) to)
-        => new()
-        {
-            Allow = to.allow == from.allow ? null : from.allow,
-            Infinite = to.infinite == from.infinite ? null : from.infinite,
-            DisableReverseVerticalMomentum = to.options.DisableReverseVerticalMomentum == from.options.DisableReverseVerticalMomentum ? null : from.options.DisableReverseVerticalMomentum
-        };
-
-    private static (bool, bool, ElytraConfiguration) RevertChanges((bool allow, bool infinite, ElytraConfiguration options) current, ElytraConfigurationChanges? changesNeededToRevert)
-        => (changesNeededToRevert?.Allow ?? current.allow, changesNeededToRevert?.Infinite ?? current.infinite, new ElytraConfiguration()
-        {
-            DisableReverseVerticalMomentum = changesNeededToRevert?.DisableReverseVerticalMomentum ?? current.options.DisableReverseVerticalMomentum
-        });
-
-    private static void SaveChanges(Player player, bool allow, bool infinite, ElytraConfiguration options)
-    {
-        CommunalHelperModule.Session.CanDeployElytra = allow;
-        CommunalHelperModule.Session.CurrentElytraConfiguration = options;
-        player.SetInfiniteElytra(infinite);
-    }
-
-    public override void OnEnter(Player player)
-    {
-        changesNeededToRevert = CalculateChangesNeededToRevert(
-            (CommunalHelperModule.Session.CanDeployElytra, player.HasInfiniteElytra(), CommunalHelperModule.Session.CurrentElytraConfiguration),
-            (allow, infinite, options));
-        SaveChanges(player, allow, infinite, options);
-        
-        if (onlyOnce) {
-            RemoveSelf();
-        }
-    }
-    
-    public override void OnLeave(Player player)
-    {
-        if (revertOnLeave && !player.Dead)
-        {
-            (bool newAllow, bool newInfinite, ElytraConfiguration newOptions) = RevertChanges((allow, infinite, options), changesNeededToRevert);
-            SaveChanges(player, newAllow, newInfinite, newOptions);
-        }
-    }
-    
-    #region Hooks
-
-    internal static void Load()
-    {
-        Everest.Events.Player.OnDie += OnDie;
-    }
-
-    internal static void Unload()
-    {
-        Everest.Events.Player.OnDie -= OnDie;
-    }
-
-    private static void OnDie(Player player)
-    {
-        foreach (ConfigureElytraTrigger trigger in player.SceneAs<Level>().Tracker.GetEntities<ConfigureElytraTrigger>()
-                                                                  .Cast<ConfigureElytraTrigger>()
-                                                                  .Where(trigger => trigger.revertOnDeath && trigger.changesNeededToRevert is not null))
-        {
-            (bool newAllow, bool newInfinite, ElytraConfiguration newOptions) = RevertChanges((trigger.allow, trigger.infinite, trigger.options), trigger.changesNeededToRevert);
-            SaveChanges(player, newAllow, newInfinite, newOptions);
-        }
-    }
-    
-    #endregion
+    public bool? Allow;
+    public bool? Infinite;
+    public ElytraConfigurationChanges Configuration;
 }

--- a/src/Triggers/ConfigureElytraTrigger.cs
+++ b/src/Triggers/ConfigureElytraTrigger.cs
@@ -1,31 +1,115 @@
-﻿using Celeste.Mod.CommunalHelper.States;
+﻿using Celeste.Mod.CommunalHelper.Components;
+using Celeste.Mod.CommunalHelper.States;
+using System.Linq;
 using static Celeste.Mod.CommunalHelper.States.Elytra;
 
 namespace Celeste.Mod.CommunalHelper.Triggers;
 
 [CustomEntity("CommunalHelper/ConfigureElytraTrigger")]
+[Tracked]
 public class ConfigureElytraTrigger : Trigger
 {
     private readonly bool allow, infinite;
-
     private readonly ElytraConfiguration options;
+    
+    private readonly bool revertOnLeave;
+    private readonly bool revertOnDeath;
+    private readonly bool onlyOnce;
+    
+    private struct ElytraConfigurationChanges
+    {
+        public bool? Allow;
+        public bool? Infinite;
+        public bool? DisableReverseVerticalMomentum;
+    }
+    
+    private ElytraConfigurationChanges? changesNeededToRevert;
 
     public ConfigureElytraTrigger(EntityData data, Vector2 offset)
         : base(data, offset)
     {
+        revertOnLeave = data.Bool("revertOnLeave", false);
+        revertOnDeath = data.Bool("revertOnDeath", true);
+        onlyOnce = data.Bool("onlyOnce", false);
+        
         allow = data.Bool("allow", false);
         infinite = data.Bool("infinite", false);
 
         options = new ElytraConfiguration()
         {
-            disableReverseVerticalMomentum = data.Bool("disableReverseVerticalMomentum"),
+            DisableReverseVerticalMomentum = data.Bool("disableReverseVerticalMomentum"),
         };
+        
+        string flag = data.Attr("flag");
+        if (!string.IsNullOrEmpty(flag)) {
+            Add(new FlagToggleComponent(flag, data.Bool("flagInverted")));
+        }
     }
+    
+    private static ElytraConfigurationChanges CalculateChangesNeededToRevert((bool allow, bool infinite, ElytraConfiguration options) from, (bool allow, bool infinite, ElytraConfiguration options) to)
+        => new()
+        {
+            Allow = to.allow == from.allow ? null : from.allow,
+            Infinite = to.infinite == from.infinite ? null : from.infinite,
+            DisableReverseVerticalMomentum = to.options.DisableReverseVerticalMomentum == from.options.DisableReverseVerticalMomentum ? null : from.options.DisableReverseVerticalMomentum
+        };
 
-    public override void OnEnter(Player player)
+    private static (bool, bool, ElytraConfiguration) RevertChanges((bool allow, bool infinite, ElytraConfiguration options) current, ElytraConfigurationChanges? changesNeededToRevert)
+        => (changesNeededToRevert?.Allow ?? current.allow, changesNeededToRevert?.Infinite ?? current.infinite, new ElytraConfiguration()
+        {
+            DisableReverseVerticalMomentum = changesNeededToRevert?.DisableReverseVerticalMomentum ?? current.options.DisableReverseVerticalMomentum
+        });
+
+    private static void SaveChanges(Player player, bool allow, bool infinite, ElytraConfiguration options)
     {
         CommunalHelperModule.Session.CanDeployElytra = allow;
         CommunalHelperModule.Session.CurrentElytraConfiguration = options;
         player.SetInfiniteElytra(infinite);
     }
+
+    public override void OnEnter(Player player)
+    {
+        changesNeededToRevert = CalculateChangesNeededToRevert(
+            (CommunalHelperModule.Session.CanDeployElytra, player.HasInfiniteElytra(), CommunalHelperModule.Session.CurrentElytraConfiguration),
+            (allow, infinite, options));
+        SaveChanges(player, allow, infinite, options);
+        
+        if (onlyOnce) {
+            RemoveSelf();
+        }
+    }
+    
+    public override void OnLeave(Player player)
+    {
+        if (revertOnLeave && !player.Dead)
+        {
+            (bool newAllow, bool newInfinite, ElytraConfiguration newOptions) = RevertChanges((allow, infinite, options), changesNeededToRevert);
+            SaveChanges(player, newAllow, newInfinite, newOptions);
+        }
+    }
+    
+    #region Hooks
+
+    internal static void Load()
+    {
+        Everest.Events.Player.OnDie += OnDie;
+    }
+
+    internal static void Unload()
+    {
+        Everest.Events.Player.OnDie -= OnDie;
+    }
+
+    private static void OnDie(Player player)
+    {
+        foreach (ConfigureElytraTrigger trigger in player.SceneAs<Level>().Tracker.GetEntities<ConfigureElytraTrigger>()
+                                                                  .Cast<ConfigureElytraTrigger>()
+                                                                  .Where(trigger => trigger.revertOnDeath && trigger.changesNeededToRevert is not null))
+        {
+            (bool newAllow, bool newInfinite, ElytraConfiguration newOptions) = RevertChanges((trigger.allow, trigger.infinite, trigger.options), trigger.changesNeededToRevert);
+            SaveChanges(player, newAllow, newInfinite, newOptions);
+        }
+    }
+    
+    #endregion
 }

--- a/src/Triggers/ConfigureElytraTrigger.cs
+++ b/src/Triggers/ConfigureElytraTrigger.cs
@@ -5,7 +5,7 @@ namespace Celeste.Mod.CommunalHelper.Triggers;
 
 [CustomEntity("CommunalHelper/ConfigureElytraTrigger")]
 [TrackedAs(typeof(AbstractConfigureStateTrigger<ElytraOptions, ElytraOptionsChanges>))]
-public class ConfigureElytraTrigger : AbstractConfigureStateTrigger<ElytraOptions, ElytraOptionsChanges>
+internal class ConfigureElytraTrigger : AbstractConfigureStateTrigger<ElytraOptions, ElytraOptionsChanges>
 {
     public ConfigureElytraTrigger(EntityData data, Vector2 offset)
         : base(data, offset)
@@ -16,7 +16,7 @@ public class ConfigureElytraTrigger : AbstractConfigureStateTrigger<ElytraOption
         {
             Allow = data.Bool("allow", false),
             Infinite = data.Bool("infinite", false),
-            Configuration = new ElytraConfiguration()
+            Configuration = new ElytraConfiguration
             {
                 DisableReverseVerticalMomentum = data.Bool("disableReverseVerticalMomentum"),
             },
@@ -38,21 +38,21 @@ public class ConfigureElytraTrigger : AbstractConfigureStateTrigger<ElytraOption
     protected override ElytraOptionsChanges CalculateChangesNeededToRevert(ElytraOptions from, ElytraOptions to)
         => new()
         {
-            Allow = to.Allow == from.Allow ? null : from.Allow,
-            Infinite = to.Infinite == from.Infinite ? null : from.Infinite,
-            Configuration = new ElytraOptionsChanges.ElytraConfigurationChanges()
+            NewAllow = to.Allow == from.Allow ? null : from.Allow,
+            NewInfinite = to.Infinite == from.Infinite ? null : from.Infinite,
+            NewConfiguration = new ElytraOptionsChanges.ElytraConfigurationChanges
             {
-                DisableReverseVerticalMomentum = to.Configuration.DisableReverseVerticalMomentum == from.Configuration.DisableReverseVerticalMomentum ? null : from.Configuration.DisableReverseVerticalMomentum
+                NewDisableReverseVerticalMomentum = to.Configuration.DisableReverseVerticalMomentum == from.Configuration.DisableReverseVerticalMomentum ? null : from.Configuration.DisableReverseVerticalMomentum
             }
         };
     protected override ElytraOptions RevertChanges(ElytraOptions current, ElytraOptionsChanges? changesNeededToRevert)
         => new()
         {
-            Allow = changesNeededToRevert?.Allow ?? current.Allow,
-            Infinite = changesNeededToRevert?.Infinite ?? current.Infinite,
-            Configuration = new ElytraConfiguration()
+            Allow = changesNeededToRevert?.NewAllow ?? current.Allow,
+            Infinite = changesNeededToRevert?.NewInfinite ?? current.Infinite,
+            Configuration = new ElytraConfiguration
             {
-                DisableReverseVerticalMomentum = changesNeededToRevert?.Configuration.DisableReverseVerticalMomentum ?? current.Configuration.DisableReverseVerticalMomentum
+                DisableReverseVerticalMomentum = changesNeededToRevert?.NewConfiguration.NewDisableReverseVerticalMomentum ?? current.Configuration.DisableReverseVerticalMomentum
             }
         };
 }
@@ -68,10 +68,10 @@ public struct ElytraOptionsChanges
 {
     public struct ElytraConfigurationChanges
     {
-        public bool? DisableReverseVerticalMomentum;
+        public bool? NewDisableReverseVerticalMomentum;
     }
     
-    public bool? Allow;
-    public bool? Infinite;
-    public ElytraConfigurationChanges Configuration;
+    public bool? NewAllow;
+    public bool? NewInfinite;
+    public ElytraConfigurationChanges NewConfiguration;
 }


### PR DESCRIPTION
Adds a new Bounce On Collision option to Configure Dream Tunnel Dash triggers.
Also reworks configure state triggers to work more like Extended Variant triggers, including new Revert On Death and Revert On Leave options.
Unfortunately, due to the implementation using generic classes (which aren't really supported by `[Tracked(true)]`), this PR bumps the Everest dependency to latest stable in order to use `[TrackedAs(typeof(UntrackedType))]`.