### PR TITLE
Add option to disable the pulsing of Move Block Groups

### DIFF
--- a/Loenn/entities/misc/move_block_group.lua
+++ b/Loenn/entities/misc/move_block_group.lua
@@ -35,6 +35,7 @@ moveBlockGroup.placements = {
         name = "move_block_group",
         data = {
             color = defaultColorValue,
+            disablePulse = false,
             syncActivation = true,
             respawnBehavior = "Simultaneous"
         }

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -719,7 +719,8 @@ entities.CommunalHelper/UFO.attributes.description.raySizeY=The height of the be
 
 # Move Block Group
 entities.CommunalHelper/MoveBlockGroup.placements.name.move_block_group=Move Block Group
-entities.CommunalHelper/MoveBlockGroup.attributes.description.color=The display color of this Move Block group.
+entities.CommunalHelper/MoveBlockGroup.attributes.description.color=The display color of this Move Block group.\nDoes nothing if "Disable Pulse" is enabled.
+entities.CommunalHelper/MoveBlockGroup.attributes.description.disablePulse=Whether to disable the colored pulsing of the arrows of Move Blocks in this group.
 entities.CommunalHelper/MoveBlockGroup.attributes.description.syncActivation=Whether all Move Blocks from this group are bound to activate simultaneously.
 entities.CommunalHelper/MoveBlockGroup.attributes.description.respawnBehavior=Dictates how Move Blocks respawn within this group.\n* Immediate: the Move Blocks respawn immediately, like they normally do outside of a group.\n* Simultaneous: all Move Blocks from this group must have first broken in order for them to respawn.\n* Sequential: each Move Block will only respawn once all the ones that came before it in the group have respawned.   
 

--- a/src/Components/GroupableMoveBlock.cs
+++ b/src/Components/GroupableMoveBlock.cs
@@ -55,7 +55,7 @@ public class GroupableMoveBlock : Component
     public Color HighlightColor(Color? color = null)
     {
         Color baseColor = color ?? Color.Transparent;
-        return Group is null ?
+        return Group is null || Group.DisablePulse ?
             baseColor :
             Color.Lerp(baseColor, Group.Color, Calc.SineMap(Scene.TimeActive * 3, 0, 1));
     }

--- a/src/Entities/Misc/MoveBlockGroup.cs
+++ b/src/Entities/Misc/MoveBlockGroup.cs
@@ -19,20 +19,22 @@ public class MoveBlockGroup : Entity
     private readonly Vector2[] nodes;
 
     public Color Color { get; }
+    public bool DisablePulse { get; }
     public bool SyncActivation { get; }
     private readonly RespawnBehavior respawnBehavior;
 
     private readonly List<GroupableMoveBlock> components = new();
 
     public MoveBlockGroup(EntityData data, Vector2 offset)
-        : this(data.NodesOffset(offset), data.HexColor("color", defaultColor), data.Bool("syncActivation", true), data.Enum("respawnBehavior", RespawnBehavior.Simultaneous))
+        : this(data.NodesOffset(offset), data.HexColor("color", defaultColor), data.Bool("disablePulse"), data.Bool("syncActivation", true), data.Enum("respawnBehavior", RespawnBehavior.Simultaneous))
     { }
 
-    public MoveBlockGroup(Vector2[] nodes, Color color, bool syncActivation = true, RespawnBehavior respawnBehavior = RespawnBehavior.Simultaneous)
+    public MoveBlockGroup(Vector2[] nodes, Color color, bool disablePulse = false, bool syncActivation = true, RespawnBehavior respawnBehavior = RespawnBehavior.Simultaneous)
     {
         this.nodes = nodes;
 
         Color = color;
+        DisablePulse = disablePulse;
         SyncActivation = syncActivation;
         this.respawnBehavior = respawnBehavior;
     }


### PR DESCRIPTION
This PR adds an option to Move Block Groups to disable the pulsing of the arrows on Move Blocks in the group.