### PR TITLE
Fix Chained Falling Block static mover shake time + add option to render the chain behind

### DIFF
--- a/Loenn/entities/chains/chained_falling_block.lua
+++ b/Loenn/entities/chains/chained_falling_block.lua
@@ -4,22 +4,6 @@ local fakeTilesHelper = require("helpers.fake_tiles")
 local chainedFallingBlock = {}
 
 chainedFallingBlock.name = "CommunalHelper/ChainedFallingBlock"
-function chainedFallingBlock.fieldInformation()
-    return {
-        tiletype = {
-            options = fakeTilesHelper.getTilesOptions(),
-            editable = false
-        },
-        fallDistance = {
-            minimumValue = 0,
-            fieldType = "integer"
-        }
-    }
-end
-
-function chainedFallingBlock.depth(room, entity)
-    return entity.behind and 5000 or -9000
-end
 
 chainedFallingBlock.placements = {
     name = "chained_falling_block",
@@ -35,9 +19,31 @@ chainedFallingBlock.placements = {
         indicator = false,
         indicatorAtStart = false,
         chainTexture = "objects/CommunalHelper/chains/chain",
+        chainBehind = false,
         staticMoverForceShake = true
     }
 }
+
+chainedFallingBlock.fieldOrder = {
+    "x", "y", "width", "height",
+    "chainTexture", "fallDistance",
+    "tiletype", "behind", "climbFall",
+    "centeredChain", "chainOutline", "chainBehind", "staticMoverForceShake",
+    "indicator", "indicatorAtStart"
+}
+
+function chainedFallingBlock.fieldInformation()
+    return {
+        tiletype = {
+            options = fakeTilesHelper.getTilesOptions(),
+            editable = false
+        },
+        fallDistance = {
+            minimumValue = 0,
+            fieldType = "integer"
+        }
+    }
+end
 
 local fakeTilesSpriteFunction = fakeTilesHelper.getEntitySpriteFunction("tiletype", false)
 
@@ -53,6 +59,10 @@ function chainedFallingBlock.sprite(room, entity)
     table.insert(sprites, rect)
 
     return sprites
+end
+
+function chainedFallingBlock.depth(room, entity)
+    return entity.behind and 5000 or -9000
 end
 
 return chainedFallingBlock

--- a/Loenn/entities/chains/chained_falling_block.lua
+++ b/Loenn/entities/chains/chained_falling_block.lua
@@ -18,7 +18,7 @@ function chainedFallingBlock.fieldInformation()
 end
 
 function chainedFallingBlock.depth(room, entity)
-    return entity.behind and 5000 or 0
+    return entity.behind and 5000 or -9000
 end
 
 chainedFallingBlock.placements = {
@@ -34,7 +34,8 @@ chainedFallingBlock.placements = {
         chainOutline = true,
         indicator = false,
         indicatorAtStart = false,
-        chainTexture = "objects/CommunalHelper/chains/chain"
+        chainTexture = "objects/CommunalHelper/chains/chain",
+        staticMoverForceShake = true
     }
 }
 

--- a/Loenn/entities/dream_blocks/dream_falling_block.lua
+++ b/Loenn/entities/dream_blocks/dream_falling_block.lua
@@ -67,6 +67,7 @@ dreamFallingBlock.placements = {
             indicatorAtStart = false,
             chained = true,
             chainTexture = "objects/CommunalHelper/chains/chain",
+            chainBelow = false,
             legacyLandingBehavior = false
         }
     }

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -367,13 +367,14 @@ entities.CommunalHelper/DreamFallingBlock.attributes.description.oneUse=Whether 
 entities.CommunalHelper/DreamFallingBlock.attributes.description.refillCount=Number of dashes the Dream Falling Block should refill (-1 for default).
 entities.CommunalHelper/DreamFallingBlock.attributes.description.below=Determines whether the Dream Falling Block should render below foreground tiles.
 entities.CommunalHelper/DreamFallingBlock.attributes.description.noCollide=Whether the Dream Falling Block should go through solids.
