### PR TITLE
Clean up ModInterop and fix jank with EeveeHelper and `ConnectedSolid`s

### DIFF
--- a/src/CommunalHelperModule.cs
+++ b/src/CommunalHelperModule.cs
@@ -122,15 +122,6 @@ public class CommunalHelperModule : EverestModule
         
         Shapeshifter.Load();
 
-        #region Imports
-
-        typeof(Imports.CavernHelper).ModInterop();
-        typeof(Imports.GravityHelper).ModInterop();
-        typeof(Imports.ReverseHelper).ModInterop();
-        typeof(Imports.LylyraHelper).ModInterop();
-
-        #endregion
-
         ModExports.Initialize();
     }
 
@@ -241,11 +232,6 @@ public class CommunalHelperModule : EverestModule
             LaserEmitter.Load();
         }
 
-        if (Everest.Loader.DependencyLoaded(new EverestModuleMetadata { Name = "LylyraHelper", Version = new Version("1.3.12") }))
-        {
-            LylyraHelper.Load();
-        }
-
         // Register CustomCassetteBlock types
         CustomCassetteBlock.Initialize();
 
@@ -256,20 +242,18 @@ public class CommunalHelperModule : EverestModule
 
         BetaCube.Initialize();
 
-        Imports.ReverseHelper.RegisterDreamBlockLike?.Invoke(typeof(DreamTunnelEntry),
-            e => (e as DreamTunnelEntry).ActivateNoRoutine(),
-            e => (e as DreamTunnelEntry).DeactivateNoRoutine());
-        /*
-         * Some Communal Helper mechanics don't work well with Gravity Helper.
-         * To fix this, Gravity Helper has implemented hooks that patch some of Communal Helper's methods.
-         * From now on though, we'll be supporting Gravity Helper with the methods it exports, and fix quirks ourselves.
-         * So, we need to call RegisterModSupportBlacklist, which will discard hooks implemented in Gravity Helper.
-         */
-        Imports.GravityHelper.RegisterModSupportBlacklist?.Invoke("CommunalHelper");
-
-        Imports.SpeedrunTool.Initialize();
-
         AeroBlockCharged.SpirialisHelperLoaded = Everest.Loader.DependencyLoaded(new EverestModuleMetadata() { Name = "SpirialisHelper", Version = new Version(1, 0, 8) });
+        
+        #region Imports
+        
+        CavernHelper.Initialize();
+        GravityHelper.Initialize();
+        ReverseHelper.Initialize();
+        LylyraHelper.Initialize();
+        SpeedrunTool.Initialize();
+        EeveeHelper.Initialize();
+
+        #endregion
     }
 
     public override void LoadContent(bool firstLoad)

--- a/src/Entities/DreamBlocks/ConnectedDreamBlock.cs
+++ b/src/Entities/DreamBlocks/ConnectedDreamBlock.cs
@@ -69,7 +69,11 @@ public class ConnectedDreamBlock : CustomDreamBlock
 
     private List<SpaceJamEdge> GroupEdges;
     private List<SpaceJamCorner> GroupCorners;
