### PR TITLE
Allow Move Blocks to ignore certain solids

### DIFF
--- a/Loenn/entities/cassette_blocks/cassette_move_block.lua
+++ b/Loenn/entities/cassette_blocks/cassette_move_block.lua
@@ -60,6 +60,7 @@ for i = 1, 4 do
             noDebris = false,
             spritePath = "",
             sideAlpha = 1.0,
+            ignore="",
         }
     }
 end

--- a/Loenn/entities/connected_blocks/connected_move_block.lua
+++ b/Loenn/entities/connected_blocks/connected_move_block.lua
@@ -61,7 +61,8 @@ for i, direction in ipairs(enums.move_block_directions) do
             regenTime = 3.0,
             shakeOnCollision = true,
             noDebris = false,
-            redirectIsPersistent = false
+            redirectIsPersistent = false,
+            ignore=""
         }
     }
 end

--- a/Loenn/entities/connected_blocks/equation_move_block.lua
+++ b/Loenn/entities/connected_blocks/equation_move_block.lua
@@ -82,7 +82,8 @@ for i, direction in ipairs(enums.move_block_directions) do
             regenTime = 3.0,
             shakeOnCollision = true,
             noDebris = false,
-            redirectIsPersistent = false
+            redirectIsPersistent = false,
+            ignore = ""
         }
     }
 end

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -210,6 +210,7 @@ entities.CommunalHelper/CassetteMoveBlock.attributes.description.noDebris=Whethe
 entities.CommunalHelper/CassetteMoveBlock.attributes.description.spritePath=Path to a folder to use for custom sprites, starting from Graphics/Atlases/Gameplay. The following textures must be defined:\n- solid: Used when the block is currently active.\n- pressed00 to pressed03: Used when the block is currently inactive, with the number of the texture corresponding to the block's index (00 for blue, 01 for pink, 02 for yellow, 03 for green).\n- arrow00 to arrow07, arrowPressed00 to arrowPressed07, arrowHighlight00 to arrowHighlight07, arrowHighlightPressed00 to arrowHighlightPressed07: Used for the arrow.\n- x, xPressed, xHighlight, xHighlightPressed: Used for the breaking cross.\n- debris00 to debris02: Used for the debris.\nIf left empty, the default textures will be used.
 entities.CommunalHelper/CassetteMoveBlock.attributes.description.sideAlpha=The alpha (opacity) of the darker rectangle at the bottom of the block. 0 will make it fully transparent, 1 will make it fully opaque.
 entities.CommunalHelper/CassetteMoveBlock.attributes.description.held=Whether this Cassette Block is activated by holding the manual cassette key binding (using the Manual Cassette Controller).\nThis only works if this block's index is 0 or 1:\n- index 0: ACTIVE when key is HELD.\n- index 1: INACTIVE when key is HELD.
+entities.CommunalHelper/CassetteMoveBlock.attributes.description.ignore=Comma-separated list of entity placement names to ignore.\ne.g. "zipMover,XaphanHelper/FlagDashSwitch,templeCrackedBlock"
 
 # Cassette Swap Block
 entities.CommunalHelper/CassetteSwapBlock.placements.name.cassette_block_0=Cassette Swap Block (0 - Blue)
@@ -464,6 +465,7 @@ entities.CommunalHelper/ConnectedMoveBlock.attributes.description.regenTime=The 
 entities.CommunalHelper/ConnectedMoveBlock.attributes.description.shakeOnCollision=Whether this Connected Move Block should start shaking if it collides with a solid for longer than the default break time.
 entities.CommunalHelper/ConnectedMoveBlock.attributes.description.noDebris=Whether this Connected Move Block should not spawn debris when it breaks.
 entities.CommunalHelper/ConnectedMoveBlock.attributes.description.redirectIsPersistent=Whether the effects of any Move Block Redirects on this block should persist after this block breaks and respawns.
+entities.CommunalHelper/ConnectedMoveBlock.attributes.description.ignore=Comma-separated list of entity placement names to ignore.\ne.g. "zipMover,XaphanHelper/FlagDashSwitch,templeCrackedBlock"
 
 # Connected Temple Cracked Block
 entities.CommunalHelper/ConnectedTempleCrackedBlock.placements.name.normal=Connected Temple Cracked Block
