### PR TITLE
Held Cassete Blocks options

### DIFF
--- a/Loenn/entities/cassette_blocks/cassette_falling_block.lua
+++ b/Loenn/entities/cassette_blocks/cassette_falling_block.lua
@@ -32,6 +32,7 @@ for i = 1, 4 do
             height = 16,
             customColor = colors[i],
             oldConnectionBehavior = false,
+            held = false,
         }
     }
 end

--- a/Loenn/entities/cassette_blocks/cassette_move_block.lua
+++ b/Loenn/entities/cassette_blocks/cassette_move_block.lua
@@ -49,6 +49,7 @@ for i = 1, 4 do
             direction = "Right",
             moveSpeed = 60.0,
             oldConnectionBehavior = false,
+            held = false,
             crashTime = 0.15,
             regenTime = 3.0,
             shakeOnCollision = true,

--- a/Loenn/entities/cassette_blocks/cassette_swap_block.lua
+++ b/Loenn/entities/cassette_blocks/cassette_swap_block.lua
@@ -36,6 +36,7 @@ for i = 1, 4 do
             customColor = colors[i],
             noReturn = false,
             oldConnectionBehavior = false,
+            held = false,
         }
     }
 end

--- a/Loenn/entities/cassette_blocks/cassette_zip_mover.lua
+++ b/Loenn/entities/cassette_blocks/cassette_zip_mover.lua
@@ -47,6 +47,7 @@ for i = 1, 4 do
             noReturn = false,
             customColor = colors[i],
             oldConnectionBehavior = false,
+            held = false,
         }
     }
 end

--- a/Loenn/entities/cassette_blocks/custom_cassette_block.lua
+++ b/Loenn/entities/cassette_blocks/custom_cassette_block.lua
@@ -32,6 +32,7 @@ for i = 1, 4 do
             height = 16,
             customColor = colors[i],
             oldConnectionBehavior = false,
+            held = false,
         }
     }
 end

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -156,6 +156,7 @@ entities.CommunalHelper/CustomCassetteBlock.attributes.description.index=The col
 entities.CommunalHelper/CustomCassetteBlock.attributes.description.tempo=The tempo of the cassette music in the room.
 entities.CommunalHelper/CustomCassetteBlock.attributes.description.customColor=Optional hexadecimal color code, visual-only change.
 entities.CommunalHelper/CustomCassetteBlock.attributes.description.oldConnectionBehavior=Force the old texture connection behavior (cassette entities connect to anything around them that is on the same index).
+entities.CommunalHelper/CustomCassetteBlock.attributes.description.held=Whether this Cassette Block is activated by holding the manual cassette key binding (using the Manual Cassette Controller).\nThis only works if this block's index is 0 or 1:\n- index 0: ACTIVE when key is HELD.\n- index 1: INACTIVE when key is HELD.
 
 # Cassette Falling Block
 entities.CommunalHelper/CassetteFallingBlock.placements.name.cassette_block_0=Cassette Falling Block (0 - Blue)
@@ -166,6 +167,7 @@ entities.CommunalHelper/CassetteFallingBlock.attributes.description.index=The co
 entities.CommunalHelper/CassetteFallingBlock.attributes.description.tempo=The tempo of the cassette music in the room.
 entities.CommunalHelper/CassetteFallingBlock.attributes.description.customColor=Optional hexadecimal color code, visual-only change.
 entities.CommunalHelper/CassetteFallingBlock.attributes.description.oldConnectionBehavior=Force the old texture connection behavior (cassette entities connect to anything around them that is on the same index).
+entities.CommunalHelper/CassetteFallingBlock.attributes.description.held=Whether this Cassette Block is activated by holding the manual cassette key binding (using the Manual Cassette Controller).\nThis only works if this block's index is 0 or 1:\n- index 0: ACTIVE when key is HELD.\n- index 1: INACTIVE when key is HELD.
 
 # Cassette Zip Mover
 entities.CommunalHelper/CassetteZipMover.placements.name.cassette_block_0=Cassette Zip Mover (0 - Blue)
