### PR TITLE
Fix liftboost being wonky on Solar Elevators with savestates

### DIFF
--- a/src/Entities/ConnectedBlocks/ConnectedSolid.cs
+++ b/src/Entities/ConnectedBlocks/ConnectedSolid.cs
@@ -400,8 +400,6 @@ public class ConnectedSolid : Solid
         GetRiders();
         Player player = Scene.Tracker.GetEntity<Player>();
 
-        HashSet<Actor> riders = data.Get<HashSet<Actor>>("riders");
-
         if (player is not null && Input.MoveX.Value == Math.Sign(move) && Math.Sign(player.Speed.X) == Math.Sign(move) && !riders.Contains(player) && CollideCheck(player, Position + (Vector2.UnitX * move) - Vector2.UnitY))
         {
             player.MoveV(1f);
@@ -461,7 +459,6 @@ public class ConnectedSolid : Solid
         GravityHelper.BeginOverride?.Invoke();
 
         GetRiders();
-        HashSet<Actor> riders = data.Get<HashSet<Actor>>("riders");
 
         Y += move;
         MoveStaticMovers(Vector2.UnitY * move);

--- a/src/Entities/StrawberryJam/SolarElevator.cs
+++ b/src/Entities/StrawberryJam/SolarElevator.cs
@@ -72,8 +72,6 @@ public class SolarElevator : Solid
 
     private Background bg;
 
-    private readonly HashSet<Actor> riders;
-
     public EntityID ID { get; }
 
     public SolarElevator(EntityData data, Vector2 offset, EntityID id)
@@ -150,8 +148,6 @@ public class SolarElevator : Solid
         img.JustifyOrigin(0.5f, 1.0f);
         img.Position.Y = 10;
         Add(img);
-
-        riders = new DynamicData(typeof(Solid), this).Get<HashSet<Actor>>("riders");
     }
 
     public override void Awake(Scene scene)


### PR DESCRIPTION
Previously Solar Elevators only got a reference to their riders once on construction, which breaks when savestates clone everything as the reference will no longer point to the right place.