-    private Rectangle GroupRect;
+    private Rectangle GroupRect => new(
+        (int) GroupBoundsMin.X,
+        (int) GroupBoundsMin.Y,
+        (int) (GroupBoundsMax.X - GroupBoundsMin.X),
+        (int) (GroupBoundsMax.Y - GroupBoundsMin.Y));
 
     private enum Edges
     {
@@ -118,11 +122,6 @@ public class ConnectedDreamBlock : CustomDreamBlock
             AddToGroupAndFindChildren(this);
             SetupCustomParticles(0, 0); // Parameters are ignored
 
-            GroupRect = new Rectangle(
-                (int) GroupBoundsMin.X,
-                (int) GroupBoundsMin.Y,
-                (int) (GroupBoundsMax.X - GroupBoundsMin.X),
-                (int) (GroupBoundsMax.Y - GroupBoundsMin.Y));
             GroupOffset = new Vector2(GroupBoundsMin.X, GroupBoundsMin.Y) - Position;
 
             float groupW = GroupBoundsMax.X - GroupBoundsMin.X;
@@ -743,11 +742,6 @@ public class ConnectedDreamBlock : CustomDreamBlock
             Level level = SceneAs<Level>();
             level.Shake(.65f);
             Vector2 camera = level.Camera.Position;
-            Rectangle GroupRect = new(
-                (int) GroupBoundsMin.X,
-                (int) GroupBoundsMin.Y,
-                (int) (GroupBoundsMax.X - GroupBoundsMin.X),
-                (int) (GroupBoundsMax.Y - GroupBoundsMin.Y));
 
             Vector2 centre = new(GroupRect.Center.X, GroupRect.Center.Y);
             for (int i = 0; i < particles.Length; i++)

--- a/src/Imports/CavernHelper.cs
+++ b/src/Imports/CavernHelper.cs
@@ -9,4 +9,9 @@ namespace Celeste.Mod.CommunalHelper.Imports;
 public static class CavernHelper
 {
     public static Func<Action<Vector2>, Collider, Component> GetCrystalBombExplosionCollider;
+
+    public static void Initialize()
+    {
+        typeof(CavernHelper).ModInterop();
+    }
 }

--- a/src/Imports/EeveeHelper.cs
+++ b/src/Imports/EeveeHelper.cs
@@ -1,0 +1,19 @@
+using Celeste.Mod.CommunalHelper.Entities;
+using MonoMod.ModInterop;
+using System.Collections.Generic;
+
+namespace Celeste.Mod.CommunalHelper.Imports;
+
+[ModImportName("EeveeHelper")]
+public static class EeveeHelper
+{
+    public static Action<Type, HashSet<string>> RegisterIgnoredAnchors;
+
+    public static void Initialize()
+    {
+        typeof(EeveeHelper).ModInterop();
+
+        RegisterIgnoredAnchors?.Invoke(typeof(ConnectedSolid), ["GroupBoundsMin", "GroupBoundsMax", "GroupOffset", "GroupCenter"]);
+        RegisterIgnoredAnchors?.Invoke(typeof(ConnectedDreamBlock), ["GroupBoundsMin", "GroupBoundsMax", "GroupOffset"]);
+    }
+}

--- a/src/Imports/EeveeHelper.cs
+++ b/src/Imports/EeveeHelper.cs
@@ -8,14 +8,14 @@ namespace Celeste.Mod.CommunalHelper.Imports;
 [ModImportName("EeveeHelper")]
 public static class EeveeHelper
 {
+    public static Action<Type, bool, HashSet<string>> RegisterWhitelistedAnchors;
     public static Action<Type, bool, HashSet<string>> RegisterBlacklistedAnchors;
 
     public static void Initialize()
     {
         typeof(EeveeHelper).ModInterop();
 
-        string[] defaultBlacklistedAnchors = ["Position", "ExactPosition", "TopLeft", "TopCenter", "TopRight", "Center", "CenterLeft", "CenterRight", "BottomLeft", "BottomCenter", "BottomRight"];
-        RegisterBlacklistedAnchors?.Invoke(typeof(ConnectedSolid), true, defaultBlacklistedAnchors.Union(["GroupBoundsMin", "GroupBoundsMax", "GroupOffset", "GroupCenter"]).ToHashSet());
-        RegisterBlacklistedAnchors?.Invoke(typeof(ConnectedDreamBlock), false, defaultBlacklistedAnchors.Union(["GroupBoundsMin", "GroupBoundsMax", "GroupOffset"]).ToHashSet());
+        RegisterWhitelistedAnchors?.Invoke(typeof(ConnectedSolid), true, []);
+        RegisterWhitelistedAnchors?.Invoke(typeof(ConnectedDreamBlock), true, []);
     }
 }

--- a/src/Imports/EeveeHelper.cs
+++ b/src/Imports/EeveeHelper.cs
@@ -1,19 +1,21 @@
 using Celeste.Mod.CommunalHelper.Entities;
 using MonoMod.ModInterop;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Celeste.Mod.CommunalHelper.Imports;
 
 [ModImportName("EeveeHelper")]
 public static class EeveeHelper
 {
-    public static Action<Type, HashSet<string>> RegisterIgnoredAnchors;
+    public static Action<Type, bool, HashSet<string>> RegisterBlacklistedAnchors;
 
     public static void Initialize()
     {
         typeof(EeveeHelper).ModInterop();
 
-        RegisterIgnoredAnchors?.Invoke(typeof(ConnectedSolid), ["GroupBoundsMin", "GroupBoundsMax", "GroupOffset", "GroupCenter"]);
-        RegisterIgnoredAnchors?.Invoke(typeof(ConnectedDreamBlock), ["GroupBoundsMin", "GroupBoundsMax", "GroupOffset"]);
+        string[] defaultBlacklistedAnchors = ["Position", "ExactPosition", "TopLeft", "TopCenter", "TopRight", "Center", "CenterLeft", "CenterRight", "BottomLeft", "BottomCenter", "BottomRight"];
+        RegisterBlacklistedAnchors?.Invoke(typeof(ConnectedSolid), true, defaultBlacklistedAnchors.Union(["GroupBoundsMin", "GroupBoundsMax", "GroupOffset", "GroupCenter"]).ToHashSet());
+        RegisterBlacklistedAnchors?.Invoke(typeof(ConnectedDreamBlock), false, defaultBlacklistedAnchors.Union(["GroupBoundsMin", "GroupBoundsMax", "GroupOffset"]).ToHashSet());
     }
 }

--- a/src/Imports/GravityHelper.cs
+++ b/src/Imports/GravityHelper.cs
@@ -39,6 +39,19 @@ public static class GravityHelper
     public static Action EndOverride;
     public static Action<Action> ExecuteOverride;
     public static Func<IDisposable> WithOverride;
+
+    public static void Initialize()
+    {
+        typeof(GravityHelper).ModInterop();
+        
+        /*
+         * Some Communal Helper mechanics don't work well with Gravity Helper.
+         * To fix this, Gravity Helper has implemented hooks that patch some of Communal Helper's methods.
+         * From now on though, we'll be supporting Gravity Helper with the methods it exports, and fix quirks ourselves.
+         * So, we need to call RegisterModSupportBlacklist, which will discard hooks implemented in Gravity Helper.
+         */
+        RegisterModSupportBlacklist?.Invoke("CommunalHelper");
+    }
 }
 
 public enum GravityType