@@ -180,6 +182,7 @@ entities.CommunalHelper/CassetteZipMover.attributes.description.waiting=Whether 
 entities.CommunalHelper/CassetteZipMover.attributes.description.ticking=Causes this block to tick 5 times at every node before going back to its starting point, unless the player triggers it again. If `permanent` is true and the player doesn't trigger the Zip Mover in time, it'll lock in place.
 entities.CommunalHelper/CassetteZipMover.attributes.description.customColor=Optional hexadecimal color code, visual-only change.
 entities.CommunalHelper/CassetteZipMover.attributes.description.oldConnectionBehavior=Force the old texture connection behavior (cassette entities connect to anything around them that is on the same index).
+entities.CommunalHelper/CassetteZipMover.attributes.description.held=Whether this Cassette Block is activated by holding the manual cassette key binding (using the Manual Cassette Controller).\nThis only works if this block's index is 0 or 1:\n- index 0: ACTIVE when key is HELD.\n- index 1: INACTIVE when key is HELD.
 
 # Cassette Move Block
 entities.CommunalHelper/CassetteMoveBlock.placements.name.cassette_block_0=Cassette Move Block (0 - Blue)
@@ -198,6 +201,7 @@ entities.CommunalHelper/CassetteMoveBlock.attributes.description.crashTime=The t
 entities.CommunalHelper/CassetteMoveBlock.attributes.description.regenTime=The time it takes for this Cassette Move Block to respawn after breaking in seconds.
 entities.CommunalHelper/CassetteMoveBlock.attributes.description.shakeOnCollision=Whether this Cassette Move Block should start shaking if it collides with a solid for longer than the default break time.
 entities.CommunalHelper/CassetteMoveBlock.attributes.description.noDebris=Whether this Cassette Move Block should not spawn debris when it breaks.
+entities.CommunalHelper/CassetteMoveBlock.attributes.description.held=Whether this Cassette Block is activated by holding the manual cassette key binding (using the Manual Cassette Controller).\nThis only works if this block's index is 0 or 1:\n- index 0: ACTIVE when key is HELD.\n- index 1: INACTIVE when key is HELD.
 
 # Cassette Swap Block
 entities.CommunalHelper/CassetteSwapBlock.placements.name.cassette_block_0=Cassette Swap Block (0 - Blue)
@@ -209,6 +213,7 @@ entities.CommunalHelper/CassetteSwapBlock.attributes.description.index=The color
 entities.CommunalHelper/CassetteSwapBlock.attributes.description.tempo=The tempo of the cassette music in the room.
 entities.CommunalHelper/CassetteSwapBlock.attributes.description.customColor=Optional hexadecimal color code, visual-only change.
 entities.CommunalHelper/CassetteSwapBlock.attributes.description.oldConnectionBehavior=Force the old texture connection behavior (cassette entities connect to anything around them that is on the same index).
+entities.CommunalHelper/CassetteSwapBlock.attributes.description.held=Whether this Cassette Block is activated by holding the manual cassette key binding (using the Manual Cassette Controller).\nThis only works if this block's index is 0 or 1:\n- index 0: ACTIVE when key is HELD.\n- index 1: INACTIVE when key is HELD.
 
 # Cassette Jump Fix Controller
 entities.CommunalHelper/CassetteJumpFixController.placements.name.controller=Cassette Jump Fix Controller

--- a/src/CommunalHelperModule.cs
+++ b/src/CommunalHelperModule.cs
@@ -59,6 +59,7 @@ public class CommunalHelperModule : EverestModule
 
         ConnectedSwapBlockHooks.Hook();
         CustomCassetteBlock.Hook();
+        HeldCassetteBlock.Hook();
 
         AttachedWallBooster.Hook();
         MoveBlockRedirect.Load();
@@ -156,6 +157,7 @@ public class CommunalHelperModule : EverestModule
 
         ConnectedSwapBlockHooks.Unhook();
         CustomCassetteBlock.Unhook();
+        HeldCassetteBlock.Unhook();
 
         AttachedWallBooster.Unhook();
         MoveBlockRedirect.Unload();
@@ -244,6 +246,7 @@ public class CommunalHelperModule : EverestModule
 
         // Register CustomCassetteBlock types
         CustomCassetteBlock.Initialize();
+        HeldCassetteBlock.Initialize();
 
         // We may hook methods in other mods, so this needs to be done after they're loaded
         AbstractPanel.LoadDelayed();

