### PR TITLE
Refactor/fix dash collision in panels

### DIFF
--- a/src/DashStates/DreamTunnelDash/DreamTunnelEntry.cs
+++ b/src/DashStates/DreamTunnelDash/DreamTunnelEntry.cs
@@ -27,7 +27,7 @@ namespace Celeste.Mod.CommunalHelper.Entities;
 
 [CustomEntity("CommunalHelper/DreamTunnelEntry = LoadDreamTunnelEntry")]
 [Tracked]
-public class DreamTunnelEntry : AbstractPanel
+public class DreamTunnelEntry : AbstractDashCollisionPanel
 {
     private struct DreamParticle
     {

--- a/src/Entities/Panels/AbstractDashCollisionPanel.cs
+++ b/src/Entities/Panels/AbstractDashCollisionPanel.cs
@@ -1,0 +1,53 @@
+﻿using Directions = Celeste.Spikes.Directions;
+
+namespace Celeste.Mod.CommunalHelper.Entities;
+
+// Note: Inheriting from this class will cause the OnDashCollide function of the attached platform to become non-null if it was previously null
+// (returning DashCollisionResults.NormalCollision as a default)
+// It may cause side effects such as a red bubble not exiting when colliding with the platform.
+public abstract class AbstractDashCollisionPanel : AbstractPanel
+{
+    protected AbstractDashCollisionPanel(EntityData data, Vector2 offset) : base(data, offset)
+    {
+    }
+
+    protected AbstractDashCollisionPanel(Vector2 position, float size, Directions orientation, bool overrideAllowStaticMovers) : base(position, size, orientation, overrideAllowStaticMovers)
+    {
+    }
+
+    protected override void OnAttach(Platform platform)
+    {
+        base.OnAttach(platform);
+        platform.OnDashCollide = DelegateHelper.ApplyDashCollisionHook(platform.OnDashCollide, OnDashCollide);
+    }
+
+    /// <summary>
+    /// Does not check dash direction or direct collision with the Panel.
+    /// Use CheckDashCollision as needed.
+    /// </summary>
+    protected virtual DashCollisionResults OnDashCollide(DashCollision orig, Player player, Vector2 dir)
+    {
+        return orig(player, dir);
+    }
+    
+    protected bool CheckDashCollision(Player player, Vector2 dir)
+    {
+        switch (Orientation)
+        {
+            case Directions.Up when dir.Y > 0:
+            case Directions.Down when dir.Y < 0:
+            case Directions.Left when dir.X > 0:
+            case Directions.Right when dir.X < 0:
+                return player.CollideCheck(this, player.Position + dir);
+        }
+        return false;
+    }
+    
+    public override void Removed(Scene scene)
+    {
+        if (staticMover.Platform is not null && (staticMover.Platform.TagCheck(Tags.Global) || staticMover.Platform.TagCheck(Tags.Persistent)))
+            DelegateHelper.RemoveDashCollisionHook(staticMover.Platform.OnDashCollide, OnDashCollide);
+
+        base.Removed(scene);
+    }
+}

--- a/src/Entities/Panels/AbstractPanel.cs
+++ b/src/Entities/Panels/AbstractPanel.cs
@@ -65,29 +65,6 @@ public abstract class AbstractPanel : Entity
 
     protected virtual void OnAttach(Platform platform)
     {
-        platform.OnDashCollide = DelegateHelper.ApplyDashCollisionHook(platform.OnDashCollide, OnDashCollide);
-    }
-
-    /// <summary>
-    /// Does not check dash direction or direct collision with the Panel.
-    /// Use CheckDashCollision as needed.
-    /// </summary>
-    protected virtual DashCollisionResults OnDashCollide(DashCollision orig, Player player, Vector2 dir)
-    {
-        return orig(player, dir);
-    }
-
-    protected bool CheckDashCollision(Player player, Vector2 dir)
-    {
-        switch (Orientation)
-        {
-            case Directions.Up when dir.Y > 0:
-            case Directions.Down when dir.Y < 0:
-            case Directions.Left when dir.X > 0:
-            case Directions.Right when dir.X < 0:
-                return player.CollideCheck(this, player.Position + dir);
-        }
-        return false;
     }
 
     // Make sure at least one side aligns, and the rest are contained within the solid
@@ -143,14 +120,6 @@ public abstract class AbstractPanel : Entity
         }
 
         base.Update();
-    }
-
-    public override void Removed(Scene scene)
-    {
-        if (staticMover.Platform is not null && (staticMover.Platform.TagCheck(Tags.Global) || staticMover.Platform.TagCheck(Tags.Persistent)))
-            DelegateHelper.RemoveDashCollisionHook(staticMover.Platform.OnDashCollide, OnDashCollide);
-
-        base.Removed(scene);
     }
 
     #region Hooks

--- a/src/Entities/Panels/DashCollisionPanel.cs
+++ b/src/Entities/Panels/DashCollisionPanel.cs
@@ -1,7 +1,7 @@
 ﻿namespace Celeste.Mod.CommunalHelper.Entities;
 
 [CustomEntity("CommunalHelper/DashCollisionPanel")]
-public class DashCollisionPanel : AbstractPanel
+public class DashCollisionPanel : AbstractDashCollisionPanel
 {
     public DashCollisionResults dashCollisionOverride;
     public bool overrideCollision;


### PR DESCRIPTION
This moves all dash collision related logic of the AbstractPanel class into the new AbstractDashCollisionPanel class, which the panels who need that logic (DashCollisionPanel, DreamTunnelEntry) inherit instead.

Rationale: In the previous version, the dash collision logic of AbstractPanel ran for all panels, even those who do not need it. The logic seems like it should not affect anything, but it does: When the OnDashCollision hook gets applied through the call to DelegateHelper, the original method (OnDashCollision) gets replaced with a default method returning NormalCollision if it was previously null. Having a NormalCollision or having no OnDashCollision method actually behaves differently - mainly in the case of red bubbles, which do not exit if there is a NormalCollision and do exit if there is no collision. So, the OnDashCollision method should only be hooked/overridden if the panel does in fact want to modify OnDashCollision. In that case, behaviour change like for the red bubbles is to be expected.