-entities.CommunalHelper/DreamFallingBlock.attributes.description.fallDistance=The maximum distance this block can fall before the chains tightens and stops the block (in other words, the chain length).
+entities.CommunalHelper/DreamFallingBlock.attributes.description.fallDistance=The maximum distance (in pixels) this block can fall before the chain tightens and stops the block (in other words, the chain length).
 entities.CommunalHelper/DreamFallingBlock.attributes.description.centeredChain=Renders only one chain at the horizontal center of this block.
 entities.CommunalHelper/DreamFallingBlock.attributes.description.chainOutline=Whether the chain of this block should have a black outline.
 entities.CommunalHelper/DreamFallingBlock.attributes.description.indicator=Renders below the block a dark transparent rectangle of the path it is going to take when it starts to fall. This indicator might not be visible against dark backgrounds.
 entities.CommunalHelper/DreamFallingBlock.attributes.description.indicatorAtStart=Makes the indicator (if enabled) visible before the block is triggered.
 entities.CommunalHelper/DreamFallingBlock.attributes.description.quickDestroy=Makes this Dream Falling Block shatter a little faster.
 entities.CommunalHelper/DreamFallingBlock.attributes.description.chainTexture=The texture for this Dream Falling Block's chain (if chained).
+entities.CommunalHelper/DreamFallingBlock.attributes.description.chainBelow=Determines if the chain should appear farther behind in the scene.\nDoes nothing if 'Below' is also enabled.
 entities.CommunalHelper/DreamFallingBlock.attributes.description.legacyLandingBehavior=Whether the Dream Falling Block should not emit particles or make sound when landing, and immediately resume falling if the platform it lands on is removed.
 
 # Dream Switch Gate
@@ -556,14 +557,15 @@ entities.CommunalHelper/ChainedKevin.attributes.description.chainTexture=The tex
 # Chained Falling Block
 entities.CommunalHelper/ChainedFallingBlock.placements.name.chained_falling_block=Falling Block (Chained)
 entities.CommunalHelper/ChainedFallingBlock.attributes.description.tiletype=Changes the visual appearance of this block.
-entities.CommunalHelper/ChainedFallingBlock.attributes.description.climbFall=Whether the block should start falling when the player is climbing it.
-entities.CommunalHelper/ChainedFallingBlock.attributes.description.behind=Whether this entity should appear farther behind in the scene or not.
-entities.CommunalHelper/ChainedFallingBlock.attributes.description.fallDistance=The maximum distance this block can fall before the chains tightens and stops the block (in other words, the chain length).
+entities.CommunalHelper/ChainedFallingBlock.attributes.description.climbFall=Whether this block should start falling when the player is climbing it.
+entities.CommunalHelper/ChainedFallingBlock.attributes.description.behind=Whether this block and its chain should both appear farther behind in the scene.
+entities.CommunalHelper/ChainedFallingBlock.attributes.description.fallDistance=The maximum distance (in pixels) this block can fall before the chain tightens and stops the block (in other words, the chain length).
 entities.CommunalHelper/ChainedFallingBlock.attributes.description.centeredChain=Renders only one chain at the horizontal center of this block.
 entities.CommunalHelper/ChainedFallingBlock.attributes.description.chainOutline=Whether the chain of this block should have a black outline.
 entities.CommunalHelper/ChainedFallingBlock.attributes.description.indicator=Renders below the block a dark transparent rectangle of the path it is going to take when it starts to fall. This indicator might not be visible against dark backgrounds.
 entities.CommunalHelper/ChainedFallingBlock.attributes.description.indicatorAtStart=Makes the indicator (if enabled) visible before the block is triggered.
 entities.CommunalHelper/ChainedFallingBlock.attributes.description.chainTexture=The texture for this Falling Block's chain.
+entities.CommunalHelper/ChainedFallingBlock.attributes.description.chainBehind=Whether the chain should appear farther behind in the scene.\nDoes nothing if 'Behind' is also enabled.
 entities.CommunalHelper/ChainedFallingBlock.attributes.description.staticMoverForceShake=Whether this block should shake for longer when triggered by an attached static mover (e.g. a spring).
 
 # Chain

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -564,6 +564,7 @@ entities.CommunalHelper/ChainedFallingBlock.attributes.description.chainOutline=
 entities.CommunalHelper/ChainedFallingBlock.attributes.description.indicator=Renders below the block a dark transparent rectangle of the path it is going to take when it starts to fall. This indicator might not be visible against dark backgrounds.
 entities.CommunalHelper/ChainedFallingBlock.attributes.description.indicatorAtStart=Makes the indicator (if enabled) visible before the block is triggered.
 entities.CommunalHelper/ChainedFallingBlock.attributes.description.chainTexture=The texture for this Falling Block's chain.
