### PR TITLE
Add Elytra Note Ring customization

### DIFF
--- a/Loenn/entities/elytra/elytra_note_ring.lua
+++ b/Loenn/entities/elytra/elytra_note_ring.lua
@@ -1,6 +1,7 @@
 local drawableLine = require "structs.drawable_line"
 local drawableSprite = require "structs.drawable_sprite"
 local utils = require "utils"
+local communalHelper = require("mods").requireFromPlugin("libraries.communal_helper")
 
 local elytraNoteRing = {}
 
@@ -53,6 +54,13 @@ elytraNoteRing.fieldInformation = {
             ["35 = B6"] = 35,
             ["36 = C7"] = 36,
         }
+    },
+    color = {
+        fieldType = "color",
+    },
+    volume = {
+        minimumValue = 0,
+        maximumValue = 5, --don't blow people's ears off, 500% volume is more than enough
     }
 }
 
@@ -61,14 +69,19 @@ elytraNoteRing.placements = {
         name = "elytra_note_ring",
         data = {
             semitone = 12,
+            volume = 1,
+            eventName = "event:/CommunalHelperEvents/game/elytra/rings/note",
+            parameters = "",
+            color = "ffffff",
         }
     }
 }
 
 local dotTexture = "objects/CommunalHelper/elytraRing/dot"
-local ringColor = {0.8, 0.8, 0.8, 1.0}
 
 function elytraNoteRing.sprite(room, entity)
+    local ringColor = communalHelper.hexToColor(entity.color, "ffffff")
+
     local sprites = {}
 
     local x, y = entity.x or 0, entity.y or 0

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -836,6 +836,10 @@ entities.CommunalHelper/ElytraStopRing.attributes.description.refill=Whether the
 # Elytra Note Ring
 entities.CommunalHelper/ElytraNoteRing.placements.name.elytra_note_ring=Elytra Note Ring
 entities.CommunalHelper/ElytraNoteRing.attributes.description.semitone=The note to play when this ring is crossed. You can input your own integer value if you want to go above or below the range available in the dropdown options.\n0 is C4, input negative integer to go below.
+entities.CommunalHelper/ElytraNoteRing.attributes.description.volume=How loud the played note is.
+entities.CommunalHelper/ElytraNoteRing.attributes.description.parameters=A semicolon-separated parameter list to be passed to the audio event when played.\nEach entry should be formatted as "<paramName>=<paramValue>", without spaces.\ne.g. "param_a=1.5;param_b=0;param_c=0.5"
+entities.CommunalHelper/ElytraNoteRing.attributes.description.eventName=The FMOD audio event the ring plays when crossed.
+entities.CommunalHelper/ElytraNoteRing.attributes.description.color=The ring's color, as RRGGBB.
 
 # Badeline Boost (Keep Holdables)
 entities.CommunalHelper/BadelineBoostKeepHoldables.placements.name.boost=Badeline Boost (Keep Holdables)

--- a/src/Entities/Elytra/ElytraNoteRing.cs
+++ b/src/Entities/Elytra/ElytraNoteRing.cs
@@ -40,11 +40,12 @@ public class ElytraNoteRing : ElytraRing
 
         if (@params is not null && @params.Length > 0)
         {
-            parameters = @params.Split(";").Select(s =>
-            {
-                string[] parts = s.Split('=');
-                return new Param() { name = parts[0], value = float.TryParse(parts[1], out float val) ? val : 0f };
-            }).ToArray();
+            parameters = @params.Split(";")
+                .Select(s => s.Split("="))
+                .Where(parts => parts.Length == 2)
+                .Select(parts => new Param() { name = parts[0], value = float.TryParse(parts[1], out float val) ? val : 0f })
+                .Where(param => !string.IsNullOrWhiteSpace(param.name))
+                .ToArray();
         }
 
         parameters ??= [];

--- a/src/Entities/Elytra/ElytraNoteRing.cs
+++ b/src/Entities/Elytra/ElytraNoteRing.cs
@@ -1,30 +1,69 @@
-﻿namespace Celeste.Mod.CommunalHelper.Entities;
+﻿using FMOD.Studio;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Celeste.Mod.CommunalHelper.Entities;
 
 [CustomEntity("CommunalHelper/ElytraNoteRing")]
 public class ElytraNoteRing : ElytraRing
 {
+    private struct Param
+    {
+        internal string name;
+        internal float value;
+    }
     public override bool PreserveTraversalOrder => false;
 
     private readonly float pitch;
+    private readonly float volume;
+    private readonly Param[] parameters;
+    private readonly string eventName;
 
     public ElytraNoteRing(EntityData data, Vector2 offset)
         : this(
             data.Position + offset,
             data.Nodes[0] + offset,
-            data.Int("semitone", 12)
+            data.Int("semitone", 12),
+            data.Float("volume", 1f),
+            data.String("parameters", null),
+            data.String("eventName", CustomSFX.game_elytra_rings_note),
+            data.HexColor("color", Color.White)
         )
     { }
 
-    public ElytraNoteRing(Vector2 a, Vector2 b, int semitone)
-        : base(a, b, Color.White)
+    public ElytraNoteRing(Vector2 a, Vector2 b, int semitone, float volume, string @params, string eventName, Color color)
+        : base(a, b, color)
     {
         pitch = (float) Math.Pow(2, semitone / 12.0f);
+
+        this.volume = volume;
+
+        if (@params is not null && @params.Length > 0)
+        {
+            parameters = @params.Split(";").Select(s =>
+            {
+                string[] parts = s.Split('=');
+                return new Param() { name = parts[0], value = float.TryParse(parts[1], out float val) ? val : 0f };
+            }).ToArray();
+        }
+
+        parameters ??= [];
+
+        this.eventName = eventName;
     }
 
     public override void OnPlayerTraversal(Player player, int sign, bool shake = true)
     {
         base.OnPlayerTraversal(player, sign, false);
-        Audio.Play(CustomSFX.game_elytra_rings_note, player.Center)
-             .setPitch(pitch / 2.0f);
+
+        EventInstance instance = Audio.Play(eventName, player.Center);
+
+        instance.setPitch(pitch / 2f);
+        instance.setVolume(volume);
+
+        foreach(var param in parameters)
+        {
+            instance.setParameterValue(param.name, param.value);
+        }
     }
 }


### PR DESCRIPTION
Adds custom events, note volume, ring color, and support for passing audio parameters.

Plugin untested in Lönn \**wink wink nudge nudge*\*, but probably works.

Unless I fucked up really bad, all previous placements should remain intact.

https://github.com/user-attachments/assets/8aaa2baa-430e-4983-b636-fb8a7c1f70c6