--- a/src/CommunalHelperModule.cs
+++ b/src/CommunalHelperModule.cs
@@ -59,7 +59,6 @@ public class CommunalHelperModule : EverestModule
 
         ConnectedSwapBlockHooks.Hook();
         CustomCassetteBlock.Hook();
-        HeldCassetteBlock.Hook();
 
         AttachedWallBooster.Hook();
         MoveBlockRedirect.Load();
@@ -157,7 +156,6 @@ public class CommunalHelperModule : EverestModule
 
         ConnectedSwapBlockHooks.Unhook();
         CustomCassetteBlock.Unhook();
-        HeldCassetteBlock.Unhook();
 
         AttachedWallBooster.Unhook();
         MoveBlockRedirect.Unload();
@@ -246,7 +244,6 @@ public class CommunalHelperModule : EverestModule
 
         // Register CustomCassetteBlock types
         CustomCassetteBlock.Initialize();
-        HeldCassetteBlock.Initialize();
 
         // We may hook methods in other mods, so this needs to be done after they're loaded
         AbstractPanel.LoadDelayed();

--- a/src/Entities/CassetteBlocks/CassetteFallingBlock.cs
+++ b/src/Entities/CassetteBlocks/CassetteFallingBlock.cs
@@ -10,14 +10,14 @@ public class CassetteFallingBlock : CustomCassetteBlock
 
     public bool HasStartedFalling { get; private set; }
 
-    public CassetteFallingBlock(Vector2 position, EntityID id, int width, int height, int index, float tempo, bool oldConnectionBehavior, Color? overrideColor)
-        : base(position, id, width, height, index, tempo, true, oldConnectionBehavior, dynamicHitbox: true, overrideColor)
+    public CassetteFallingBlock(Vector2 position, EntityID id, int width, int height, int index, float tempo, bool oldConnectionBehavior, bool held ,Color? overrideColor)
+        : base(position, id, width, height, index, tempo, true, oldConnectionBehavior,held , dynamicHitbox: true, overrideColor)
     {
         Add(new Coroutine(Sequence()));
     }
 
     public CassetteFallingBlock(EntityData data, Vector2 offset, EntityID id)
-        : this(data.Position + offset, id, data.Width, data.Height, data.Int("index"), data.Float("tempo", 1f), data.Bool("oldConnectionBehavior", true), data.HexColorNullable("customColor"))
+        : this(data.Position + offset, id, data.Width, data.Height, data.Int("index"), data.Float("tempo", 1f), data.Bool("oldConnectionBehavior", true), data.Bool("held"), data.HexColorNullable("customColor"))
     { }
 
     public override void OnStaticMoverTrigger(StaticMover sm)

--- a/src/Entities/CassetteBlocks/CassetteMoveBlock.cs
+++ b/src/Entities/CassetteBlocks/CassetteMoveBlock.cs
@@ -62,8 +62,8 @@ public class CassetteMoveBlock : CustomCassetteBlock
 
     private readonly bool noDebris;
 
-    public CassetteMoveBlock(Vector2 position, EntityID id, int width, int height, Directions direction, float moveSpeed, int index, float tempo, bool oldConnectionBehavior, Color? overrideColor, float crashTime, float regenTime, bool shakeOnCollision, bool noDebris)
-        : base(position, id, width, height, index, tempo, true, oldConnectionBehavior, dynamicHitbox: true, overrideColor)
+    public CassetteMoveBlock(Vector2 position, EntityID id, int width, int height, Directions direction, float moveSpeed, int index, float tempo, bool oldConnectionBehavior, bool held, Color? overrideColor, float crashTime, float regenTime, bool shakeOnCollision, bool noDebris)
+        : base(position, id, width, height, index, tempo, true, oldConnectionBehavior, held, dynamicHitbox: true, overrideColor)
     {
         startPosition = position;
         Direction = direction;
@@ -121,7 +121,7 @@ public class CassetteMoveBlock : CustomCassetteBlock
     }
 
     public CassetteMoveBlock(EntityData data, Vector2 offset, EntityID id)
