### PR TITLE
Allow adding cloudscapes as foreground stylegrounds

### DIFF
--- a/Loenn/effects/cloudscape.lua
+++ b/Loenn/effects/cloudscape.lua
@@ -2,7 +2,7 @@ local cloudscape = {}
 
 cloudscape.name = "CommunalHelper/Cloudscape"
 cloudscape.canBackground = true
-cloudscape.canForeground = false
+cloudscape.canForeground = true
 
 cloudscape.fieldInformation = {
     bgColor = {

--- a/src/Backdrops/Cloudscape/Cloudscape.cs
+++ b/src/Backdrops/Cloudscape/Cloudscape.cs
@@ -469,6 +469,7 @@ public class Cloudscape : Backdrop
         Engine.Graphics.GraphicsDevice.SetRenderTarget(buffer);
         Engine.Graphics.GraphicsDevice.Clear(sky);
         Engine.Graphics.GraphicsDevice.BlendState = BlendState.AlphaBlend;
+        Engine.Graphics.GraphicsDevice.RasterizerState = RasterizerState.CullNone;
 
         EffectParameterCollection parameters = CommunalHelperGFX.CloudscapeShader.Parameters;
 
@@ -505,8 +506,7 @@ public class Cloudscape : Backdrop
         // present onto RT
         Engine.Instance.GraphicsDevice.SetRenderTarget(rt);
 
-        BackdropRenderer renderer = level.Background;
-        renderer.StartSpritebatch(blend);
+        Renderer.StartSpritebatch(blend);
         switch (ZoomBehavior)
         {
             case ZoomBehaviors.StaySame:
@@ -516,7 +516,7 @@ public class Cloudscape : Backdrop
                 Draw.SpriteBatch.Draw(buffer, Vector2.Zero, Color.White * BufferAlpha);
                 break;
         }
-        renderer.EndSpritebatch();
+        Renderer.EndSpritebatch();
     }
 
     public override void Ended(Scene scene)


### PR DESCRIPTION
Also sets the rasterizer state to `RasterizerStates.CullNone` before rendering to prevent it from completely exploding sometimes (this would happen if a cloudscape was the first fg styleground since the Bloom.Apply call immediately before fg styleground rendering leaves it set to `RasterizerStates.CullCounterClockwise`)