@@ -500,6 +502,7 @@ entities.CommunalHelper/EquationMoveBlock.attributes.description.regenTime=The t
 entities.CommunalHelper/EquationMoveBlock.attributes.description.shakeOnCollision=Whether this Equation Move Block should start shaking if it collides with a solid for longer than the default break time.
 entities.CommunalHelper/EquationMoveBlock.attributes.description.noDebris=Whether this Equation Move Block should not spawn debris when it breaks.
 entities.CommunalHelper/EquationMoveBlock.attributes.description.redirectIsPersistent=Whether the effects of any Move Block Redirects on this block should persist after this block breaks and respawns.
+entities.CommunalHelper/EquationMoveBlock.attributes.description.ignore=Comma-separated list of entity placement names to ignore.\ne.g. "zipMover,XaphanHelper/FlagDashSwitch,templeCrackedBlock"
 
 # Bouncy Panel
 entities.CommunalHelper/BouncyPanel.placements.name.up=Bouncy Panel (Up)

--- a/src/Entities/CassetteBlocks/CassetteMoveBlock.cs
+++ b/src/Entities/CassetteBlocks/CassetteMoveBlock.cs
@@ -1,9 +1,11 @@
 ﻿using Celeste.Mod.CommunalHelper.Components;
+using Celeste.Mod.Registry;
 using FMOD.Studio;
 using MonoMod.Utils;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using static MonoMod.InlineRT.MonoModRule;
 using Directions = Celeste.MoveBlock.Directions;
 
 // TODO
@@ -62,7 +64,11 @@ public class CassetteMoveBlock : CustomCassetteBlock
 
     private readonly bool noDebris;
 
-    public CassetteMoveBlock(Vector2 position, EntityID id, int width, int height, Directions direction, float moveSpeed, int index, float tempo, bool oldConnectionBehavior, Color? overrideColor, string spritePath, float sideAlpha, bool held, float crashTime, float regenTime, bool shakeOnCollision, bool noDebris)
+    // when moving, ignore these solid types
+    protected readonly IEnumerable<Type> ignores;
+    protected bool HasIgnores => ignores.Count() > 0;
+
+    public CassetteMoveBlock(Vector2 position, EntityID id, int width, int height, Directions direction, float moveSpeed, int index, float tempo, bool oldConnectionBehavior, Color? overrideColor, string spritePath, float sideAlpha, bool held, float crashTime, float regenTime, bool shakeOnCollision, bool noDebris, string ignores)
         : base(position, id, width, height, index, tempo, true, oldConnectionBehavior, dynamicHitbox: true, overrideColor, spritePath, sideAlpha, held)
     {
         startPosition = position;
@@ -118,10 +124,12 @@ public class CassetteMoveBlock : CustomCassetteBlock
                 MoveBlockRedirectable.GetControllerDelegate(dynamicData, 4)(coroutine);
             },
         });
+
+        this.ignores = ignores.Split(',').SelectMany(EntityRegistry.GetKnownTypesFromSid);
     }
 
     public CassetteMoveBlock(EntityData data, Vector2 offset, EntityID id)
-        : this(data.Position + offset, id, data.Width, data.Height, data.Enum("direction", Directions.Left), data.Bool("fast") ? FastMoveSpeed : data.Float("moveSpeed", MoveSpeed), data.Int("index"), data.Float("tempo", 1f), data.Bool("oldConnectionBehavior", true), data.HexColorNullable("customColor"), data.Attr("spritePath", ""), data.Float("sideAlpha", 1f), data.Bool("held"), data.Float("crashTime", 0.15f), data.Float("regenTime", 3f), data.Bool("shakeOnCollision", true), data.Bool("noDebris"))
+        : this(data.Position + offset, id, data.Width, data.Height, data.Enum("direction", Directions.Left), data.Bool("fast") ? FastMoveSpeed : data.Float("moveSpeed", MoveSpeed), data.Int("index"), data.Float("tempo", 1f), data.Bool("oldConnectionBehavior", true), data.HexColorNullable("customColor"), data.Attr("spritePath", ""), data.Float("sideAlpha", 1f), data.Bool("held"), data.Float("crashTime", 0.15f), data.Float("regenTime", 3f), data.Bool("shakeOnCollision", true), data.Bool("noDebris"), data.String("ignore", ""))
     { }
 
     public override void Awake(Scene scene)
