### PR TITLE
Fix redirects using wrong logic + add option for dream refills to refill dash even if MaxDashes is 0

### DIFF
--- a/Loenn/entities/misc/dream_refill.lua
+++ b/Loenn/entities/misc/dream_refill.lua
@@ -11,6 +11,7 @@ dreamRefill.placements = {
         data = {
             oneUse = false,
             respawnTime = 2.5,
+            forceRefillDash = false,
             twoDash = false,
         }
     },
@@ -19,6 +20,7 @@ dreamRefill.placements = {
         data = {
             oneUse = false,
             respawnTime = 2.5,
+            forceRefillDash = false,
             twoDash = true,
         }
     }

--- a/Loenn/entities/misc/seeker_dash_refill.lua
+++ b/Loenn/entities/misc/seeker_dash_refill.lua
@@ -9,7 +9,8 @@ seekerDashRefill.placements = {
     {
         name = "seeker_dash_refill",
         data = {
-            oneUse = false
+            oneUse = false,
+            forceRefillDash = false
         }
     }
 }

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -6,6 +6,7 @@ entities.CommunalHelper/DreamRefill.placements.name.double_dream_refill=Dream Re
 entities.CommunalHelper/DreamRefill.attributes.description.oneUse=Whether the Dream Refill should be only used once.
 entities.CommunalHelper/DreamRefill.attributes.description.twoDash=Whether the Dream Refill should give two Dream Dashes.
 entities.CommunalHelper/DreamRefill.attributes.description.respawnTime=The time taken by the Dream Refill to respawn.
+entities.CommunalHelper/DreamRefill.attributes.description.forceRefillDash=Whether the Dream Refill should refill a dash even if the player's maximum dash count is 0 (via Extended Variants).
 
 # Dream Jellyfish
 entities.CommunalHelper/DreamJellyfish.placements.name.normal=Dream Jellyfish
@@ -676,6 +677,7 @@ entities.CommunalHelper/DreamStrawberry.attributes.description.order=Manually de
 # Seeker Dash Refill
 entities.CommunalHelper/SeekerDashRefill.placements.name.seeker_dash_refill=Seeker Dash Refill
 entities.CommunalHelper/SeekerDashRefill.attributes.description.oneUse=Whether the crystal should permanently disappear after being collected.
+entities.CommunalHelper/SeekerDashRefill.attributes.description.forceRefillDash=Whether the crystal should refill a dash even if the player's maximum dash count is 0 (via Extended Variants).
 
 # Player Seeker Barrier
 entities.CommunalHelper/PlayerSeekerBarrier.placements.name.normal=Player Seeker Barrier (No spikes)

--- a/src/DashStates/DashStateRefill.cs
+++ b/src/DashStates/DashStateRefill.cs
@@ -15,6 +15,7 @@ public abstract class DashStateRefill : Refill
     protected string ReturnSFX = CustomSFX.game_dreamRefill_dream_refill_return;
 
     private readonly float respawnTime;
+    private readonly bool forceRefillDash;
 
     protected DynamicData baseData;
 
@@ -24,6 +25,7 @@ public abstract class DashStateRefill : Refill
         baseData = new(typeof(Refill), this);
 
         respawnTime = data.Float("respawnTime", 2.5f); // default is 2.5 sec.
+        forceRefillDash = data.Bool("forceRefillDash", false); // whether to refill a dash even if MaxDashes is 0 via extvars
 
         Get<PlayerCollider>().OnCollide = OnPlayer;
 
@@ -53,7 +55,14 @@ public abstract class DashStateRefill : Refill
     {
         if (CanActivate(player))
         {
-            player.RefillDash();
+            if (forceRefillDash)
+            {
+                player.Dashes = Math.Max(player.Dashes, Math.Max(player.MaxDashes, 1));
+            }
+            else
+            {
+                player.RefillDash();
+            }
             player.RefillStamina();
             Activated(player);
             Audio.Play(TouchSFX, Position);

--- a/src/States/DreamTunnelDash.cs
+++ b/src/States/DreamTunnelDash.cs
@@ -106,7 +106,7 @@ public static class DreamTunnelDash
         if (config.RedirectConsumesNormalDash ? player.Dashes <= 0 : DreamTunnelDashCount <= 0)
             return;
 
-        bool flag = Input.GetAimVector().Sign() == player.Speed.Sign();
+        bool flag = Input.GetAimVector().Sign() == player.DashDir.Sign();
         if ((!config.AllowRedirect || flag) && (!config.AllowSameDirectionRedirect || !flag))
             return;
 
@@ -169,10 +169,12 @@ public static class DreamTunnelDash
         if (horizontal)
         {
             player.Speed.X *= -1;
+            player.DashDir.X *= -1;
         }
         if (vertical)
         {
             player.Speed.Y *= -1;
+            player.DashDir.Y *= -1;
         }
     }
 


### PR DESCRIPTION
Fixes dream tunnel dash redirects checking the player's Speed instead of their DashDir, adds option to allow dream + seeker dash refills to refill the player's dash even if their MaxDashes is 0 (via Extended Variants or something).