+entities.CommunalHelper/ChainedFallingBlock.attributes.description.staticMoverForceShake=Whether this block should shake for longer when triggered by an attached static mover (e.g. a spring).
 
 # Chain
 entities.CommunalHelper/Chain.placements.name.chain=Chain

--- a/src/Entities/Chains/ChainedDreamFallingBlock.cs
+++ b/src/Entities/Chains/ChainedDreamFallingBlock.cs
@@ -10,11 +10,17 @@ public class ChainedDreamFallingBlock : DreamFallingBlock
         public DreamFallingBlockChainRenderer(ChainedDreamFallingBlock dreamFallingBlock)
         {
             block = dreamFallingBlock;
-            Depth = Depths.FGTerrain + 1;
+            Depth = dreamFallingBlock.chainBelow ? Depths.SolidsBelow + 1 : Depths.FGTerrain + 1;
         }
 
         public override void Render()
         {
+            if ((block.HasStartedFalling || block.indicatorAtStart) && block.indicator && !block.heldByChain)
+            {
+                float toY = block.startY + ((block.chainStopY + block.Height - block.startY) * Ease.ExpoOut(block.pathLerp));
+                Draw.Rect(block.X, block.Y, block.Width, toY - block.Y, Color.Black * 0.75f);
+            }
+
             if (block.centeredChain)
                 Chain.DrawChainLine(new Vector2(block.X + (block.Width / 2f), block.startY), new Vector2(block.X + (block.Width / 2f), block.Y), block.chainTexture, block.chainOutline);
             else
@@ -27,10 +33,12 @@ public class ChainedDreamFallingBlock : DreamFallingBlock
 
     private DreamFallingBlockChainRenderer chainRenderer;
 
-    private readonly MTexture chainTexture;
-
     private bool heldByChain;
     protected override bool Held => heldByChain || base.Held;
+
+    private readonly MTexture chainTexture;
+
+    private readonly bool chainBelow;
 
     private readonly float chainStopY, startY;
     private readonly bool centeredChain;
@@ -57,6 +65,8 @@ public class ChainedDreamFallingBlock : DreamFallingBlock
         string chainTexturePath = data.Attr("chainTexture", Chain.DEFAULT_CHAIN_PATH);
         chainTexture = GFX.Game.GetOrDefault(chainTexturePath, Chain.DefaultChain);
 
+        chainBelow = data.Bool("below") || data.Bool("chainBelow");
+
         Add(rattle = new SoundSource()
         {
             Position = Vector2.UnitX * Width / 2f
@@ -81,17 +91,6 @@ public class ChainedDreamFallingBlock : DreamFallingBlock
 
         if (HasStartedFalling && indicator && !indicatorAtStart)
             pathLerp = Calc.Approach(pathLerp, 1f, Engine.DeltaTime * 2f);
-    }
-
-    public override void Render()
-    {
-        if ((HasStartedFalling || indicatorAtStart) && indicator && !heldByChain)
-        {
-            float toY = startY + ((chainStopY + Height - startY) * Ease.ExpoOut(pathLerp));
-            Draw.Rect(X, Y, Width, toY - Y, Color.Black * 0.75f);
-        }
-
-        base.Render();
     }
 
     protected override bool ShouldStopFalling()

--- a/src/Entities/Chains/ChainedFallingBlock.cs
+++ b/src/Entities/Chains/ChainedFallingBlock.cs
@@ -5,6 +5,36 @@ namespace Celeste.Mod.CommunalHelper.Entities;
 [CustomEntity("CommunalHelper/ChainedFallingBlock")]
 public class ChainedFallingBlock : Solid
 {
+    private class FallingBlockChainRenderer : Entity
+    {
+        private readonly ChainedFallingBlock block;
+
+        public FallingBlockChainRenderer(ChainedFallingBlock chainedFallingBlock)
+        {
+            block = chainedFallingBlock;
+            Depth = chainedFallingBlock.chainBehind ? Depths.SolidsBelow + 1 : Depths.Solids + 1;
+        }
+
+        public override void Render()
+        {
+            if ((block.hasStartedFalling || block.indicatorAtStart) && block.indicator && !block.held)
+            {
+                float toY = block.startY + ((block.chainStopY + block.Height - block.startY) * Ease.ExpoOut(block.pathLerp));
+                Draw.Rect(block.X, block.Y, block.Width, toY - block.Y, Color.Black * 0.75f);
+            }
+
+            if (block.centeredChain)
+                Chain.DrawChainLine(new Vector2(block.X + (block.Width / 2f), block.startY), new Vector2(block.X + (block.Width / 2f), block.Y), block.chainTexture, block.chainOutline);
+            else
+            {
+                Chain.DrawChainLine(new Vector2(block.X + 3, block.startY), new Vector2(block.X + 3, block.Y), block.chainTexture, block.chainOutline);
+                Chain.DrawChainLine(new Vector2(block.X + block.Width - 4, block.startY), new Vector2(block.X + block.Width - 4, block.Y), block.chainTexture, block.chainOutline);
+            }
+        }
+    }
+
+    private FallingBlockChainRenderer chainRenderer;
+
     private readonly char tileType;
     private readonly TileGrid tiles;
 
@@ -16,6 +46,8 @@ public class ChainedFallingBlock : Solid
     private bool triggeredByStaticMover;
 
     private readonly MTexture chainTexture;
+
+    private readonly bool chainBehind;
 
     private readonly float chainStopY, startY;
     private readonly bool centeredChain;
@@ -31,13 +63,13 @@ public class ChainedFallingBlock : Solid
             data.Char("tiletype", '3'), data.Bool("climbFall", true), data.Bool("behind"),
             data.Int("fallDistance"), data.Bool("centeredChain"), data.Bool("chainOutline", true),
             data.Bool("indicator"), data.Bool("indicatorAtStart"), data.Attr("chainTexture", Chain.DEFAULT_CHAIN_PATH),
-            data.Bool("staticMoverForceShake", false)) { }
+            data.Bool("chainBehind", false), data.Bool("staticMoverForceShake", false)) { }
 
     public ChainedFallingBlock(Vector2 position, int width, int height,
         char tileType, bool climbFall, bool behind,
         int maxFallDistance, bool centeredChain, bool chainOutline,
         bool indicator, bool indicatorAtStart, string chainTexturePath = Chain.DEFAULT_CHAIN_PATH,
-        bool staticMoverForceShake = false)
+        bool chainBehind = false, bool staticMoverForceShake = false)
         : base(position, width, height, safe: false)
     {
         this.climbFall = climbFall;
@@ -68,8 +100,22 @@ public class ChainedFallingBlock : Solid
         });
 
         SurfaceSoundIndex = SurfaceIndex.TileToIndex[tileType];