@@ -406,6 +414,14 @@ public class CassetteMoveBlock : CustomCassetteBlock
     {
         if (speed.X != 0f)
         {
+            if (HasIgnores)
+            {
+                if (ignores.ContainsAllFrom(CollideAll<Solid>(Position + speed.XComp()).Select(s => s.GetType())))
+                {
+                    MoveH(speed.X);
+                    return false;
+                }
+            }
             if (MoveHCollideSolids(speed.X, thruDashBlocks: false))
             {
                 for (int i = 1; i <= 3; i++)
@@ -427,6 +443,14 @@ public class CassetteMoveBlock : CustomCassetteBlock
         }
         if (speed.Y != 0f)
         {
+            if (HasIgnores)
+            {
+                if (ignores.ContainsAllFrom(CollideAll<Solid>(Position + speed.YComp()).Select(s => s.GetType())))
+                {
+                    MoveV(speed.Y);
+                    return false;
+                }
+            }
             if (MoveVCollideSolids(speed.Y, thruDashBlocks: false))
             {
                 for (int j = 1; j <= 3; j++)

--- a/src/Entities/ConnectedBlocks/ConnectedMoveBlock.cs
+++ b/src/Entities/ConnectedBlocks/ConnectedMoveBlock.cs
@@ -1,4 +1,5 @@
 ﻿using Celeste.Mod.CommunalHelper.Components;
+using Celeste.Mod.Registry;
 using FMOD.Studio;
 using MonoMod.Utils;
 using System.Collections;
@@ -127,6 +128,10 @@ public class ConnectedMoveBlock : ConnectedSolid
     // whether any MoveBlockRedirects' effects on this move block should persist after respawn
     protected readonly bool redirectIsPersistent;
 
+    // when moving, ignore these solid types
+    protected readonly IEnumerable<Type> ignores;
+    protected bool HasIgnores => ignores.Count() > 0;
+
     public ConnectedMoveBlock(EntityData data, Vector2 offset)
         : this(data.Position + offset, data.Width, data.Height, data.Enum<MoveBlock.Directions>("direction"), data.Bool("fast") ? 75f : data.Float("moveSpeed", 60f))
     {
@@ -208,6 +213,8 @@ public class ConnectedMoveBlock : ConnectedSolid
         noDebris = data.Bool("noDebris");
 
         redirectIsPersistent = data.Bool("redirectIsPersistent", true);
+
+        ignores = data.String("ignore", "").Split(',').SelectMany(EntityRegistry.GetKnownTypesFromSid);
     }
 
     public ConnectedMoveBlock(Vector2 position, int width, int height, MoveBlock.Directions direction, float moveSpeed)
@@ -577,6 +584,14 @@ public class ConnectedMoveBlock : ConnectedSolid
     {
         if (speed.X != 0f)
         {
+            if (HasIgnores)
+            {
+                if (ignores.ContainsAllFrom(CollideAll<Solid>(Position + speed.XComp()).Select(s => s.GetType())))
+                {
+                    MoveH(speed.X);
+                    return false;
+                }
+            }
             if (MoveHCollideSolids(speed.X, thruDashBlocks: false))
             {
                 for (int i = 1; i <= 3; i++)
@@ -598,8 +613,23 @@ public class ConnectedMoveBlock : ConnectedSolid
         }
         if (speed.Y != 0f)
         {
+            if (HasIgnores)
+            {
+                if (ignores.ContainsAllFrom(CollideAll<Solid>(Position + speed.YComp()).Select(s => s.GetType())))
+                {
+                    MoveV(speed.Y);
+                    return false;
+                }
+            }
             if (MoveVCollideSolids(speed.Y, thruDashBlocks: false))
             {
+                if (HasIgnores)
+                {
+                    if (ignores.ContainsAllFrom(CollideAll<Solid>().Select(s => s.GetType())))
+                    {
+                        return false;
+                    }
+                }
                 for (int j = 1; j <= 3; j++)
                 {
                     for (int num2 = 1; num2 >= -1; num2 -= 2)

--- a/src/Utils/Util.cs
+++ b/src/Utils/Util.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 namespace Celeste.Mod.CommunalHelper;
@@ -317,5 +318,15 @@ public static class Util
             middle.RenderPosition = pos + new Vector2(width / 2f, height / 2f);
             middle.Render();
         }
+    }
+
+    public static bool SharesAnyValueWith<T>(this IEnumerable<T> a, IEnumerable<T> b)
+    {
+        return a.Intersect(b).Any();
+    }
+
+    public static bool ContainsAllFrom<T>(this IEnumerable<T> a, IEnumerable<T> b)
+    {
+        return !b.Except(a).Any();
     }
 }


### PR DESCRIPTION
Adds an `Ignore` attribute to `ConnectedMoveBlock`s and `CassetteMoveBlock`s that takes in a comma-separated list of entity SIDs to ignore while moving.

Serves as a per-entity variant of my helper's Move Block Ignore Controller, since the person I made that for was actually using Connected Move Blocks.