### PR TITLE
Add support for entity SIDs to Glow Controllers and Show Hitbox Triggers

### DIFF
--- a/Loenn/entities/misc/glow_controller.lua
+++ b/Loenn/entities/misc/glow_controller.lua
@@ -1,15 +1,42 @@
+local communalHelper = require("mods").requireFromPlugin("libraries.communal_helper")
+
 local glowController = {}
 
 glowController.name = "CommunalHelper/GlowController"
 glowController.depth = -1000000
 glowController.texture = "objects/CommunalHelper/glowController/icon"
 
+glowController.fieldOrder = {
+    "x", "y",
+    "lightBlacklist", "bloomBlacklist",
+    "lightWhitelist", "bloomWhitelist",
+    "lightColor", "bloomAlpha",
+    "lightAlpha", "bloomRadius",
+    "lightStartFade", "bloomOffsetX",
+    "lightEndFade", "bloomOffsetY",
+    "lightOffsetX", "deathAnimationIds",
+    "lightOffsetY", "respawnAnimationIds",
+    "flag", "flagFadeTime"
+}
+
 glowController.fieldInformation = {
     lightWhitelist = {
         fieldType = "list",
+        elementSeparator = ",",
+        elementDefault = "",
+        elementOptions = {
+             options = function() return communalHelper.getMapSIDs() end,
+             searchable = true,
+        },
     },
     lightBlacklist = {
         fieldType = "list",
+        elementSeparator = ",",
+        elementDefault = "",
+        elementOptions = {
+             options = function() return communalHelper.getMapSIDs() end,
+             searchable = true,
+        },
     },
     lightColor = {
         fieldType = "color",
@@ -31,9 +58,21 @@ glowController.fieldInformation = {
     },
     bloomWhitelist = {
         fieldType = "list",
+        elementSeparator = ",",
+        elementDefault = "",
+        elementOptions = {
+             options = function() return communalHelper.getMapSIDs() end,
+             searchable = true,
+        },
     },
     bloomBlacklist = {
         fieldType = "list",
+        elementSeparator = ",",
+        elementDefault = "",
+        elementOptions = {
+             options = function() return communalHelper.getMapSIDs() end,
+             searchable = true,
+        },
     },
     bloomAlpha = {
         fieldType = "number",

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -854,16 +854,16 @@ entities.CommunalHelper/BadelineBoostKeepHoldables.attributes.description.finalC
 
 # Glow Controller
 entities.CommunalHelper/GlowController.placements.name.controller=Glow Controller
-entities.CommunalHelper/GlowController.attributes.description.lightWhitelist=A comma-separated list of fully qualified entity class names to apply VertexLights to.  Defaults to empty string.
-entities.CommunalHelper/GlowController.attributes.description.lightBlacklist=A comma-separated list of fully qualified entity class names to remove VertexLights from.  Defaults to empty string.
+entities.CommunalHelper/GlowController.attributes.description.lightWhitelist=A comma-separated list of fully qualified entity class names or entity SIDs to apply VertexLights to.  Defaults to empty string.
+entities.CommunalHelper/GlowController.attributes.description.lightBlacklist=A comma-separated list of fully qualified entity class names or entity SIDs to remove VertexLights from.  Defaults to empty string.
 entities.CommunalHelper/GlowController.attributes.description.lightColor=The colour to use for the lights, as a hex representation.  Defaults to white (FFFFFF).
 entities.CommunalHelper/GlowController.attributes.description.lightAlpha=The opacity of the light, ranging from 0 (invisible) to 1 (opaque).  Defaults to 1.
 entities.CommunalHelper/GlowController.attributes.description.lightStartFade=The distance from the entity's position at which the light should begin to fade in.  Defaults to 24.
 entities.CommunalHelper/GlowController.attributes.description.lightEndFade=The distance from the entity's position at which the light should begin to fade out.  Defaults to 48.
 entities.CommunalHelper/GlowController.attributes.description.lightOffsetX=The X offset from the entity's position at which to place the VertexLight.  Defaults to 0.
 entities.CommunalHelper/GlowController.attributes.description.lightOffsetY=The Y offset from the entity's position at which to place the VertexLight.  Defaults to 0.
-entities.CommunalHelper/GlowController.attributes.description.bloomWhitelist=A comma-separated list of fully qualified entity class names to apply BloomPoints to.  Defaults to empty string.
-entities.CommunalHelper/GlowController.attributes.description.bloomBlacklist=A comma-separated list of fully qualified entity class names to remove BloomPoints and CustomBlooms from.  Defaults to empty string.
+entities.CommunalHelper/GlowController.attributes.description.bloomWhitelist=A comma-separated list of fully qualified entity class names or entity SIDs to apply BloomPoints to.  Defaults to empty string.
+entities.CommunalHelper/GlowController.attributes.description.bloomBlacklist=A comma-separated list of fully qualified entity class names or entity SIDs to remove BloomPoints and CustomBlooms from.  Defaults to empty string.
 entities.CommunalHelper/GlowController.attributes.description.bloomAlpha=The opacity of the bloom, ranging from 0 (invisible) to 1 (opaque).  Defaults to 1.
 entities.CommunalHelper/GlowController.attributes.description.bloomRadius=The radius of the bloom in pixels.  Defaults to 8.
 entities.CommunalHelper/GlowController.attributes.description.bloomOffsetX=The X offset from the entity's position at which to place the BloomPoint.  Defaults to 0.
@@ -1039,7 +1039,7 @@ entities.CommunalHelper/DreamTunnelBlocker.attributes.description.blockDreamDash
 # [Strawberry Jam] Show Hitbox Trigger
 triggers.CommunalHelper/SJ/ShowHitboxTrigger.placements.name.trigger=Show Hitbox [Strawberry Jam]
 triggers.CommunalHelper/SJ/ShowHitboxTrigger.placements.description.trigger=Shows the hitboxes of specified entities while inside.
-triggers.CommunalHelper/SJ/ShowHitboxTrigger.attributes.description.typeNames=A comma-separated list of class names of the entities to show hitboxes when player is inside the trigger.\nExample: Celeste.Player,Celeste.CrystalStaticSpinner,Refill
+triggers.CommunalHelper/SJ/ShowHitboxTrigger.attributes.description.typeNames=A comma-separated list of class names or entity SIDs of the entities to show hitboxes when player is inside the trigger.\nExample: Celeste.Player,Celeste.CrystalStaticSpinner,Refill,FrostHelper/IceSpinner
 
 # [Strawberry Jam] Oshiro Attack Time Trigger
 triggers.CommunalHelper/SJ/OshiroAttackTimeTrigger.placements.name.trigger=Oshiro Faster Attack [Strawberry Jam]

--- a/Loenn/libraries/communal_helper.lua
+++ b/Loenn/libraries/communal_helper.lua
@@ -4,6 +4,8 @@ local drawableSprite = require("structs.drawable_sprite")
 local drawableNinePatch = require("structs.drawable_nine_patch")
 local utils = require("utils")
 local connectedEntities = require("helpers.connected_entities")
+local loadedState = require("loaded_state")
+local entities = require("entities")
 
 local communalHelper = {}
 
@@ -396,5 +398,36 @@ communalHelper.easers = {
     ["Bounce Out"] = "BounceOut",
     ["Bounce In Out"] = "BounceInOut",
 }
+
+-- sids
+
+function communalHelper.getAllSIDs()
+    local sids = {}
+    for sid, _ in pairs(entities.registeredEntities) do
+        table.insert(sids, sid)
+    end
+    table.sort(sids)
+
+    return sids
+end
+
+function communalHelper.getMapSIDs()
+    if not loadedState.map then return communalHelper.getAllSIDs() end
+
+    local sidsInMap = {}
+    for _, room in pairs(loadedState.map.rooms) do
+        for _, entity in pairs(room.entities) do
+            sidsInMap[entity._name] = true
+        end
+    end
+
+    local sids = {}
+    for sid, _ in pairs(sidsInMap) do
+        table.insert(sids, sid)
+    end
+    table.sort(sids)
+
+    return sids
+end
 
 return communalHelper

--- a/Loenn/triggers/strawberry_jam/show_hitbox_trigger.lua
+++ b/Loenn/triggers/strawberry_jam/show_hitbox_trigger.lua
@@ -1,9 +1,22 @@
+local communalHelper = require("mods").requireFromPlugin("libraries.communal_helper")
+
 return {
     name = "CommunalHelper/SJ/ShowHitboxTrigger",
     placements = {
         name = "trigger",
         data = {
             typeNames = "Celeste.CrystalStaticSpinner"
+        }
+    },
+    fieldInformation = {
+        typeNames = {
+            fieldType = "list",
+            elementSeparator = ",",
+            elementDefault = "",
+            elementOptions = {
+                 options = function() return communalHelper.getMapSIDs() end,
+                 searchable = true
+            },
         }
     }
 }

--- a/src/Entities/Misc/GlowController.cs
+++ b/src/Entities/Misc/GlowController.cs
@@ -5,10 +5,12 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Celeste.Mod.Registry;
 
 namespace Celeste.Mod.CommunalHelper.Entities;
 
 [CustomEntity("CommunalHelper/GlowController")]
+[Tracked]
 public class GlowController(EntityData data, Vector2 offset) : Entity(data.Position + offset)
 {
     #region Hooks
@@ -60,49 +62,51 @@ public class GlowController(EntityData data, Vector2 offset) : Entity(data.Posit
             instr => instr.MatchStloc(4)))
             return;
         
-        VariableDefinition allGlowControllers = new(il.Import(typeof(IEnumerable<GlowController>)));
+        VariableDefinition allGlowControllers = new(il.Import(typeof(GlowController[])));
         il.Body.Variables.Add(allGlowControllers);
 
         cursor.Emit(OpCodes.Ldarg_0);
         cursor.EmitDelegate(GetGlowControllers);
         cursor.Emit(OpCodes.Stloc, allGlowControllers);
 
-        if (!cursor.TryGotoNextBestFit(MoveType.Before,
-            instr => instr.MatchLdfld<EntityList>("toAwake"),
-            instr => instr.MatchCallvirt<List<Entity>>("Clear")))
+        if (!cursor.TryGotoNextBestFit(MoveType.After,
+            instr => instr.MatchLdloc(5),
+            instr => instr.MatchLdarg(0),
+            instr => instr.MatchCallvirt<EntityList>("get_Scene"),
+            instr => instr.MatchCallvirt<Entity>("Awake")))
             return;
 
-        cursor.Emit(OpCodes.Ldarg, 0);
+        cursor.Emit(OpCodes.Ldloc, 5);
         cursor.Emit(OpCodes.Ldloc, allGlowControllers);
         cursor.EmitDelegate(ProcessEntity);
 
         return;
         
-        // maybe a bit expensive to be doing every frame
-        static IEnumerable<GlowController> GetGlowControllers(EntityList entityList)
-            => entityList.Concat(entityList.ToAdd).OfType<GlowController>();
+        // new entities have already been added to the tracker at this point in UpdateLists (and toAdd has been cleared anyway), so using the tracker should be sufficient
+        static GlowController[] GetGlowControllers(EntityList entityList)
+            => entityList.Scene.Tracker.GetEntities<GlowController>().Cast<GlowController>().ToArray();
 
-        static void ProcessEntity(EntityList entities, IEnumerable<GlowController> glowControllers) {
+        static void ProcessEntity(Entity entity, GlowController[] glowControllers)
+        {
             foreach (GlowController controller in glowControllers)
-                foreach (Entity entity in entities.toAwake)
-                    controller.Process(entity);
-         }
+                controller.Process(entity);
+        }
     }
     
     #endregion
 
     private const StringSplitOptions SplitOptions = StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries;
 
-    private readonly string[] lightWhitelist = data.Attr("lightWhitelist").Split(',', SplitOptions);
-    private readonly string[] lightBlacklist = data.Attr("lightBlacklist").Split(',', SplitOptions);
+    private readonly HashSet<string> lightWhitelist = data.Attr("lightWhitelist").Split(',', SplitOptions).ToHashSet();
+    private readonly HashSet<string> lightBlacklist = data.Attr("lightBlacklist").Split(',', SplitOptions).ToHashSet();
     private readonly Color lightColor = data.HexColor("lightColor", Color.White);
     private readonly float lightAlpha = data.Float("lightAlpha", 1f);
     private readonly int lightStartFade = data.Int("lightStartFade", 24);
     private readonly int lightEndFade = data.Int("lightEndFade", 48);
     private readonly Vector2 lightOffset = new(data.Int("lightOffsetX"), data.Int("lightOffsetY", -10));
 
-    private readonly string[] bloomWhitelist = data.Attr("bloomWhitelist").Split(',', SplitOptions);
-    private readonly string[] bloomBlacklist = data.Attr("bloomBlacklist").Split(',', SplitOptions);
+    private readonly HashSet<string> bloomWhitelist = data.Attr("bloomWhitelist").Split(',', SplitOptions).ToHashSet();
+    private readonly HashSet<string> bloomBlacklist = data.Attr("bloomBlacklist").Split(',', SplitOptions).ToHashSet();
     private readonly float bloomAlpha = data.Float("bloomAlpha", 1f);
     private readonly float bloomRadius = data.Float("bloomRadius", 8f);
     private readonly Vector2 bloomOffset = new(data.Int("bloomOffsetX"), data.Int("bloomOffsetY", -10));
@@ -117,22 +121,26 @@ public class GlowController(EntityData data, Vector2 offset) : Entity(data.Posit
     {
         Type type = entity.GetType();
         string typeName = type.FullName;
+        Func<HashSet<string>, bool> containsSid = entity.SourceData?.Name is { } sourceSid
+            ? typeList => typeList.Contains(sourceSid)
+            : typeList => typeList.Overlaps(EntityRegistry.GetKnownSidsFromType(type));
+
         bool lightOrBloomAdded = false;
 
-        if (lightBlacklist.Contains(typeName))
+        if (lightBlacklist.Contains(typeName) || containsSid(lightBlacklist))
             entity.Remove(entity.Components.GetAll<VertexLight>().ToArray<Component>());
-        if (lightWhitelist.Contains(typeName))
+        if (lightWhitelist.Contains(typeName) || containsSid(lightWhitelist))
         {
             entity.Add(new VertexLight(lightOffset, lightColor, lightAlpha, lightStartFade, lightEndFade));
             lightOrBloomAdded = true;
         }
 
-        if (bloomBlacklist.Contains(typeName))
+        if (bloomBlacklist.Contains(typeName) || containsSid(bloomBlacklist))
         {
             entity.Remove(entity.Components.GetAll<BloomPoint>().ToArray<Component>());
             entity.Remove(entity.Components.GetAll<CustomBloom>().ToArray<Component>());
         }
-        if (bloomWhitelist.Contains(typeName))
+        if (bloomWhitelist.Contains(typeName) || containsSid(bloomWhitelist))
         {
             entity.Add(new BloomPoint(bloomOffset, bloomAlpha, bloomRadius));
             lightOrBloomAdded = true;
@@ -152,6 +160,8 @@ public class GlowController(EntityData data, Vector2 offset) : Entity(data.Posit
             multipliers.Add(DeathFadeMultiplier(entity, sprite));
         
         entity.Add(new Coroutine(AlphaFadeRoutine(entity, multipliers)));
+
+        return;
     }
 
     private static IEnumerator AlphaFadeRoutine(Entity entity, List<IEnumerator> multipliers)

--- a/src/Triggers/StrawberryJam/ShowHitboxTrigger.cs
+++ b/src/Triggers/StrawberryJam/ShowHitboxTrigger.cs
@@ -2,6 +2,7 @@
 using MonoMod.Cil;
 using System.Collections.Generic;
 using System.Linq;
+using Celeste.Mod.Registry;
 
 namespace Celeste.Mod.CommunalHelper.Triggers.StrawberryJam;
 
@@ -55,24 +56,26 @@ public class ShowHitboxTrigger : Trigger
         }
     }
 
+    #region Hooks
+
     public static void Load()
     {
-        IL.Celeste.GameplayRenderer.Render += PatchGameplayRendererRender;
-        On.Celeste.SoundSource.DebugRender += SoundSourceOnDebugRender;
+        IL.Celeste.GameplayRenderer.Render += IL_GameplayRenderer_Render;
+        On.Celeste.SoundSource.DebugRender += On_SoundSource_DebugRender;
         // below are hitbox fixes from CelesteTAS, maybe they will get integrated into Everest
-        On.Monocle.Draw.HollowRect_float_float_float_float_Color += ModDrawHollowRect;
-        On.Monocle.Draw.Circle_Vector2_float_Color_int += ModDrawCircle;
+        On.Monocle.Draw.HollowRect_float_float_float_float_Color += On_Draw_HollowRect_float_float_float_float_Color;
+        On.Monocle.Draw.Circle_Vector2_float_Color_int += On_Draw_Circle_Vector2_float_Color_int;
     }
 
     public static void Unload()
     {
-        IL.Celeste.GameplayRenderer.Render -= PatchGameplayRendererRender;
-        On.Celeste.SoundSource.DebugRender -= SoundSourceOnDebugRender;
-        On.Monocle.Draw.HollowRect_float_float_float_float_Color -= ModDrawHollowRect;
-        On.Monocle.Draw.Circle_Vector2_float_Color_int -= ModDrawCircle;
+        IL.Celeste.GameplayRenderer.Render -= IL_GameplayRenderer_Render;
+        On.Celeste.SoundSource.DebugRender -= On_SoundSource_DebugRender;
+        On.Monocle.Draw.HollowRect_float_float_float_float_Color -= On_Draw_HollowRect_float_float_float_float_Color;
+        On.Monocle.Draw.Circle_Vector2_float_Color_int -= On_Draw_Circle_Vector2_float_Color_int;
     }
 
-    private static void PatchGameplayRendererRender(ILContext il)
+    private static void IL_GameplayRenderer_Render(ILContext il)
     {
         ILCursor cursor = new(il);
         if (cursor.TryGotoNext(MoveType.Before, instr => instr.MatchCall<GameplayRenderer>("End")))
@@ -96,7 +99,12 @@ public class ShowHitboxTrigger : Trigger
             cursor.MoveAfterLabels();
             cursor.Emit(OpCodes.Ldarg_0); // self
             cursor.Emit(OpCodes.Ldarg_1); // scene
-            cursor.EmitDelegate<Action<GameplayRenderer, Scene>>((self, scene) =>
+            cursor.EmitDelegate(DrawEnabledHitboxes);
+            cursor.MarkLabel(beforeGameplayRendererEnd);
+
+            return;
+
+            static void DrawEnabledHitboxes(GameplayRenderer self, Scene scene)
             {
                 if (EnabledTypeNames.Count == 0)
                 {
@@ -105,17 +113,20 @@ public class ShowHitboxTrigger : Trigger
 
                 foreach (Entity entity in scene.Entities)
                 {
-                    if (EnabledTypeNames.Contains(entity.GetType().FullName) || EnabledTypeNames.Contains(entity.GetType().Name))
+                    Type type = entity.GetType();
+                    if (EnabledTypeNames.Contains(type.FullName) || EnabledTypeNames.Contains(type.Name)
+                        || (entity.SourceData?.Name is { } sourceSid
+                            ? EnabledTypeNames.Contains(sourceSid)
+                            : EnabledTypeNames.Overlaps(EntityRegistry.GetKnownSidsFromType(type))))
                     {
                         entity.DebugRender(self.Camera);
                     }
                 }
-            });
-            cursor.MarkLabel(beforeGameplayRendererEnd);
+            }
         }
     }
 
-    private static void SoundSourceOnDebugRender(On.Celeste.SoundSource.orig_DebugRender orig, SoundSource self, Camera camera)
+    private static void On_SoundSource_DebugRender(On.Celeste.SoundSource.orig_DebugRender orig, SoundSource self, Camera camera)
     {
         if (EnabledTypeNames.Count == 0 || Engine.Commands.Open)
         {
@@ -123,7 +134,7 @@ public class ShowHitboxTrigger : Trigger
         }
     }
 
-    private static void ModDrawHollowRect(On.Monocle.Draw.orig_HollowRect_float_float_float_float_Color orig, float x, float y, float width, float height, Color color)
+    private static void On_Draw_HollowRect_float_float_float_float_Color(On.Monocle.Draw.orig_HollowRect_float_float_float_float_Color orig, float x, float y, float width, float height, Color color)
     {
         if (EnabledTypeNames.Count == 0)
         {
@@ -138,7 +149,7 @@ public class ShowHitboxTrigger : Trigger
         orig(fx, fy, cw, cy, color);
     }
 
-    private static void ModDrawCircle(On.Monocle.Draw.orig_Circle_Vector2_float_Color_int orig, Vector2 center, float radius, Color color, int resolution)
+    private static void On_Draw_Circle_Vector2_float_Color_int(On.Monocle.Draw.orig_Circle_Vector2_float_Color_int orig, Vector2 center, float radius, Color color, int resolution)
     {
         // Adapted from John Kennedy, "A Fast Bresenham Type Algorithm For Drawing Circles"
         // https://web.engr.oregonstate.edu/~sllu/bcircle.pdf
@@ -240,4 +251,6 @@ public class ShowHitboxTrigger : Trigger
 
         Draw.SpriteBatch.Draw(Draw.Pixel.Texture.Texture, rect, Draw.Pixel.ClipRect, color);
     }
+
+    #endregion
 }


### PR DESCRIPTION
This PR adds support for using entity SIDs instead of class names to Glow Controllers and Show Hitbox Triggers, and adds dropdowns with all SIDs in the current map to their Lönn plugins.

Also makes Glow Controllers use the tracker instead of searching through the entire entity list (should be sufficient since entities are added to the tracker earlier in `UpdateLists` than where we're hooking) and process entities inside the normal `toAwake` loop.