-        : this(data.Position + offset, id, data.Width, data.Height, data.Enum("direction", Directions.Left), data.Bool("fast") ? FastMoveSpeed : data.Float("moveSpeed", MoveSpeed), data.Int("index"), data.Float("tempo", 1f), data.Bool("oldConnectionBehavior", true), data.HexColorNullable("customColor"), data.Float("crashTime", 0.15f), data.Float("regenTime", 3f), data.Bool("shakeOnCollision", true), data.Bool("noDebris"))
+        : this(data.Position + offset, id, data.Width, data.Height, data.Enum("direction", Directions.Left), data.Bool("fast") ? FastMoveSpeed : data.Float("moveSpeed", MoveSpeed), data.Int("index"), data.Float("tempo", 1f), data.Bool("oldConnectionBehavior", true), data.Bool("held"),data.HexColorNullable("customColor"), data.Float("crashTime", 0.15f), data.Float("regenTime", 3f), data.Bool("shakeOnCollision", true), data.Bool("noDebris"))
     {
     }
 

--- a/src/Entities/CassetteBlocks/CassetteSwapBlock.cs
+++ b/src/Entities/CassetteBlocks/CassetteSwapBlock.cs
@@ -65,8 +65,8 @@ public class CassetteSwapBlock : CustomCassetteBlock
 
     private readonly bool noReturn;
 
-    public CassetteSwapBlock(Vector2 position, EntityID id, int width, int height, Vector2 node, int index, float tempo, bool oldConnectionBehavior, bool noReturn, Color? overrideColor)
-        : base(position, id, width, height, index, tempo, true, oldConnectionBehavior, false, overrideColor)
+    public CassetteSwapBlock(Vector2 position, EntityID id, int width, int height, Vector2 node, int index, float tempo, bool oldConnectionBehavior, bool held ,bool noReturn, Color? overrideColor)
+        : base(position, id, width, height, index, tempo, true, oldConnectionBehavior, held ,false, overrideColor)
     {
         start = Position;
         end = node;
@@ -107,7 +107,7 @@ public class CassetteSwapBlock : CustomCassetteBlock
     }
 
     public CassetteSwapBlock(EntityData data, Vector2 offset, EntityID id)
-        : this(data.Position + offset, id, data.Width, data.Height, data.Nodes[0] + offset, data.Int("index"), data.Float("tempo", 1f), data.Bool("oldConnectionBehavior", true), data.Bool("noReturn", false), data.HexColorNullable("customColor"))
+        : this(data.Position + offset, id, data.Width, data.Height, data.Nodes[0] + offset, data.Int("index"), data.Float("tempo", 1f), data.Bool("oldConnectionBehavior", true), data.Bool("held"), data.Bool("noReturn", false), data.HexColorNullable("customColor"))
     {
     }
 

--- a/src/Entities/CassetteBlocks/CassetteZipMover.cs
+++ b/src/Entities/CassetteBlocks/CassetteZipMover.cs
@@ -215,8 +215,8 @@ public class CassetteZipMover : CustomCassetteBlock
 
     private static MTexture cog, cogPressed, cogWhite;
 
-    public CassetteZipMover(Vector2 position, EntityID id, int width, int height, Vector2[] nodes, int index, float tempo, bool oldConnectionBehavior, bool noReturn, bool perm, bool waits, bool ticking, Color? overrideColor)
-        : base(position, id, width, height, index, tempo, true, oldConnectionBehavior, false, overrideColor)
+    public CassetteZipMover(Vector2 position, EntityID id, int width, int height, Vector2[] nodes, int index, float tempo, bool oldConnectionBehavior,bool held, bool noReturn, bool perm, bool waits, bool ticking, Color? overrideColor)
+        : base(position, id, width, height, index, tempo, true, oldConnectionBehavior, held, false, overrideColor)
     {
         this.noReturn = noReturn;
         permanent = perm;
@@ -232,7 +232,7 @@ public class CassetteZipMover : CustomCassetteBlock
     }
 
     public CassetteZipMover(EntityData data, Vector2 offset, EntityID id)