+
         if (behind)
             Depth = Depths.SolidsBelow;
+        this.chainBehind = behind || chainBehind;
+    }
+
+    public override void Added(Scene scene)
+    {
+        base.Added(scene);
+        scene.Add(chainRenderer = new FallingBlockChainRenderer(this));
+    }
+
+    public override void Removed(Scene scene)
+    {
+        base.Removed(scene);
+        chainRenderer.RemoveSelf();
     }
 
     public override void OnShake(Vector2 amount)
@@ -231,24 +277,5 @@ public class ChainedFallingBlock : Solid
 
         if (hasStartedFalling && indicator && !indicatorAtStart)
             pathLerp = Calc.Approach(pathLerp, 1f, Engine.DeltaTime * 2f);
-    }
-
-    public override void Render()
-    {
-        if ((hasStartedFalling || indicatorAtStart) && indicator && !held)
-        {
-            float toY = startY + ((chainStopY + Height - startY) * Ease.ExpoOut(pathLerp));
-            Draw.Rect(X, Y, Width, toY - Y, Color.Black * 0.75f);
-        }
-
-        if (centeredChain)
-            Chain.DrawChainLine(new Vector2(X + (Width / 2f), startY), new Vector2(X + (Width / 2f), Y), chainTexture, chainOutline);
-        else
-        {
-            Chain.DrawChainLine(new Vector2(X + 3, startY), new Vector2(X + 3, Y), chainTexture, chainOutline);
-            Chain.DrawChainLine(new Vector2(X + Width - 4, startY), new Vector2(X + Width - 4, Y), chainTexture, chainOutline);
-        }
-
-        base.Render();
     }
 }