--- a/src/Imports/LylyraHelper.cs
+++ b/src/Imports/LylyraHelper.cs
@@ -3,132 +3,125 @@ using Celeste.Mod.CommunalHelper.Entities.StrawberryJam;
 using MonoMod.ModInterop;
 using MonoMod.Utils;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Celeste.Mod.CommunalHelper.Imports;
 
 [ModImportName("LylyraHelper")]
 public static class LylyraHelper
 {
-    //parameters are as follows:
-    //Type of entity to slice
-    //A function that gives the EntityData used to create the Entity in question
-    //hex string of the color of the particles you want slicers to spawn upon block being cut, can be null (given as a string specifically so it can be nulled)
-    //the minimum width of your solid
-    //the minimum height of your solid 
-    //an audio path for a sound to be played upon your block breaking, can be null
+    // Parameters are as follows:
+    // - Type of entity to slice
+    // - A function that gives the EntityData used to create the Entity in question
+    // - Hex string of the color of the particles you want slicers to spawn upon block being cut, can be null (given as a string specifically so it can be nulled)
+    // - The minimum width of your solid
+    // - The minimum height of your solid 
+    // - An audio path for a sound to be played upon your block breaking, can be null
     public static Action<Type, Func<Entity, DynamicData, EntityData>, string, int, int, string> RegisterSimpleSolidSlicerAction;
 
-    //Allows you to register custom functions for your item incase RegisterSimpleSolidSlicerAction isn't enough
-    //Quick explaination of basic functions:
-    //activate: aka "SecondFrameSlicing", activates post awake
-    //postSlice: called immediately after slicing an entity
-    //getparticlecolor: a function describing what particle color to show (as a hex string)
+    // Allows you to register custom functions for your item in case RegisterSimpleSolidSlicerAction isn't enough
+    // Quick explaination of basic functions:
+    // - "activate": aka "secondframeslicing", activates post-Awake
+    // - "postslice": called immediately after slicing an entity
+    // - "getparticlecolor": a function describing what particle color to show (as a hex string)
     public static Action<Type, Dictionary<string, Delegate>> RegisterSlicerActionSet;
     public static Action<Type> UnregisterSlicerAction;
 
-    //this method handles attached static movers (like spikes) for Solids. Convenience Method.
+    // This method handles attached static movers (like spikes) for Solids. Convenience method.
     public static Action<DynamicData, Solid, Solid, List<StaticMover>> HandleStaticMovers;
 
     public static Func<Solid, DynamicData, Vector2[]> CalcNewBlockPosAndSize;
     public static Func<Entity, DynamicData> GetSlicer;
 
-    public static void Load()
+    public static void Initialize()
     {
-        Func<Entity, DynamicData, EntityData> GetDreamEntityData = (Entity data, DynamicData slicer) => {
-            return (data as CustomDreamBlock).creatingData;
-        };
+        typeof(LylyraHelper).ModInterop();
+        
+        // audio paths have been left blank for the moment
+        RegisterSimpleSolidSlicerAction?.Invoke(typeof(DreamFallingBlock), GetDreamBlockEntityData, "000000", 8, 8, null); // color chosen to be consistent with other dream block types
+        RegisterSimpleSolidSlicerAction?.Invoke(typeof(DreamFloatySpaceBlock), GetDreamBlockEntityData, "000000", 8, 8, null); // color chosen to be consistent with other dream block types
+        RegisterSimpleSolidSlicerAction?.Invoke(typeof(DreamMoveBlock), GetDreamBlockEntityData, "000000", 8, 8, null); // color chosen to be consistent with other dream block types
+        RegisterSimpleSolidSlicerAction?.Invoke(typeof(LoopBlock), (data, _) => (data as LoopBlock)!.creatingData, null, 24, 24, null); // color is overridden via a custom function so it matches the loop block being cut
+        RegisterSimpleSolidSlicerAction?.Invoke(typeof(Melvin), (data, _) => (data as Melvin)!.creationData, null, 24, 24, null); //  color is overridden via a custom function so it matches the melvin being cut
 
-        //audio paths have been left blank for the moment
-        RegisterSimpleSolidSlicerAction(typeof(DreamFallingBlock), GetDreamEntityData, "000000", 8, 8, null); //color chosen to be consistent with other dream block types
-        RegisterSimpleSolidSlicerAction(typeof(DreamFloatySpaceBlock), GetDreamEntityData, "000000", 8, 8, null);
-        RegisterSimpleSolidSlicerAction(typeof(DreamMoveBlock), GetDreamEntityData, "000000", 8, 8, null);
-        RegisterSimpleSolidSlicerAction(typeof(LoopBlock), (Entity data, DynamicData slicer) => {return (data as LoopBlock).creatingData;}, null, 24, 24, null); //color is overridden via a custom function so it matches the loop block being cut
-        RegisterSimpleSolidSlicerAction(typeof(Melvin), (Entity data, DynamicData slicer) => { return (data as Melvin).creationData; }, null, 24, 24, null); //color is overridden via a custom function so it matches the melvin being cut
+        // vanity function registration for LoopBlocks
+        RegisterSlicerActionSet?.Invoke(typeof(LoopBlock), new Dictionary<string, Delegate>
+        {
+            { "getparticlecolor", (Entity e, DynamicData _) => (e as LoopBlock)!.color }
+        });
+        
+        // these methods are needed to fix small things in DreamMoveBlock and DreamFallingBlock
+        RegisterSlicerActionSet?.Invoke(typeof(DreamFallingBlock), new Dictionary<string, Delegate>
+        {
+            { "postslice", (Action<Entity, Entity, DynamicData>) PostSliceDreamFallingBlock }
+        });
+        RegisterSlicerActionSet?.Invoke(typeof(DreamMoveBlock), new Dictionary<string, Delegate>
+        {
+            { "activate", (Action<Entity, DynamicData>) ActivateDreamMoveBlock },
+            { "postslice", (Action<Entity, Entity, DynamicData>) PostSliceDreamMoveBlock }
+        });
 
-        //vanity function registration for LoopBlocks
-        Dictionary<string, Delegate> loopBlockDict = new() {
-            {"getparticlecolor",  
-                (Entity e, DynamicData y) =>
-                {
-                    return (e as LoopBlock).color;
-                }
-            }
-        };
-        RegisterSlicerActionSet(typeof(LoopBlock), loopBlockDict);
-        //these methods are needed to fix small things in the DreamMoveBlocks and DreamFallingBlocks
+        // melvin behavior is based on CrushBlock behavior
+        RegisterSlicerActionSet?.Invoke(typeof(Melvin), new Dictionary<string, Delegate>
+        {
+            { "activate", (Action<Entity, DynamicData>) ActivateMelvin },
+            { "postslice", (Action<Entity, Entity, DynamicData>) PostSliceMelvin },
+            { "getparticlecolor", (Func<Entity, DynamicData, Color>) ParticleColorMelvin }
+        });
 
-        //This method activates the DreamFallingBlock after being sliced
-        Action<Entity, Entity, DynamicData> PostSlice = (Entity created, Entity data, DynamicData slicer) => {
-            DreamFallingBlock block = created as DreamFallingBlock;
+        return;
+        
+        EntityData GetDreamBlockEntityData(Entity entity, DynamicData _)
+            => (entity as CustomDreamBlock)!.creatingData;
+        
+        // this method activates the DreamFallingBlock after being sliced
+        void PostSliceDreamFallingBlock(Entity created, Entity data, DynamicData slicer)
+        {
+            DreamFallingBlock block = (created as DreamFallingBlock)!;
             block.Triggered = true;
             block.FallDelay = 0;
-        };
-        Dictionary<string, Delegate> fallingDreamBlockDic = new Dictionary<string, Delegate>()
+        }
+        
+        // this method is called on Awake for each DreamMoveBlock that is generated, as activating them the frame they are added crashes the game
+        void ActivateDreamMoveBlock(Entity entity, DynamicData slicer)
         {
-            { "postslice", PostSlice }
-        };
-        RegisterSlicerActionSet(typeof(DreamFallingBlock), fallingDreamBlockDic);
+            if (entity is null)
+                return;
 
-        //the start position technically changes after slicing, so this method fixes that.
-        Action<Entity, Entity, DynamicData> PostSliceMoveBlock = (Entity created, Entity entity, DynamicData slicer) => {
-            bool vertical = slicer.Get<Vector2>("Direction").Y != 0;
-            DreamMoveBlock original = entity as DreamMoveBlock;
-            DreamMoveBlock block = created as DreamMoveBlock;
-            block.startPosition = vertical ? new Vector2(block.X, original.startPosition.Y + block.Y - original.Position.Y) : new Vector2(original.startPosition.X + block.X - original.Position.X, block.Y);
-        };
-        //this method is called on each DreamMoveBlock that is generated the frame after (at Awake()), as activating the frame of adding crashes the game
-        Action<Entity, DynamicData> activate = (Entity entity, DynamicData slicer) => {
-            if (entity is not null)
-            {
-
-                DreamMoveBlock block = entity as DreamMoveBlock;
-                block.Get<Coroutine>().enumerators.Peek().MoveNext();
-                block.triggered = true;
-            }
-        };
-
-        Dictionary<string, Delegate> dmbDict = new Dictionary<string, Delegate>()
+            DreamMoveBlock block = (entity as DreamMoveBlock)!;
+            block.Get<Coroutine>().enumerators.Peek().MoveNext();
+            block.triggered = true;
+        }
+        // the start position technically changes after slicing, so this method fixes that.
+        void PostSliceDreamMoveBlock(Entity created, Entity entity, DynamicData slicer)
         {
-            { "activate", activate },
-            { "postslice", PostSliceMoveBlock}
-        };
-
-        RegisterSlicerActionSet(typeof(DreamMoveBlock), dmbDict);
-
-        //melvin behavior is based on CrushBlock behavior
-        //reset the melvin return stacks so it can return to where it was
-        Action<Entity, Entity, DynamicData> melvinReturn = (Entity created, Entity entity, DynamicData slicer) => {
             bool vertical = slicer.Get<Vector2>("Direction").Y != 0;
-            Melvin original = entity as Melvin;
-            Melvin block = created as Melvin;
+            DreamMoveBlock original = (entity as DreamMoveBlock)!;
+            DreamMoveBlock block = (created as DreamMoveBlock)!;
+            block.startPosition = vertical
+                ? new Vector2(block.X, original.startPosition.Y + block.Y - original.Position.Y)
+                : new Vector2(original.startPosition.X + block.X - original.Position.X, block.Y);
+        }
+        
+        void ActivateMelvin(Entity created, DynamicData slicer)
+        {
+            Melvin block = (created as Melvin)!;
+            block.crushDir = -slicer.Get<Vector2>("Direction");
+            block.Attack(true); // a slicer hitting it counts as a dash right?
+        }
+        // reset the melvin return stacks so it can return to where it was
+        void PostSliceMelvin(Entity created, Entity entity, DynamicData slicer)
+        {
+            Melvin original = (entity as Melvin)!;
+            Melvin block = (created as Melvin)!;
 
-            var returnStack = original.returnStack;
             Vector2 offset = block.Position - original.Position;
+            List<Melvin.MoveState> returnStack = original.returnStack;
             List<Melvin.MoveState> newReturnStack = block.returnStack;
             newReturnStack.Clear();
-            foreach (Melvin.MoveState state in returnStack)
-            {
-                newReturnStack.Add(new Melvin.MoveState(state.From + offset, state.Direction));
-            };
-        };
-        //
-
-        Action<Entity, DynamicData> melvinActivate = (Entity created, DynamicData slicer) => {
-            (created as Melvin).crushDir = -slicer.Get<Vector2>("Direction");
-            (created as Melvin).Attack(true); //slicer hit it counts as a dash right?
-        };
-        Func<Entity, DynamicData, Color> melvinParticleColor = (Entity created, DynamicData _) =>
-        {
-            return (created as Melvin).fill;
-        };
-        
-        Dictionary<string, Delegate> melvinDict = new Dictionary<string, Delegate>()
-        {
-            { "activate", melvinActivate },
-            { "postslice", melvinReturn },
-            { "getparticlecolor", melvinParticleColor }
-        };
-
-        RegisterSlicerActionSet(typeof(Melvin), melvinDict);
+            newReturnStack.AddRange(returnStack.Select(state => new Melvin.MoveState(state.From + offset, state.Direction)));
+        }
+        Color ParticleColorMelvin(Entity created, DynamicData _)
+            => (created as Melvin)!.fill;
     }
 }