-        : this(data.Position + offset, id, data.Width, data.Height, data.NodesWithPosition(offset), data.Int("index"), data.Float("tempo", 1f), data.Bool("oldConnectionBehavior", true),
+        : this(data.Position + offset, id, data.Width, data.Height, data.NodesWithPosition(offset), data.Int("index"), data.Float("tempo", 1f), data.Bool("oldConnectionBehavior", true), data.Bool("held"),
               data.Bool("noReturn", false),
               data.Bool("permanent"),
               data.Bool("waiting"),

--- a/src/Entities/CassetteBlocks/CustomCassetteBlock.cs
+++ b/src/Entities/CassetteBlocks/CustomCassetteBlock.cs
@@ -3,7 +3,6 @@ using MonoMod.Utils;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using static MonoMod.InlineRT.MonoModRule;
 
 namespace Celeste.Mod.CommunalHelper.Entities;
 

--- a/src/Entities/CassetteBlocks/CustomCassetteBlock.cs
+++ b/src/Entities/CassetteBlocks/CustomCassetteBlock.cs
@@ -3,13 +3,16 @@ using MonoMod.Utils;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using static MonoMod.InlineRT.MonoModRule;
 
 namespace Celeste.Mod.CommunalHelper.Entities;
 
 [TrackedAs(typeof(CassetteBlock), true)]
 [CustomEntity("CommunalHelper/CustomCassetteBlock")]
 public class CustomCassetteBlock : CassetteBlock
-{
+{   
+
+
     public static List<string> CustomCassetteBlockNames = new();
 
     public static void Initialize()
@@ -71,6 +74,9 @@ public class CustomCassetteBlock : CassetteBlock
             Collidable = value && virtualCollidable;
         }
     }
+
+    public bool Held { get; set; }
+
     // Whether the block is collidable according to cassette state
     private bool virtualCollidable = true;
 
@@ -95,13 +101,14 @@ public class CustomCassetteBlock : CassetteBlock
     }
 
     public CustomCassetteBlock(EntityData data, Vector2 offset, EntityID id)
-        : this(data.Position + offset, id, data.Width, data.Height, data.Int("index"), data.Float("tempo", 1f), false, data.Bool("oldConnectionBehavior", true), false, data.HexColorNullable("customColor")) { }
+        : this(data.Position + offset, id, data.Width, data.Height, data.Int("index"), data.Float("tempo", 1f), false, data.Bool("oldConnectionBehavior", true), data.Bool("held"), false, data.HexColorNullable("customColor")) { }
 
-    public CustomCassetteBlock(Vector2 position, EntityID id, int width, int height, int index, float tempo, bool lonely, bool oldConnectionBehavior, bool dynamicHitbox = false, Color? overrideColor = null)
+    public CustomCassetteBlock(Vector2 position, EntityID id, int width, int height, int index, float tempo, bool lonely, bool oldConnectionBehavior, bool held, bool dynamicHitbox = false, Color? overrideColor = null)
         : base(position, id, width, height, index, tempo)
     {
         blockData = new(typeof(CassetteBlock), this);
 
+        Held = held;
         Index = index;
         color = overrideColor ?? colorOptions[index];
         pressedColor = color.Mult(Calc.HexToColor("667da5"));

--- a/src/Entities/CassetteBlocks/ManualCassetteController.cs
+++ b/src/Entities/CassetteBlocks/ManualCassetteController.cs
@@ -81,7 +81,7 @@ public class ManualCassetteController : AbstractInputController
 
     public void HeldTick()
     {
-        heldIndex = 1- heldIndex;
+        heldIndex = 1 - heldIndex;
         SetHeldFlag(heldIndex);
         SetHeldIndex(heldIndex);
 /*      Audio.Play("event:/game/general/cassette_block_switch_" + ((heldIndex % 2) + 1));

--- a/src/Entities/CassetteBlocks/ManualCassetteController.cs
+++ b/src/Entities/CassetteBlocks/ManualCassetteController.cs
@@ -3,6 +3,7 @@ using MonoMod.Cil;
 using MonoMod.RuntimeDetour;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Metadata.Ecma335;
 
 namespace Celeste.Mod.CommunalHelper.Entities;
 
@@ -12,11 +13,14 @@ public class ManualCassetteController : AbstractInputController
 
     private int roomBeats;
     private int currentIndex;
+    private int heldIndex;
 
     private const string blueFlag = "CH_cas_blue";
     private const string pinkFlag = "CH_cas_rose";
     private const string yellowFlag = "CH_cas_brightsun";
     private const string greenFlag = "CH_cas_malachite";
+    private const string heldFlag = "CH_cas_held";
+
 
     public ManualCassetteController(EntityData data)
     {
@@ -51,12 +55,16 @@ public class ManualCassetteController : AbstractInputController
         base.Update();
         if (CommunalHelperModule.Settings.CycleCassetteBlocks.Pressed)
             Tick();
+        if (CommunalHelperModule.Settings.CycleCassetteBlocks.Check != Convert.ToBoolean(heldIndex))
+            HeldTick();
     }
 
     public override void FrozenUpdate()
     {
         if (CommunalHelperModule.Settings.CycleCassetteBlocks.Pressed)
             Tick();
+        if (CommunalHelperModule.Settings.CycleCassetteBlocks.Check != Convert.ToBoolean(heldIndex))
+            HeldTick();
     }
 
     public void Tick()
@@ -69,6 +77,15 @@ public class ManualCassetteController : AbstractInputController
         Input.Rumble(RumbleStrength.Medium, RumbleLength.Short);
     }
 
+    public void HeldTick()
+    {
+        heldIndex = 1- heldIndex;
+        SetHeldFlag(heldIndex);
+        SetHeldIndex(heldIndex);
+/*      Audio.Play("event:/game/general/cassette_block_switch_" + ((heldIndex % 2) + 1));
+        Input.Rumble(RumbleStrength.Medium, RumbleLength.Short);*/ // I don't want the audio to play twice
+    }
+
     public void SetFlag(int index)
     {
         Session session = SceneAs<Level>().Session;
@@ -78,16 +95,41 @@ public class ManualCassetteController : AbstractInputController
         session.SetFlag(greenFlag, index == 3);
     }
 
+    public void SetHeldFlag(int index)
+    {
+        Session session = SceneAs<Level>().Session;
+        session.SetFlag(heldFlag, index == 1);
+    }
+
     public void SetActiveIndex(int index, bool silent = false)
     {
         foreach (CassetteBlock entity in Scene.Tracker.GetEntities<CassetteBlock>().Cast<CassetteBlock>())
         {
-            entity.Activated = entity.Index == index;
-            bool activated = entity.Index == index;
-            if (silent)
-                entity.SetActivatedSilently(activated);
-            else
-                entity.Activated = activated;
+            if (!(entity is CustomCassetteBlock cassette && cassette.Held))
+            {
+                entity.Activated = entity.Index == index;
+                bool activated = entity.Index == index;
+                if (silent)
+                    entity.SetActivatedSilently(activated);
+                else
+                    entity.Activated = activated;
+            }
+        }
+    }
+
+    public void SetHeldIndex(int index, bool silent = false)
+    {
+        foreach (CassetteBlock entity in Scene.Tracker.GetEntities<CassetteBlock>().Cast<CassetteBlock>())
+        {
+            if (entity is CustomCassetteBlock cassette && cassette.Held)
+            {
+                entity.Activated = entity.Index == index;
+                bool activated = entity.Index == index;
+                if (silent)
+                    entity.SetActivatedSilently(activated);
+                else
+                    entity.Activated = activated;
+            }            
         }
     }
 

--- a/src/Entities/CassetteBlocks/ManualCassetteController.cs
+++ b/src/Entities/CassetteBlocks/ManualCassetteController.cs
@@ -3,7 +3,6 @@ using MonoMod.Cil;
 using MonoMod.RuntimeDetour;
 using System.Linq;
 using System.Reflection;
-using System.Reflection.Metadata.Ecma335;
 
 namespace Celeste.Mod.CommunalHelper.Entities;
 

--- a/src/Entities/CassetteBlocks/ManualCassetteController.cs
+++ b/src/Entities/CassetteBlocks/ManualCassetteController.cs
@@ -48,6 +48,9 @@ public class ManualCassetteController : AbstractInputController
         currentIndex = startIndex;
 
         SetActiveIndex(currentIndex, true);
+        SetFlag(currentIndex);
+        SetHeldIndex(currentIndex, true);
+        SetHeldFlag(currentIndex);
     }
 
     public override void Update()


### PR DESCRIPTION
Implemented an option for manual cassette blocks to work based on a held input, works with all cassette variants in the helper using the new "held" option. Index 0 being active when the cassete input is unheld and vice versa for index 1. There's also a corresponding flag.

The implementation I use is intended to allow cassette held blocks and non held blocks to function together if the mapper desires.