### PR TITLE
Fix ILCursor extensions moving the wrong way with 1 predicate

### DIFF
--- a/src/Utils/Extensions.cs
+++ b/src/Utils/Extensions.cs
@@ -880,7 +880,7 @@ public static class Extensions
 
         if (predicates.Length == 1)
         {
-            return cursor.TryGotoNext(moveType, predicates[0]);
+            return cursor.TryGotoPrev(moveType, predicates[0]);
         }
 
         int matchFrom = -1, matchTo = -1;
@@ -1024,7 +1024,7 @@ public static class Extensions
 
         if (predicates.Length == 1)
         {
-            return cursor.TryGotoNext(moveType, predicates[0]);
+            return cursor.TryGotoPrev(moveType, predicates[0]);
         }
 
         int matchFrom = -1, matchTo = -1;


### PR DESCRIPTION
typo wehh
Fixes the `TryGotoPrevFirstFit` and `TryGotoPrevFirstFitReversed` ILCursor extensions moving the wrong way when supplied with only 1 predicate . thanks @SnipUndercover 