--- a/src/Imports/ReverseHelper.cs
+++ b/src/Imports/ReverseHelper.cs
@@ -1,12 +1,22 @@
-﻿using MonoMod.ModInterop;
+﻿using Celeste.Mod.CommunalHelper.Entities;
+using MonoMod.ModInterop;
 
 namespace Celeste.Mod.CommunalHelper.Imports;
 
 /// <summary>
-/// Import methods defined here: <see href="https://github.com/wuke32767/CelesteReverseHelper/blob/main/ReverseHelperInterop.cs">CavernInterop</see>.
+/// Import methods defined here: <see href="https://github.com/wuke32767/CelesteReverseHelper/blob/main/ReverseHelperInterop.cs">ReverseHelperInterop</see>.
 /// </summary>
 [ModImportName("ReverseHelper.DreamBlock")]
 public static class ReverseHelper
 {
     public static Action<Type, Action<Entity>, Action<Entity>> RegisterDreamBlockLike;
+
+    public static void Initialize()
+    {
+        typeof(ReverseHelper).ModInterop();
+        
+        RegisterDreamBlockLike?.Invoke(typeof(DreamTunnelEntry),
+            e => (e as DreamTunnelEntry)!.ActivateNoRoutine(),
+            e => (e as DreamTunnelEntry)!.DeactivateNoRoutine());
+    }
 }

