### PR TITLE
Add option to fix Move Block Redirects' effects sometimes persisting after block respawn

### DIFF
--- a/Loenn/entities/connected_blocks/connected_move_block.lua
+++ b/Loenn/entities/connected_blocks/connected_move_block.lua
@@ -61,6 +61,7 @@ for i, direction in ipairs(enums.move_block_directions) do
             regenTime = 3.0,
             shakeOnCollision = true,
             noDebris = false,
+            redirectIsPersistent = false
         }
     }
 end
@@ -82,6 +83,7 @@ connectedMoveBlock.placements[5] = {
         regenTime = 3.0,
         shakeOnCollision = true,
         noDebris = false,
+        redirectIsPersistent = false
     }
 }
 connectedMoveBlock.placements[6] = {
@@ -102,6 +104,7 @@ connectedMoveBlock.placements[6] = {
         regenTime = 3.0,
         shakeOnCollision = true,
         noDebris = false,
+        redirectIsPersistent = false,
         activatorFlags = "_pressed",
         breakerFlags = "_obstructed",
         onActivateFlags = "",

--- a/Loenn/entities/connected_blocks/equation_move_block.lua
+++ b/Loenn/entities/connected_blocks/equation_move_block.lua
@@ -82,6 +82,7 @@ for i, direction in ipairs(enums.move_block_directions) do
             regenTime = 3.0,
             shakeOnCollision = true,
             noDebris = false,
+            redirectIsPersistent = false
         }
     }
 end
@@ -105,6 +106,7 @@ equationMoveBlock.placements[5] = {
         regenTime = 3.0,
         shakeOnCollision = true,
         noDebris = false,
+        redirectIsPersistent = false
     }
 }
 equationMoveBlock.placements[6] = {
@@ -127,6 +129,7 @@ equationMoveBlock.placements[6] = {
         regenTime = 3.0,
         shakeOnCollision = true,
         noDebris = false,
+        redirectIsPersistent = false,
         activatorFlags = "_pressed",
         breakerFlags = "_obstructed",
         onActivateFlags = "",

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -442,6 +442,7 @@ entities.CommunalHelper/ConnectedMoveBlock.attributes.description.crashTime=The 
 entities.CommunalHelper/ConnectedMoveBlock.attributes.description.regenTime=The time it takes for this Connected Move Block to respawn after breaking in seconds.
 entities.CommunalHelper/ConnectedMoveBlock.attributes.description.shakeOnCollision=Whether this Connected Move Block should start shaking if it collides with a solid for longer than the default break time.
 entities.CommunalHelper/ConnectedMoveBlock.attributes.description.noDebris=Whether this Connected Move Block should not spawn debris when it breaks.
+entities.CommunalHelper/ConnectedMoveBlock.attributes.description.redirectIsPersistent=Whether the effects of any Move Block Redirects on this block should persist after this block breaks and respawns.
 
 # Connected Temple Cracked Block
 entities.CommunalHelper/ConnectedTempleCrackedBlock.placements.name.normal=Connected Temple Cracked Block
@@ -477,6 +478,7 @@ entities.CommunalHelper/EquationMoveBlock.attributes.description.crashTime=The t
 entities.CommunalHelper/EquationMoveBlock.attributes.description.regenTime=The time it takes for this Equation Move Block to respawn after breaking in seconds.
 entities.CommunalHelper/EquationMoveBlock.attributes.description.shakeOnCollision=Whether this Equation Move Block should start shaking if it collides with a solid for longer than the default break time.
 entities.CommunalHelper/EquationMoveBlock.attributes.description.noDebris=Whether this Equation Move Block should not spawn debris when it breaks.
+entities.CommunalHelper/EquationMoveBlock.attributes.description.redirectIsPersistent=Whether the effects of any Move Block Redirects on this block should persist after this block breaks and respawns.
 
 # Bouncy Panel
 entities.CommunalHelper/BouncyPanel.placements.name.up=Bouncy Panel (Up)

--- a/src/Entities/ConnectedBlocks/ConnectedMoveBlock.cs
+++ b/src/Entities/ConnectedBlocks/ConnectedMoveBlock.cs
@@ -124,6 +124,9 @@ public class ConnectedMoveBlock : ConnectedSolid
 
     protected readonly bool noDebris;
 
+    // whether any MoveBlockRedirects' effects on this move block should persist after respawn
+    protected readonly bool redirectIsPersistent;
+
     public ConnectedMoveBlock(EntityData data, Vector2 offset)
         : this(data.Position + offset, data.Width, data.Height, data.Enum<MoveBlock.Directions>("direction"), data.Bool("fast") ? 75f : data.Float("moveSpeed", 60f))
     {
@@ -203,6 +206,8 @@ public class ConnectedMoveBlock : ConnectedSolid
         shakeOnCollision = data.Bool("shakeOnCollision", true);
 
         noDebris = data.Bool("noDebris");
+
+        redirectIsPersistent = data.Bool("redirectIsPersistent", true);
     }
 
     public ConnectedMoveBlock(Vector2 position, int width, int height, MoveBlock.Directions direction, float moveSpeed)
@@ -368,6 +373,8 @@ public class ConnectedMoveBlock : ConnectedSolid
             yield return 0.2f;
 
             BreakParticles();
+            if (!redirectIsPersistent)
+                ((MoveBlockRedirectable) Get<Redirectable>())?.ResetBlock();
 
             List<MoveBlockDebris> debris = new();
             if (!noDebris)

--- a/src/Entities/ConnectedBlocks/EquationMoveBlock.cs
+++ b/src/Entities/ConnectedBlocks/EquationMoveBlock.cs
@@ -187,6 +187,8 @@ internal class EquationMoveBlock : ConnectedMoveBlock
             yield return 0.2f;
 
             BreakParticles();
+            if (!redirectIsPersistent)
+                ((MoveBlockRedirectable) Get<Redirectable>())?.ResetBlock();
 
             List<MoveBlockDebris> debris = new();
             if (!noDebris)


### PR DESCRIPTION
Having Connected and Equation Move Blocks hit a Move Block Redirect and then break would cause the direction change from the Redirect to persist after the block respawned. This PR adds a toggle for this behaviour, defaulting to off on new placements.