--- a/src/Entities/Chains/ChainedFallingBlock.cs
+++ b/src/Entities/Chains/ChainedFallingBlock.cs
@@ -12,6 +12,9 @@ public class ChainedFallingBlock : Solid
     private readonly bool climbFall;
     private bool held;
 
+    private readonly bool staticMoverForceShake;
+    private bool triggeredByStaticMover;
+
     private readonly MTexture chainTexture;
 
     private readonly float chainStopY, startY;
@@ -24,9 +27,17 @@ public class ChainedFallingBlock : Solid
     private readonly SoundSource rattle;
 
     public ChainedFallingBlock(EntityData data, Vector2 offset)
-        : this(data.Position + offset, data.Width, data.Height, data.Char("tiletype", '3'), data.Bool("climbFall", true), data.Bool("behind"), data.Int("fallDistance"), data.Bool("centeredChain"), data.Bool("chainOutline", true), data.Bool("indicator"), data.Bool("indicatorAtStart"), data.Attr("chainTexture", Chain.DEFAULT_CHAIN_PATH)) { }
+        : this(data.Position + offset, data.Width, data.Height,
+            data.Char("tiletype", '3'), data.Bool("climbFall", true), data.Bool("behind"),
+            data.Int("fallDistance"), data.Bool("centeredChain"), data.Bool("chainOutline", true),
+            data.Bool("indicator"), data.Bool("indicatorAtStart"), data.Attr("chainTexture", Chain.DEFAULT_CHAIN_PATH),
+            data.Bool("staticMoverForceShake", false)) { }
 
-    public ChainedFallingBlock(Vector2 position, int width, int height, char tileType, bool climbFall, bool behind, int maxFallDistance, bool centeredChain, bool chainOutline, bool indicator, bool indicatorAtStart, string chainTexturePath = Chain.DEFAULT_CHAIN_PATH)
+    public ChainedFallingBlock(Vector2 position, int width, int height,
+        char tileType, bool climbFall, bool behind,
+        int maxFallDistance, bool centeredChain, bool chainOutline,
+        bool indicator, bool indicatorAtStart, string chainTexturePath = Chain.DEFAULT_CHAIN_PATH,
+        bool staticMoverForceShake = false)
         : base(position, width, height, safe: false)
     {
         this.climbFall = climbFall;
@@ -41,6 +52,8 @@ public class ChainedFallingBlock : Solid
         pathLerp = Util.ToInt(indicatorAtStart);
 
         chainTexture = GFX.Game.GetOrDefault(chainTexturePath, Chain.DefaultChain);
+
+        this.staticMoverForceShake = staticMoverForceShake;
 
         Calc.PushRandom(Calc.Random.Next());
         Add(tiles = GFX.FGAutotiler.GenerateBox(tileType, width / 8, height / 8).TileGrid);
@@ -68,6 +81,7 @@ public class ChainedFallingBlock : Solid
     public override void OnStaticMoverTrigger(StaticMover sm)
     {
         hasStartedFalling = true;
+        triggeredByStaticMover = true;
     }
 
     private bool PlayerFallCheck()
@@ -77,6 +91,9 @@ public class ChainedFallingBlock : Solid
 
     private bool PlayerWaitCheck()
     {
+        if (staticMoverForceShake && triggeredByStaticMover)
+            return true;
+
         if (PlayerFallCheck())
             return true;
 


### PR DESCRIPTION
Adds an option to fix Chained Falling Blocks not shaking for their full shake time when activated by attached static movers (like other falling blocks do), and an option to make just the chain render farther behind in the scene.