--- a/src/Imports/SpeedrunTool.cs
+++ b/src/Imports/SpeedrunTool.cs
@@ -3,13 +3,16 @@ using MonoMod.ModInterop;
 
 namespace Celeste.Mod.CommunalHelper.Imports;
 
+[ModImportName("SpeedrunTool.SaveLoad")]
 public static class SpeedrunTool
 {
+    public static Func<Type, string[], object> RegisterStaticTypes;
+    
     public static void Initialize()
     {
-        typeof(SaveLoadImports).ModInterop();
-
-        SaveLoadImports.RegisterStaticTypes?.Invoke(typeof(DreamTunnelDash), [
+        typeof(SpeedrunTool).ModInterop();
+        
+        RegisterStaticTypes?.Invoke(typeof(DreamTunnelDash), [
             "St.DreamTunnelDash",
             "hasDreamTunnelDash",
             "dreamTunnelDashCount",
@@ -20,13 +23,5 @@ public static class SpeedrunTool
             "overrideDreamDashCheck",
             "DreamTrailColorIndex"
         ]);
-    }
-
-    [ModImportName("SpeedrunTool.SaveLoad")]
-    private static class SaveLoadImports
-    {
-#pragma warning disable CS0649 // Field 'RegisterStaticTypes' is never assigned to, and will always have its default value null
-        public static Func<Type, string[], object> RegisterStaticTypes;
-#pragma warning restore CS0649
     }
 }


### PR DESCRIPTION
This PR ensures all ModInterop is done in `Initialize` (since we don't have optional dependencies on any of the mods we use interop from, this guarantees that interop will always be loaded) and adds interop with EeveeHelper (https://github.com/CommunalHelper/EeveeHelper/pull/53) to stop it modifying the group properties of `ConnectedSolid`s and `ConnectedDreamBlock`s.